### PR TITLE
webgpu: fix two 3D shader-translation crashes found on real GPU (patches 0011, 0012)

### DIFF
--- a/BOOTSTRAP_REPORT.md
+++ b/BOOTSTRAP_REPORT.md
@@ -47,7 +47,7 @@ matching source and artifact provenance.
 
 ## Not yet claimed
 
-- **In-browser 3D render verification** — the 3D-black *crash* is fixed (patch 0009) and verified offline (shader translation no longer crashes), but rendering a 3D frame in a browser has not been confirmed here (no GPU on this dev box); needs a GPU-capable run
+- **A visible 3D frame** — in-browser translation is now verified on real hardware (NVIDIA Tesla P40): with patches 0009–0012 the engine no longer crashes translating the runtime-specialized 3D scene shader. But a rendered frame is **still not produced** — the scene render pipeline is rejected because Godot Forward Mobile binds 18 samplers to the vertex stage, over WebGPU's hard 16-per-stage limit. That is a driver/shader-structure issue (per-stage bind-group visibility or vertex-sampler reduction), separate from shader translation, and is the next blocker to a visible frame
 - A published OSWT (or other real-game) WebGPU capture and deployment produced from the accepted templates
 - Safari/iOS WebGPU behavior
 - Native Android and iOS device runs

--- a/README.md
+++ b/README.md
@@ -29,9 +29,21 @@ engine fork is fetched or required.
 > also fixes a class of *silent* shader-translation failures — combined
 > image-samplers forwarded through function call chains (bicubic glow,
 > `taa_resolve`) — raising offline coverage to 177/182; the remaining 5 are
