### PR TITLE
docs: WebGPU is 2D-only today — 3D renders black

### DIFF
--- a/BOOTSTRAP_REPORT.md
+++ b/BOOTSTRAP_REPORT.md
@@ -26,7 +26,7 @@ consumer.
 | Template installation | The installer selects only the archive matching the lock's thread mode and rejects archives missing the WebGPU loader bridge or compiled backend marker |
 | Browser evidence | The smoke test instruments engine-owned adapter, device, and canvas-context requests and rejects any WebGL/WebGL 2 request |
 | Artifact acceptance | The recorder requires a complete release/debug pair; on 2026-07-24 the release and debug WebGPU templates were recorded by byte count and SHA-256 in `engine-lock.toml` after passing the runtime gate |
-| Current engine result | A no-threads build reaches a WebGPU adapter, device, and active canvas context and renders through the Mobile renderer without requesting WebGL. It passes the browser probe and the visual comparison against the WebGL baseline (1.2% diff, 3% cross-renderer band). The earlier `texture.cc:606` Tint assertion and a later Emdawn/Godot `RefCounted` heap-buffer-overflow are both fixed — via the locked Tint patches (`OpImage` ordering, storage-buffer lowering) and the checksum-locked Emdawn private-namespace toolchain backport |
+| Current engine result | A no-threads build reaches a WebGPU adapter, device, and active canvas context under the Forward Mobile renderer without requesting WebGL, and **renders 2D/Control UI**: it passes the browser probe and a visual comparison of the neutral template's 2D menu against the WebGL baseline (1.2% diff). **3D does not render — a lit or even unshaded 3D mesh is black under WebGPU while WebGL renders it; the 3D draw path stalls after device init.** The earlier `texture.cc:606` Tint assertion and a later Emdawn/Godot `RefCounted` heap-buffer-overflow are both fixed (locked Tint patches + the checksum-locked Emdawn private-namespace backport); the 3D draw path is the next open work |
 | Optional Nakama bridge | The bridge carries opaque consumer-owned payloads and remains optional |
 
 ## Engine lineage
@@ -46,6 +46,7 @@ matching source and artifact provenance.
 
 ## Not yet claimed
 
+- **3D rendering under WebGPU** — a 3D scene (meshes/lighting) is black under WebGPU today; WebGL 2 renders it. The Forward Mobile 3D draw path is under investigation
 - A published OSWT (or other real-game) WebGPU capture and deployment produced from the accepted templates
 - Safari/iOS WebGPU behavior
 - Native Android and iOS device runs

--- a/README.md
+++ b/README.md
@@ -9,16 +9,20 @@ component is a beta WebGPU export path maintained as checksum-pinned patches
 against Godot 4.7.1. WebGL 2 remains the fallback. No separate LX Solutions
 engine fork is fetched or required.
 
-> **Status:** WebGPU support is beta. The locked source build fixes Tint
-> storage-buffer lowering, Tint `OpImage` lowering order, and an Emdawn/Godot
-> `RefCounted` symbol collision. On 2026-07-24 the release and debug templates
-> were rebuilt from those locked inputs and passed the engine-owned browser
-> WebGPU probe (active canvas context, no runtime error) and visual comparison
-> against the WebGL baseline (1.2% diff, 3% cross-renderer band); both templates
-> are now recorded by byte count and SHA-256 in
-> [engine-lock.toml](engine/engine-lock.toml). A specific game or deployment
-> still needs its own matching provenance before it is labeled WebGPU.
-> Reproducible findings and known gaps are recorded in
+> **Status:** WebGPU support is beta and **2D-only today.** The locked source
+> build boots the WebGPU backend (Forward Mobile renderer) and renders 2D/Control
+> UI in-browser — verified 2026-07-24 against the engine-owned WebGPU probe
+> (active canvas context, no runtime error) and a visual comparison of the neutral
+> template's 2D menu against the WebGL baseline (1.2% diff). Both templates are
+> recorded by byte count and SHA-256 in [engine-lock.toml](engine/engine-lock.toml).
+>
+> **Known gap — 3D does not render yet.** A lit *or even unshaded* 3D mesh that
+> renders correctly under WebGL comes out black under WebGPU: the backend
+> initializes and selects Forward Mobile, then the 3D draw path stalls before any
+> frame presents. So this is **not usable for 3D games yet.** Getting here fixed
+> Tint storage-buffer lowering, Tint `OpImage` ordering, and an Emdawn/Godot
+> `RefCounted` link-time crash; the 3D render path is the next open work. WebGL 2
+> is the maintained fallback and renders both 2D and 3D. Findings and gaps:
 > [BOOTSTRAP_REPORT.md](BOOTSTRAP_REPORT.md).
 
 ## What is verifiable
@@ -29,8 +33,9 @@ engine fork is fetched or required.
 | WebGPU source | Eight ordered patches are stored in [engine/patches/](engine/patches/) and checked by SHA-256 before application |
 | WebGPU toolchain | The exact Emdawn source and Dawn namespace backport are independently versioned and checksum-locked under [engine/toolchain/](engine/toolchain/) |
 | Source preparation | `engine-fetch` clones official Godot only and creates a disposable patched worktree |
-| Export templates | Accepted archives are recorded by filename, byte count, and SHA-256 in [engine-lock.toml](engine/engine-lock.toml); the release and debug WebGPU templates passed the browser + visual gate on 2026-07-24 and are locked |
+| Export templates | Accepted archives are recorded by filename, byte count, and SHA-256 in [engine-lock.toml](engine/engine-lock.toml); the release and debug WebGPU templates are locked (they passed the **2D** browser + visual gate on 2026-07-24) |
 | Runtime verification | Browser smoke tests observe the engine's adapter, device, and WebGPU canvas requests and reject any WebGL context request |
+| 3D rendering (WebGPU) | **Not working yet.** A lit or unshaded 3D mesh renders under WebGL but is black under WebGPU — the Forward Mobile 3D draw path stalls after device init. Under investigation; WebGL 2 renders 3D as the fallback |
 | Fallback | The same template project has an official WebGL 2 export preset |
 | Template behavior | Headless GDScript tests cover the shared addon and neutral starter project |
 | Optional services | Rust and Nakama components are independently tested and are not required for client-only use |


### PR DESCRIPTION
Corrects an overclaim introduced in #3. The status docs said the WebGPU templates "passed the browser + visual gate," but that gate only ever exercised a **2D Control menu** (the neutral template's boot scene).

Direct testing (this session): WebGPU renders 2D/UI, but a lit **or even unshaded** 3D mesh is **black** under WebGPU while it renders fine under WebGL. The backend initializes and selects Forward Mobile, then the 3D draw path stalls — a genuine hang, not slowness: instrumented tracing shows the first ~50 shaders translate via Tint, then translation of the ~51st shader (the 3D scene uber-shader) never completes.

Updates:
- `README.md` — Status block + verifiable table now state **2D verified / 3D not working yet**; added a "3D rendering (WebGPU)" row.
- `BOOTSTRAP_REPORT.md` — current-result row and a new not-yet-claimed bullet reflect the 3D gap.

WebGL 2 remains the maintained fallback and renders both 2D and 3D. The 3D shader-translation hang is the next open engineering work (diagnosis in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)