### PR TITLE
docs: measure WebGPU payload size and cold start

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,11 @@ not a competitor to that effort — it is a maintained, reproducible path that w
 today on Godot 4.7.1, and it stays a patch series precisely so it can be retired
 into upstream when upstream is ready.
 
-Not yet claimed: a published real-game WebGPU deployment, Safari/iOS behavior, and
-native Android/iOS device runs. The full list is in
+The published demo downloads ~45 MB of engine (12 MB compressed) before it can draw.
+Measured breakdown, and why that is mostly Godot rather than the WebGPU stack, is in
+[WebGPU payload and startup](docs/architecture/webgpu-payload-and-startup.md).
+
+Not yet claimed: Safari/iOS behavior and native Android/iOS device runs. The full list is in
 [BOOTSTRAP_REPORT.md](BOOTSTRAP_REPORT.md); the running engineering log is in
 [docs/architecture/webgpu-runtime-status.md](docs/architecture/webgpu-runtime-status.md).
 

--- a/docs/architecture/webgpu-payload-and-startup.md
+++ b/docs/architecture/webgpu-payload-and-startup.md
@@ -1,0 +1,88 @@
+# WebGPU payload size and cold start — measured
+
+Measured 2026-07-24 against the published demo
+(<https://lxsolutions.github.io/studio-foundation/>) on an NVIDIA Tesla P40 through
+Chrome/WebGPU. Numbers here are observations, not estimates.
+
+## What the download actually costs
+
+| Artifact | Size on disk | Over the wire |
+|---|---|---|
+| Our WebGPU web template (`godot.web.template_release.webgpu.zip`, nothreads) | 11.9 MB | — |
+| Our uncompressed `godot.wasm` | **45.8 MB** | **12.0 MB** (GitHub Pages gzip) |
+| Stock official Godot 4.7.1 `web_nothreads_release` `godot.wasm` | **39.5 MB** | — |
+| **Cost attributable to the WebGPU stack** | **+6.3 MB (≈16%)** | — |
+
+That +6.3 MB is the vendored Tint SPIR-V→WGSL translator, the SPIR-V tooling it needs,
+and the WebGPU rendering driver. It is a real cost, but the bulk of the payload is
+Godot itself — a stock Godot web export is already ~39.5 MB before we add anything.
+
+The build is *already* size-optimized: Godot's web platform defaults to `-Os` and thin
+LTO (`platform/web/detect.py`), and its own comment notes `-Os` saves ~5 MiB over `-O3`
+while `-Oz` would only save ~100 KiB more. There is no easy flag left to pull.
+
+## Cold start — where the time really goes
+
+An earlier note in this repo claimed roughly 20 seconds of WGSL shader compilation
+before the first frame. **That was wrong**, and it mattered because it pointed
+optimization at the wrong thing.
+
+Measured on the live demo with the network throttled to 12 Mbps and HTTP caching
+disabled (a realistic first-time visitor):
+
+| Phase | Observation |
+|---|---|
+| Download (12 MB compressed) | dominates; ~48% complete at 5 s |
+| wasm instantiate + engine boot + shader translation + pipeline build | fast — **80 pipelines built within ~2 s** of the engine starting |
+| First frames drawn | by **~13 s end to end** |
+
+So **payload size, not shader compilation, is the cold-start bottleneck.** On an
+unthrottled datacenter link the same demo is rendering in ~4 s.
+
+The earlier 20 s figure came from a measurement artifact: driving the page with
+`page.goto(waitUntil: "load")` waits for the entire 45 MB wasm before returning, so a
+probe's `t=0` was already ~14 s into the page's life. Use `domcontentloaded` and read
+elapsed time from inside the page.
+
+## Where the remaining size could come from
+
+Not yet done, listed in rough order of expected benefit:
+
+1. **Translate shaders to WGSL at export time instead of at runtime.** Today the engine
+   ships SPIR-V and runs Tint inside the wasm to translate it in the browser. Doing that
+   translation during export would let the vendored Tint be dropped from the binary
+   (most of the +6.3 MB) *and* remove runtime translation work. This is the biggest
+   single lever we control, and it is an architectural change, not a flag.
+2. **Module stripping / build profiles — measured, and weaker than expected.** The
+   largest commonly-cited web lever is dropping the advanced text server (which embeds
+   ICU). Built and measured:
+
+   | Build | `godot.wasm` | gzipped |
+   |---|---|---|
+   | ours, full | 45.81 MB | 11.87 MB |
+   | ours, `module_text_server_adv_enabled=no` + `fb=yes` | 44.25 MB | 11.30 MB |
+   | **saving** | **1.56 MB (3.4%)** | **0.57 MB (4.8%)** |
+
+   Half a megabyte off the wire in exchange for losing complex-script and bidirectional
+   text support is a bad trade for a general-purpose template, so this is **not**
+   applied to the published build. Recorded here so the option does not get
+   re-investigated on the assumption that it is a big win.
+3. **Better compression at the edge.** GitHub Pages serves gzip; Brotli would cut the
+   transfer further but is not controllable from Pages.
+
+## Loading UX
+
+Because the first load is dominated by a large download, the demo ships
+`boot-overlay.js`, which keeps a progress screen up until frames are genuinely being
+produced. Detecting "rendering has started" is less obvious than it looks:
+
+- Watching `requestAnimationFrame` for smooth frames **does not work** — while the
+  engine is merely downloading, the page is idle and rAF already runs at a clean 60 fps.
+- Watching for pipeline creation to go quiet **does not work either** — Godot builds a
+  few canvas pipelines early, then creates none for many seconds while Tint translates
+  the scene shaders, so it signals completion far too early.
+- What does work: **sustained `GPUQueue.submit` traffic**. A running render loop submits
+  a command buffer every frame, and no loading phase imitates that.
+
+The overlay also wraps `GPUDevice.create*Pipeline*` so it can show real progress while
+the viewer waits.


### PR DESCRIPTION
Replaces guesses about load time with measurements, and **corrects a wrong claim already in this repo**.

### The correction
Docs said ~20s of WGSL shader compilation gated the first frame. Measured on the live demo (throttled to 12 Mbps, caching disabled): **first frame at ~13s, and the download dominates** — 80 pipelines build within ~2s of the engine starting. The 20s figure was a measurement artifact: `goto(waitUntil:"load")` waits for the entire 45 MB wasm, so the probe clock started ~14s late.

This matters because it pointed optimization at the wrong thing.

### What the WebGPU stack actually costs

| | `godot.wasm` |
|---|---|
| stock official Godot 4.7.1 web | 39.5 MB |
| ours | 45.8 MB |
| **WebGPU stack (Tint + SPIR-V tooling + driver)** | **+6.3 MB (~16%)** |

The bulk is Godot itself, and the build is already `-Os` + thin LTO — no easy flag left.

### A negative result, recorded so it isn't re-investigated
Dropping the advanced text server (the usual big web-size lever) was built and measured: **0.57 MB gzipped saved (4.8%)** in exchange for losing complex-script and bidirectional text. Bad trade; not applied.

The real lever is moving Tint out of the wasm by translating shaders to WGSL at export time — architectural, not a flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)