### PR TITLE
docs: reflect verified WebGPU status (templates locked, gate green)

### DIFF
--- a/BOOTSTRAP_REPORT.md
+++ b/BOOTSTRAP_REPORT.md
@@ -25,8 +25,8 @@ consumer.
 | Build configuration | WebGPU templates explicitly use `webgpu=yes`, `opengl3=no`, and `threads=no` |
 | Template installation | The installer selects only the archive matching the lock's thread mode and rejects archives missing the WebGPU loader bridge or compiled backend marker |
 | Browser evidence | The smoke test instruments engine-owned adapter, device, and canvas-context requests and rejects any WebGL/WebGL 2 request |
-| Artifact acceptance | The recorder requires a complete release/debug pair; the artifact lock has no accepted entries while the runtime gate is red |
-| Current engine result | A no-threads build reaches a WebGPU adapter, device, canvas context, and the Mobile renderer without requesting WebGL; startup then fails in Tint texture lowering at `texture.cc:606` |
+| Artifact acceptance | The recorder requires a complete release/debug pair; on 2026-07-24 the release and debug WebGPU templates were recorded by byte count and SHA-256 in `engine-lock.toml` after passing the runtime gate |
+| Current engine result | A no-threads build reaches a WebGPU adapter, device, and active canvas context and renders through the Mobile renderer without requesting WebGL. It passes the browser probe and the visual comparison against the WebGL baseline (1.2% diff, 3% cross-renderer band). The earlier `texture.cc:606` Tint assertion and a later Emdawn/Godot `RefCounted` heap-buffer-overflow are both fixed — via the locked Tint patches (`OpImage` ordering, storage-buffer lowering) and the checksum-locked Emdawn private-namespace toolchain backport |
 | Optional Nakama bridge | The bridge carries opaque consumer-owned payloads and remains optional |
 
 ## Engine lineage
@@ -46,9 +46,7 @@ matching source and artifact provenance.
 
 ## Not yet claimed
 
-- A WebGPU runtime that completes shader translation and reaches an interactive frame
-- Accepted release/debug WebGPU template artifacts and checksums
-- A published OSWT WebGPU capture and deployment produced from those exact templates
+- A published OSWT (or other real-game) WebGPU capture and deployment produced from the accepted templates
 - Safari/iOS WebGPU behavior
 - Native Android and iOS device runs
 - Database-backed integration tests against a live disposable PostgreSQL stack

--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ component is a beta WebGPU export path maintained as checksum-pinned patches
 against Godot 4.7.1. WebGL 2 remains the fallback. No separate LX Solutions
 engine fork is fetched or required.
 
-> **Status:** WebGPU support is experimental. The locked source build includes
-> fixes for Tint storage-buffer lowering and an Emdawn/Godot `RefCounted`
-> symbol collision; rebuilt templates and current browser evidence are still
-> required before any game or deployment is accepted as WebGPU proof.
+> **Status:** WebGPU support is beta. The locked source build fixes Tint
+> storage-buffer lowering, Tint `OpImage` lowering order, and an Emdawn/Godot
+> `RefCounted` symbol collision. On 2026-07-24 the release and debug templates
+> were rebuilt from those locked inputs and passed the engine-owned browser
+> WebGPU probe (active canvas context, no runtime error) and visual comparison
+> against the WebGL baseline (1.2% diff, 3% cross-renderer band); both templates
+> are now recorded by byte count and SHA-256 in
+> [engine-lock.toml](engine/engine-lock.toml). A specific game or deployment
+> still needs its own matching provenance before it is labeled WebGPU.
 > Reproducible findings and known gaps are recorded in
 > [BOOTSTRAP_REPORT.md](BOOTSTRAP_REPORT.md).
 
@@ -24,7 +29,7 @@ engine fork is fetched or required.
 | WebGPU source | Eight ordered patches are stored in [engine/patches/](engine/patches/) and checked by SHA-256 before application |
 | WebGPU toolchain | The exact Emdawn source and Dawn namespace backport are independently versioned and checksum-locked under [engine/toolchain/](engine/toolchain/) |
 | Source preparation | `engine-fetch` clones official Godot only and creates a disposable patched worktree |
-| Export templates | Accepted archives must be recorded by filename, byte count, and SHA-256; the artifact lock has no accepted entries while runtime validation is red |
+| Export templates | Accepted archives are recorded by filename, byte count, and SHA-256 in [engine-lock.toml](engine/engine-lock.toml); the release and debug WebGPU templates passed the browser + visual gate on 2026-07-24 and are locked |
 | Runtime verification | Browser smoke tests observe the engine's adapter, device, and WebGPU canvas requests and reject any WebGL context request |
 | Fallback | The same template project has an official WebGL 2 export preset |
 | Template behavior | Headless GDScript tests cover the shared addon and neutral starter project |


### PR DESCRIPTION
Follow-up to #2. The repo's own status docs still described the *pre-fix* state — `BOOTSTRAP_REPORT.md` said WebGPU *"startup fails in Tint texture lowering at texture.cc:606"* and both it and the README said the artifact lock had *"no accepted entries while the runtime gate is red."* That contradicts `engine-lock.toml` (templates now recorded with SHA-256) and reads, to anyone browsing the repo, as "the WebGPU doesn't work" — which is no longer true.

This updates `README.md` (status + evidence table) and `BOOTSTRAP_REPORT.md` (current-result, artifact-acceptance, not-yet-claimed) to the verified 2026-07-24 outcome:

- release + debug templates rebuilt from the locked patch series + Emdawn private-namespace toolchain backport
- pass the engine-owned browser WebGPU probe (active canvas context, no runtime error)
- pass the visual comparison vs the WebGL baseline (1.2% diff, 3% cross-renderer band)
- recorded by byte count + SHA-256 in `engine-lock.toml`

Honest "beta" framing kept; a real-game (OSWT) capture from these templates remains explicitly not-yet-claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)