### PR TITLE
docs: reflect verified 3D rendering + independent-WebGPU positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,26 @@ component is a beta WebGPU export path maintained as checksum-pinned patches
 against Godot 4.7.1. WebGL 2 remains the fallback. No separate LX Solutions
 engine fork is fetched or required.
 
-> **Status:** WebGPU support is beta and **2D-only today.** The locked source
-> build boots the WebGPU backend (Forward Mobile renderer) and renders 2D/Control
-> UI in-browser — verified 2026-07-24 against the engine-owned WebGPU probe
-> (active canvas context, no runtime error) and a visual comparison of the neutral
-> template's 2D menu against the WebGL baseline (1.2% diff). Both templates are
-> recorded by byte count and SHA-256 in [engine-lock.toml](engine/engine-lock.toml).
+## Why an independent WebGPU backend
+
+Godot itself does not accept AI-generated code contributions, and has stated it does
+not intend to add AI features to the engine. Under that policy an AI-assisted
+capability — even one the community has asked about for years, like a browser-grade
+WebGPU backend — cannot land upstream no matter how well it works. Studio Foundation
+carries the work forward in the open instead: official Godot as the base (MIT), a
+transparent, checksum-pinned patch series on top, and every change reproducible and
+verified on real hardware (the 3D render above was confirmed on an NVIDIA Tesla P40).
+The capability ships to anyone who wants it, for free — no gatekeeping, no permission
+required.
+
+> **Status:** WebGPU support is beta and now **renders 3D in-browser on real
+> hardware.** The locked source build boots the WebGPU backend (Forward Mobile
+> renderer) and, as of 2026-07-24 (patch 0013), draws a lit, perspective-projected
+> 3D mesh in Chrome on an NVIDIA Tesla P40 — 60 fps, **0 `GPUValidationError`** (was
+> 2283) — verified against the engine-owned WebGPU probe, alongside the earlier 2D
+> menu gate (active canvas context, no runtime error; 1.2% vs the WebGL baseline).
+> Both templates are recorded by byte count and SHA-256 in
+> [engine-lock.toml](engine/engine-lock.toml). WebGL 2 remains a supported fallback.
 >
 > **3D-black bug — root-caused and fixed (2026-07-24, patch 0009).** A lit *or
 > even unshaded* 3D mesh rendered black under WebGPU while rendering fine under

--- a/docs/architecture/webgpu-runtime-status.md
+++ b/docs/architecture/webgpu-runtime-status.md
@@ -14,28 +14,32 @@
 
 ## TL;DR
 
-> **⚠️ Corrected later on 2026-07-24: the gate below only ever exercised 2D UI.**
-> WebGPU renders 2D/Control content but **not 3D** — a lit *or even unshaded* 3D
-> mesh is black under WebGPU while WebGL renders it. Root cause: the 3D scene
-> uber-shader **hangs during synchronous SPIR‑V→WGSL translation** (first ~50
-> shaders translate; the ~51st never completes). See **§3D rendering gap** below.
-> Do not read "renders in the browser" as "renders 3D games."
+> **✅ Updated 2026-07-24: 3D now renders in-browser on real hardware.** The
+> original symptom (a lit *or even unshaded* 3D mesh came out black; translation
+> stalled on the runtime-specialized scene shader) was a chain of shader-translation
+> and bind-group defects, not one bug. Patches 0009–0013 fix the whole chain —
+> verified on an NVIDIA Tesla P40 (headed Chrome/WebGPU): the 3D scene draws a lit,
+> perspective-projected mesh at 60 fps with **0 `GPUValidationError`** (was 2283).
+> The historical root-cause analysis is kept below in **§3D rendering gap** for the
+> record.
 
 The boot/RefCounted blocker was genuinely fixed and both templates are locked: the
 ADR 0002 gate — rebuild → export → browser WebGPU probe (active canvas context, no
 runtime error) → visual compare **1.2%** vs the WebGL baseline — is green **for the
 neutral template's 2D menu**, and `engine-lock.toml [artifacts.export_templates]`
 records `web_webgpu_release` (`3642cf5e…`) + `web_webgpu_debug` (`1f1ed2b5…`). The
-gate's blind spot — it renders a 2D Control scene, never a 3D one — is exactly what
-let "WebGPU renders" overclaim slip through. **A 3D probe must be added to the gate.**
+automated gate historically rendered only a 2D Control scene; 3D is now **verified
+manually on GPU hardware** (NVIDIA Tesla P40 — lit mesh, 60 fps, 0 `GPUValidationError`).
+Folding that 3D render into the automated gate is the remaining CI task.
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| Patch series (0001–0008) applies to official 4.7.1 `a13da4feb8` | ✅ | `just engine-versions` → "patch series: 8 patch(es)" |
+| Patch series (0001–0013) applies to official 4.7.1 `a13da4feb8` | ✅ | `just engine-versions` → "patch series: 13 patch(es)" |
 | Web templates compile (release + debug, `nothreads`, `webgpu=yes`) | ✅ | `bin/godot.web.template_*.wasm32.nothreads.*` |
 | Tint SPIR‑V→WGSL translation (storage‑buffer + OpImage ordering) | ✅ | patches 0007, 0008 |
 | **Emdawn/Godot `RefCounted` ODR collision** (the heap‑buffer‑overflow) | ✅ **fixed in source** | `engine/toolchain/patches/0001-emdawn-private-namespace.patch`, locked in `[toolchain.emdawnwebgpu]` |
-| **Rebuild + browser probe (2D UI only)** with the backport | ✅ 2026‑07‑24 — **2D only** | 2D menu, 1.2% vs WebGL |
+| Rebuild + browser probe (2D menu) with the backport | ✅ 2026‑07‑24 | 2D menu, 1.2% vs WebGL |
+| **3D render on GPU hardware** (NVIDIA Tesla P40) | ✅ 2026‑07‑24 — patches 0009–0013 | lit mesh, 60 fps, 0 `GPUValidationError` |
 | **3D rendering under WebGPU** | 🟢 **in-browser render VERIFIED on an NVIDIA Tesla P40 (patches 0009–0013)** — 3D scene draws a lit mesh at 60 fps, 0 GPUValidationError | §3D rendering gap |
 | **3D scene-shader translation** | 🟢 **177/182 translate offline** (was 174); the runtime-specialized scene shader also translates *and renders* after patches 0011–0013 | §3D rendering gap |
 | Template artifacts locked in `engine-lock.toml` | ✅ | `[artifacts.export_templates]`: release + debug + sha256 |


### PR DESCRIPTION
Makes the docs match the shipped reality (patch 0013 / PR #8): removes the stale "2D-only today / 3D black" claims that critics were quoting, states the verified P40 3D render (lit mesh, 60 fps, 0 GPUValidationError), and adds a short **Why an independent WebGPU backend** section (Godot declines AI-generated contributions, so this capability is carried forward as an open, reproducible patch series on official Godot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)