### PR TITLE
docs: link the live WebGPU 3D demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,20 @@ SHA-256-locked patch series, plus the MCP server, agent workflows, and asset
 pipeline that make the whole thing drivable by AI assistants. WebGL 2 remains the
 supported fallback.
 
-![Godot 4.7.1 rendering a lit, shadowed 3D scene through WebGPU in a browser](docs/images/webgpu-3d-lit-shadows.png)
+### ▶ [Try it live — Godot 3D through WebGPU, in your browser](https://lxsolutions.github.io/studio-foundation/)
+
+No install, no plugin. Needs a WebGPU-capable browser (Chrome/Edge 113+, Safari 26+,
+Firefox on Windows); the page tells you if yours qualifies before you click.
+
+[![Godot 4.7.1 rendering a lit, shadowed 3D scene through WebGPU in a browser](docs/images/webgpu-3d-lit-shadows.png)](https://lxsolutions.github.io/studio-foundation/)
 
 *Six PBR meshes, a directional light, and real-time shadow mapping — rendered by
 Godot 4.7.1 through WebGPU in Chrome on an NVIDIA Tesla P40: 59–60 fps, 36 draws per
 frame, **0 `GPUValidationError`**. The scene is
 [`webgpu_showcase.gd`](templates/godot-game/project/scenes/webgpu_showcase.gd) —
 about 100 lines of GDScript, no external assets — so you can rebuild and re-verify
-this exact frame yourself.*
+this exact frame yourself. The published demo above was itself re-rendered from its
+public URL on that same GPU as a final check.*
 
 ## Our lane: AI-native, open-source game development
 


### PR DESCRIPTION
Publishes and links the live demo: **https://lxsolutions.github.io/studio-foundation/**

Anyone with a WebGPU browser can now see Godot 4.7.1 render lit, shadowed 3D without installing anything — which is a far stronger answer to "does this actually work?" than a screenshot.

- `gh-pages` branch serves the Godot web export of `webgpu_showcase` under `/demo/`, behind a landing page that feature-detects WebGPU and states the beta status honestly.
- Verified **after** publishing by pointing the GPU render harness at the public URL on the Tesla P40: adapter `nvidia/pascal`, lit + shadowed scene, 59 fps, **0 GPUValidationError**.
- wasm is served as `application/wasm` and gzips 45.8 MB → 12 MB over the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)