-> fundamental WGSL feature gaps, not crashes. **In-browser render verification is
-> still pending** a GPU-capable machine (this dev box has no hardware GPU). WebGL 2
-> remains the maintained fallback. Details:
+> fundamental WGSL feature gaps, not crashes.
+>
+> **In-browser render now verified on real hardware (2026-07-24, NVIDIA Tesla P40).**
+> Running the rebuilt WebGPU build in headless Chrome on an actual GPU exposed two
+> more shader-translation defects that the offline corpus missed (only the
+> runtime-*specialized* scene shader triggers them): patch 0011 stops
+> `flatten_binding_arrays` from corrupting struct-offset decoration literals, and
+> patch 0012 fixes Tint's SPIR-V reader so textures passed by *function parameter*
+> (Godot's lightmap/shadow helpers) are converted to core texture types instead of
+> crashing its texture lowering. With 0009–0012 the engine **no longer crashes** on
+> 3D shader translation on the GPU. **3D is still not yet visible**, now blocked by a
+> *different, non-crash* issue: Godot's Forward Mobile scene shader binds 18 samplers
+> to the vertex stage, exceeding WebGPU's hard limit of 16 per stage, so the scene
+> pipeline is rejected. That is a driver/shader-structure problem (tracked separately),
+> not shader translation. WebGL 2 remains the maintained fallback. Details:
 > [BOOTSTRAP_REPORT.md](BOOTSTRAP_REPORT.md).
 
 ## What is verifiable
@@ -44,8 +56,9 @@ engine fork is fetched or required.
 | Source preparation | `engine-fetch` clones official Godot only and creates a disposable patched worktree |
 | Export templates | Accepted archives are recorded by filename, byte count, and SHA-256 in [engine-lock.toml](engine/engine-lock.toml); the release and debug WebGPU templates are locked (they passed the **2D** browser + visual gate on 2026-07-24) |
 | Runtime verification | Browser smoke tests observe the engine's adapter, device, and WebGPU canvas requests and reject any WebGL context request |
-| 3D rendering (WebGPU) | Root-caused + fixed (patch 0009 strips the `Volatile` decoration Tint's SPIR-V reader aborts on, from Godot's coherent compute shaders). Verified offline (native reproducer, 0/182 shaders crash, was 1). In-browser render verification pending a GPU-capable machine |
-| WebGPU shader coverage | 177 of 182 engine shaders translate to valid WGSL offline (was 174). Patch 0010 fixes combined image-samplers forwarded through function call chains (tonemap bicubic glow, `taa_resolve`). The 5 remaining are fundamental WGSL feature gaps (subpass `input_attachment`, storage-texture format inference, vertex-stage `read_write` storage), not crashes — the effect degrades, 3D still renders |
+| 3D shader translation (WebGPU) | No longer crashes — verified in-browser on an NVIDIA Tesla P40. Patches 0009–0012 fix four distinct translation crashes (`Volatile` decoration, transitive combined-sampler split, flatten decoration-literal corruption, and Tint's texture-function-parameter conversion). The rebuilt engine boots the WebGPU device and translates the specialized 3D scene shader without SIGILL |
+| WebGPU shader coverage | 177 of 182 engine shaders translate to valid WGSL offline; the runtime-specialized scene shader (which the offline corpus did not cover) also translates after 0011/0012. The 5 offline gaps are fundamental WGSL limits (subpass `input_attachment`, storage-texture format inference, vertex-stage `read_write` storage), not crashes |
+| 3D render (visible frame) | **Not yet.** With the crash chain fixed, the scene pipeline is now *rejected* (not crashed): Godot Forward Mobile binds 18 samplers to the vertex stage, over WebGPU's hard 16-per-stage limit. A driver/shader-structure issue, separate from translation, tracked for follow-up |
 | Fallback | The same template project has an official WebGL 2 export preset |
 | Template behavior | Headless GDScript tests cover the shared addon and neutral starter project |
 | Optional services | Rust and Nakama components are independently tested and are not required for client-only use |

--- a/engine/engine-lock.toml
+++ b/engine/engine-lock.toml
@@ -68,6 +68,8 @@ series = [
   { file = "patches/0008-tint-image-ordering.patch", sha256 = "14af2071b54ca4233b7a5280f2b8c48052a94be18bc64c912c13d07a8576c6db" },
   { file = "patches/0009-tint-volatile-decoration.patch", sha256 = "55e4611a21f3c809e3e3dbf0f6e3fb052f2a8f23e659ca91019306cd25b28fe0" },
   { file = "patches/0010-webgpu-transitive-sampler-split.patch", sha256 = "ef6039b6c68077fd6956745a602778f986aadd15280e1e346f5a89d966c8de39" },
+  { file = "patches/0011-webgpu-flatten-decoration-literals.patch", sha256 = "118d06a98d3046010dfe4926698242792125aeb08eac55c65e2abd1e6a323b17" },
+  { file = "patches/0012-tint-texture-function-params.patch", sha256 = "b22a21de0dcc1e0df2ae8b50cac055635f48db7faace9917a03e620cbaee81ae" },
 ]
 
 [artifacts.export_templates]

--- a/engine/patches/0011-webgpu-flatten-decoration-literals.patch
+++ b/engine/patches/0011-webgpu-flatten-decoration-literals.patch
@@ -1,0 +1,29 @@
+Subject: [PATCH] webgpu: don't rewrite OpDecorate/OpMemberDecorate literals in flatten_binding_arrays
+
+flatten_binding_arrays() eliminates arrays of handle types by replacing every array-type
+id with its element-type id across all instruction words, excluding only OpConstant and
+OpSwitch literals. It did NOT exclude OpDecorate/OpMemberDecorate arguments (Offset,
+ArrayStride, Binding, Location, ...), which are literals, not ids. A large struct member
+Offset literal that happened to equal an array/pointer type id got rewritten, corrupting
+the struct layout (e.g. member offset 7603, not 16-aligned) and producing invalid SPIR-V
+that crashes Tint's texture lowering. Treat decorations as having literal operands (only
+word 1, the target, is an id). After this the flattened SPIR-V passes SPIRV-Tools validation.
+
+diff --git a/drivers/webgpu/spirv_preprocess.cpp b/drivers/webgpu/spirv_preprocess.cpp
+--- a/drivers/webgpu/spirv_preprocess.cpp
++++ b/drivers/webgpu/spirv_preprocess.cpp
+@@ -2415,6 +2415,14 @@
+ 		if (op == OP_CONSTANT || op == OP_SPEC_CONSTANT) {
+ 			has_literals = true;
+ 			literal_start = 3;
++		} else if (op == OP_DECORATE || op == OP_MEMBER_DECORATE) {
++			// Decoration args (Offset, ArrayStride, Binding, Location, ...) are
++			// LITERALS, not IDs. Only word 1 (the target) is an ID. Without this,
++			// a large literal (e.g. a struct member Offset) that happens to equal
++			// an array/pointer type ID gets wrongly rewritten, corrupting the
++			// struct layout and crashing Tint's texture lowering.
++			has_literals = true;
++			literal_start = 2;
+ 		} else if (op == 251 /* OpSwitch */) {
+ 			switch_alternating = true;
+ 		}

--- a/engine/patches/0012-tint-texture-function-params.patch
+++ b/engine/patches/0012-tint-texture-function-params.patch
@@ -1,0 +1,41 @@
+Subject: [PATCH] tint/spirv-reader: convert texture function-parameter types
+
+The spirv reader's texture lowering (State::Process) rewrites spirv::type::Image
+to core::type::Texture only for global variables in ir.root_block. A texture
+forwarded through a function PARAMETER keeps its spirv::type::Image type, then
+hits ProcessCoords -> TINT_ASSERT(tex_ty) (texture.cc). Godot's forward-mobile
+lightmap/shadow PCF helpers pass textures by parameter, so any 3D scene crashes
+shader translation. Convert texture parameters with the same TypeFor() the global
+loop uses; the existing dref/comparison propagation re-specialises depth params.
+
+diff --git a/thirdparty/tint/src/tint/lang/spirv/reader/lower/texture.cc b/thirdparty/tint/src/tint/lang/spirv/reader/lower/texture.cc
+--- a/thirdparty/tint/src/tint/lang/spirv/reader/lower/texture.cc
++++ b/thirdparty/tint/src/tint/lang/spirv/reader/lower/texture.cc
+@@ -125,6 +125,27 @@
+             });
+         }
+ 
++        // The global-var loop above only rewrites root-block texture vars.
++        // A texture forwarded through function PARAMETERS (Godot's lightmap /
++        // shadow sampling helpers do this) otherwise keeps its spirv::type::Image
++        // type and later crashes ProcessCoords. Convert texture params here too;
++        // depth/comparison params are re-specialised by the dref propagation below.
++        for (auto* _fn : ir.functions) {
++            for (auto* _param : _fn->Params()) {
++                auto* _pty = _param->Type();
++                if (auto* _ptr = _pty->As<core::type::Pointer>()) {
++                    auto* _inner = _ptr->UnwrapPtr();
++                    if (_inner->Is<spirv::type::Image>()) {
++                        _param->SetType(ty.ptr(_ptr->AddressSpace(), TypeFor(_inner), _ptr->Access()));
++                        values_to_fix_usages_.Push(_param);
++                    }
++                } else if (_pty->Is<spirv::type::Image>()) {
++                    _param->SetType(TypeFor(_pty));
++                    values_to_fix_usages_.Push(_param);
++                }
++            }
++        }
++
+         Vector<spirv::ir::BuiltinCall*, 4> depth_worklist;
+         for (auto* inst : ir.Instructions()) {
+             if (auto* builtin = inst->As<spirv::ir::BuiltinCall>()) {

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -26,6 +26,14 @@ browser WebGPU template build. They apply to the official Godot commit in
     from a wrapper into a deeper helper (e.g. tonemap's `texture2D_bicubic`, and
     `taa_resolve`) no longer produces invalid SPIR-V (`OpFunctionCall` argument
     type mismatch) that silently fails Tint translation.
+11. `0011-webgpu-flatten-decoration-literals.patch` - stop `flatten_binding_arrays`
+    from rewriting `OpDecorate`/`OpMemberDecorate` literal arguments (Offset,
+    ArrayStride, ...). A struct-member Offset literal that collided with an array
+    type id was being remapped, corrupting the struct layout into invalid SPIR-V.
+12. `0012-tint-texture-function-params.patch` - Tint spirv-reader fix: convert
+    texture types on function PARAMETERS, not only global vars. Godot forward-mobile
+    passes lightmap/shadow textures by parameter; those kept `spirv::type::Image`
+    and crashed Tint's texture lowering (`ProcessCoords` assert) on any 3D scene.
 
 The WebGPU implementation originated in `dwalter/godotwebgpu`. Studio
 Foundation owns the 4.7.1 port, scoped patch curation, preparation/build tooling,


### PR DESCRIPTION
## What

Two more WebGPU shader-translation crash fixes, **found by running the build on an actual GPU** (NVIDIA Tesla P40, headless Chrome) — not reachable by the offline 182-shader corpus because they only fire on the runtime-**specialized** Forward Mobile scene shader.

- **0011 — flatten decoration literals.** `flatten_binding_arrays` replaces every array-type id with its element-type id across all instruction words, excluding only `OpConstant`/`OpSwitch` literals — **not** `OpDecorate`/`OpMemberDecorate` args. A struct-member `Offset` literal that collided with an array type id got rewritten, corrupting the struct layout (offset `7603`, not 16-aligned) into invalid SPIR-V. Fix: treat decorations as literal-bearing. → flattened SPIR-V passes SPIRV-Tools validation.
- **0012 — Tint texture function parameters.** Tint's spirv-reader converts `spirv::type::Image → core::type::Texture` only for **global vars**. A texture passed by **function parameter** (Godot's lightmap/shadow PCF helpers) stayed `spirv::type::Image` and crashed `ProcessCoords` (`TINT_ASSERT(tex_ty)`) on any 3D scene. Fix: convert texture params with the same `TypeFor()`; dref/comparison propagation re-specializes depth params. → 191 KB scene frag shader translates to correct WGSL (shadow params → `texture_depth_2d`, 14 `textureSampleCompare`).

## Verification (real hardware)

Rebuilt the engine with 0009–0012 on the P40 and re-ran in headless Chrome+WebGPU:
- engine boots the WebGPU device; **`texture.cc:613` crash count = 0** (was crashing on the 3D scene shader).
- Each patch independently reproduced + fixed **offline** via a native `tint_convert_cli` (SPIRV-Tools validate + correct-WGSL spot checks).
- Patch-series checksum verifier passes for all 12 patches; 0011/0012 apply cleanly in series on the post-0010 tree.

## Honest status — not a visible frame yet

With the crash chain cleared, 3D is **still black**, now blocked by a *different, non-crash* issue: Godot Forward Mobile binds **18 samplers to the vertex stage**, over WebGPU's hard **16-per-stage** limit, so the scene pipeline is **rejected**. That's a driver/shader-structure problem (per-stage bind-group visibility, or reducing vertex-stage samplers), **separate from shader translation**, and is the documented next blocker. The device already requests the adapter's max limit; Dawn caps `maxSamplersPerShaderStage` at 16, so it can't simply be raised.

Docs (README, BOOTSTRAP_REPORT) updated to this exact state. WebGL 2 remains the maintained fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)