### PR TITLE
Correct cold-start attribution: payload, not shader compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ supported fallback.
 
 No install, no plugin. Needs a WebGPU-capable browser (Chrome/Edge 113+, Safari 26+,
 Firefox on Windows); the page tells you if yours qualifies before you click. First load
-takes ~30 seconds — most of it compiling shaders to WGSL in your browser.
+takes roughly 15–30 seconds depending on your connection — most of it downloading the
+~46 MB engine, not compiling shaders (pipelines build in about 2 seconds). It is
+cached afterwards. Details: [webgpu-performance.md](docs/architecture/webgpu-performance.md).
 
 [![The Chariot Club: a Roman colosseum with crowded stands and chariots, rendered in Godot through WebGPU](docs/images/webgpu-chariot.png)](https://lxsolutions.github.io/studio-foundation/)
 

--- a/docs/architecture/webgpu-performance.md
+++ b/docs/architecture/webgpu-performance.md
@@ -75,27 +75,50 @@ settings.
 
 ---
 
-## Cold start: ~20s to first frame
+## Cold start: ~20s to first frame — and it is NOT shader compilation
 
-Measured on Chariot, and the reason several earlier investigations wrongly
-concluded "3D is black":
+Measured on Chariot over a LAN-local server, and the reason several earlier
+investigations wrongly concluded "3D is black":
 
 | Milestone | Time |
 | --- | --- |
+| WebGPU device acquired | +1.3s |
 | `studio: boot completed` | +8.7s |
-| WGSL shader compilation running | to ~18s |
+| All WGSL module-compilation log entries | **+17.9s → +18.0s** |
 | **First drawn frame (non-zero draw calls)** | **+20.9s** |
 
-Riftline pays a similar cost despite ~350x fewer primitives, so this is
-**largely a fixed per-session shader-compilation cost, not scene complexity**.
+**Shader compilation is not the bottleneck.** Every one of the 21 compilation-log
+entries lands inside a **single sub-second burst**, and the count is identical
+across all three games regardless of scene size (Riftline +17.4s, Chariot
++17.9s, The Deep +24.5s) — they are the engine's own built-in shaders
+(`CanvasShaderRD`, `SceneForwardMobileShaderRD`, `TonemapMobileShaderRD`), not
+game content. An independent run against the *published* demo, throttled to
+12 Mbps with caching disabled, agrees: **80 pipelines built within ~2s** of the
+engine starting, with total time to first frame ~13s **dominated by downloading
+the 45.8 MB wasm**.
 
-Two consequences:
+So the cost is **engine startup — fetching and instantiating a 45.8 MB wasm,
+then engine and scene init — not WGSL translation**. For reference, the WebGL 2
+control reached its first frame at **+13.0s** on the same harness, so WebGPU adds
+real startup overhead, but far less than the raw ~20s figure suggests.
+
+Three consequences:
 
 1. **Any capture window shorter than ~25s screenshots a blank canvas.**
    `tests/browser/capture.mjs` previously defaulted to 6s, which could not
    photograph a real 3D scene before it drew anything. The default is now 25s.
-2. **Shader precompilation/caching is the highest-value optimization** for a
-   shippable web build — ahead of any scene-level tuning.
+   This holds regardless of *why* the first frame is late.
+2. **Payload size is the lever** — shrinking/streaming the wasm and compressing
+   transfer beats shader precompilation, which is already only ~2s.
+3. Measure first-frame latency with the **engine's own draw counters**, and
+   beware `page.goto(waitUntil: "load")`: it waits for the entire wasm and can
+   start a probe clock ~14s late, inflating every number after it.
+
+> **Correction (2026-07-24).** An earlier revision of this file attributed the
+> cold start to "a fixed per-session shader-compilation cost" and called shader
+> precompilation the highest-value optimization. The compilation-burst timing and
+> the throttled-network run above both refute that; the claim is corrected here
+> rather than quietly dropped.
 
 ---
 

--- a/tests/browser/capture.mjs
+++ b/tests/browser/capture.mjs
@@ -6,9 +6,10 @@
 //     [--out captures/web-main.png] [--wait 25000] [--size 1280x720]
 //
 // --wait must outlast the export's cold start, or the screenshot is a blank
-// canvas that reads as "nothing rendered". A real 3D scene spends most of that
-// time compiling WGSL: measured on an NVIDIA Tesla P40, boot completed at ~8.7s,
-// shader compilation ran to ~18s, and the first drawn frame landed at ~20.9s.
+// canvas that reads as "nothing rendered". Measured on an NVIDIA Tesla P40: boot
+// completed at ~8.7s and the first drawn frame landed at ~20.9s. That time goes
+// to fetching and instantiating the ~45.8 MB wasm plus engine/scene init, NOT to
+// shader compilation (all WGSL module compiles land in one sub-second burst).
 // The old 6s default screenshotted every real 3D scene before it drew a single
 // frame. Small 2D scenes are ready far sooner; pass a lower --wait for those.
 // See docs/architecture/webgpu-performance.md.


### PR DESCRIPTION
## Why

#16 (mine) and the README's live-demo blurb both told readers that the first load is spent **compiling shaders to WGSL**. That is wrong. Correcting it in the open rather than quietly dropping it.

## Evidence

Re-reading the capture logs from the same runs:

- All **21** WGSL module-compilation entries land inside a **single sub-second burst**, and the count is **identical across all three games regardless of scene size** — Riftline +17.4s, Chariot +17.9s, The Deep +24.5s. They are the engine's own built-in shaders (`CanvasShaderRD`, `SceneForwardMobileShaderRD`, `TonemapMobileShaderRD`), not game content.
- An independent run against the **published demo**, throttled to 12 Mbps with caching disabled, agrees: **80 pipelines built within ~2s** of engine start, with the ~13s to first frame **dominated by downloading the 45.8 MB wasm**.
- For scale, the **WebGL 2 control reached its first frame at +13.0s** on the same harness — so WebGPU does add real startup overhead, just far less than the raw ~20s figure implied.

## What changes

| Claim | Before | After |
| --- | --- | --- |
| Cause of cold start | "fixed per-session shader-compilation cost" | engine startup: fetch + instantiate 45.8 MB wasm, then engine/scene init |
| Top optimization | shader precompilation/caching | **payload size** (shader compile is already only ~2s) |
| README blurb | "~30 seconds — most of it compiling shaders" | "15–30s depending on connection — most of it downloading the ~46 MB engine, not compiling shaders (pipelines build in about 2 seconds)" |

Also adds a measurement warning: `page.goto(waitUntil: "load")` waits for the entire wasm and can start a probe clock ~14s late, inflating everything measured after it.

## Unaffected

The **25s `capture.mjs` default from #16 stands** — first frames land at 17–25s regardless of the cause, so the fix was right even though its stated reason was not. Only the explanatory comment changed.

The performance A/B itself (WebGPU ~2.5–3x WebGL 2) is untouched and unaffected: it compares steady-state fps well after first frame.

## Validation

`node --check tests/browser/capture.mjs` passes. Docs and comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)