### PR TITLE
Verify the WebGPU patch series with a real check

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ to work here.
 | Capability | Evidence in this repository |
 |---|---|
 | Official engine base | Godot 4.7.1 stable is pinned by full commit in [engine-lock.toml](engine/engine-lock.toml) |
-| WebGPU source | An ordered patch series in [engine/patches/](engine/patches/), each checked by SHA-256 before application |
+| WebGPU source | An ordered patch series in [engine/patches/](engine/patches/), each checked by SHA-256 before application. `just engine-verify-patches` re-checks the whole series — checksums, ordering, and that nothing on disk is unlocked — with no toolchain required |
 | WebGPU toolchain | The exact Emdawn source and Dawn namespace backport are independently versioned and checksum-locked under [engine/toolchain/](engine/toolchain/) |
 | Source preparation | `engine-fetch` clones official Godot only and creates a disposable patched worktree |
 | Export templates | Accepted archives are recorded by filename, byte count, and SHA-256 in [engine-lock.toml](engine/engine-lock.toml) |

--- a/engine/scripts/tests/test_verify_patch_series.py
+++ b/engine/scripts/tests/test_verify_patch_series.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+ENGINE_DIR = SCRIPTS.parent
+VERIFIER = SCRIPTS / "verify_patch_series.py"
+
+
+def _run(engine_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Run the verifier against a copy of engine/ staged at engine_dir."""
+    return subprocess.run(
+        [sys.executable, str(engine_dir / "scripts" / "verify_patch_series.py")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class VerifyPatchSeriesTests(unittest.TestCase):
+    """The patch series is the project's core reproducibility claim, so the check
+    that guards it needs its own teeth verified — a checker that always passes is
+    worse than none."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.engine = Path(self._tmp.name) / "engine"
+        shutil.copytree(ENGINE_DIR, self.engine, symlinks=True)
+        self.patches = self.engine / "patches"
+        self.addCleanup(self._tmp.cleanup)
+
+    def _a_patch(self) -> Path:
+        candidates = sorted(self.patches.glob("*.patch"))
+        self.assertTrue(candidates, "expected at least one patch in engine/patches")
+        return candidates[-1]
+
+    def test_real_series_is_intact(self) -> None:
+        result = _run(self.engine)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("patch series OK", result.stdout)
+
+    def test_modified_patch_is_rejected(self) -> None:
+        target = self._a_patch()
+        target.write_bytes(target.read_bytes() + b"\n")
+        result = _run(self.engine)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("checksum mismatch", result.stderr)
+
+    def test_unlocked_patch_file_is_rejected(self) -> None:
+        rogue = self.patches / "9999-not-in-the-lock.patch"
+        rogue.write_text("not a real patch\n", encoding="utf-8")
+        result = _run(self.engine)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not locked", result.stderr)
+
+    def test_missing_patch_file_is_rejected(self) -> None:
+        self._a_patch().unlink()
+        result = _run(self.engine)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("missing", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/engine/scripts/verify_patch_series.py
+++ b/engine/scripts/verify_patch_series.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Verify the WebGPU patch series against engine-lock.toml.
+
+The project's central claim is that the WebGPU backend is a transparent,
+checksum-locked series of patches on an official Godot commit — so drift between
+the patch files and the lock is exactly the failure worth catching automatically.
+
+Checks, in order:
+  1. every patch named in the lock exists, and its SHA-256 matches,
+  2. no patch file on disk is missing from the lock (an unlocked patch would be
+     applied by nobody, or worse, silently ignored),
+  3. the series is ordered and contiguous by its NNNN- prefix.
+
+Stdlib only (tomllib needs Python 3.11+), so this runs anywhere without a
+toolchain — no Godot, no Emscripten, no GPU.
+
+Exit status is 0 when the series is intact, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from patch_series import PatchSeriesError, verified_patches  # noqa: E402
+
+ENGINE_DIR = Path(__file__).resolve().parents[1]
+LOCK_PATH = ENGINE_DIR / "engine-lock.toml"
+
+
+def main() -> int:
+    if not LOCK_PATH.is_file():
+        print(f"error: missing {LOCK_PATH}", file=sys.stderr)
+        return 1
+
+    with LOCK_PATH.open("rb") as handle:
+        lock = tomllib.load(handle)
+
+    # 1. Locked patches exist and match their recorded checksums.
+    try:
+        patches = verified_patches(lock, ENGINE_DIR)
+    except PatchSeriesError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    locked = {patch.relative for patch in patches}
+
+    # 2. Nothing on disk is left out of the lock.
+    on_disk = {
+        f"patches/{path.name}"
+        for path in sorted((ENGINE_DIR / "patches").glob("*.patch"))
+    }
+    unlocked = sorted(on_disk - locked)
+    if unlocked:
+        print("error: patch files present but not locked in engine-lock.toml:", file=sys.stderr)
+        for name in unlocked:
+            print(f"  {name}", file=sys.stderr)
+        return 1
+
+    # 3. The series is ordered and contiguous.
+    numbers = []
+    for patch in patches:
+        match = re.match(r"patches/(\d{4})-", patch.relative)
+        if not match:
+            print(f"error: patch is not NNNN- prefixed: {patch.relative}", file=sys.stderr)
+            return 1
+        numbers.append(int(match.group(1)))
+
+    expected = list(range(1, len(numbers) + 1))
+    if numbers != expected:
+        print(
+            f"error: patch series must be ordered and contiguous; got {numbers}",
+            file=sys.stderr,
+        )
+        return 1
+
+    base = lock["godot"]["webgpu"]["base_commit"]
+    print(f"patch series OK — {len(patches)} patches, checksums match, applied over {base[:12]}")
+    for patch in patches:
+        print(f"  {patch.relative}  {patch.sha256[:16]}…")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/justfile
+++ b/justfile
@@ -224,6 +224,11 @@ engine-test:
 engine-versions:
     {{PY}} engine/scripts/engine.py versions
 
+# Verify the WebGPU patch series against engine-lock.toml (checksums, ordering,
+# nothing unlocked). Stdlib only — no Godot, Emscripten, or GPU required.
+engine-verify-patches:
+    {{PY}} engine/scripts/verify_patch_series.py
+
 # Fetch pinned official Godot and apply the verified local patch series
 engine-fetch:
     {{PY}} engine/scripts/engine.py fetch


### PR DESCRIPTION
The repo's central claim is *checksum-locked, reproducible patch series* — but nothing was enforcing it. Patch files and `engine-lock.toml` could drift apart silently, which is exactly what the claim rules out.

```bash
just engine-verify-patches
```

Checks that every locked patch exists with a matching SHA-256, that **no patch file on disk is missing from the lock**, and that the series is ordered and contiguous. Stdlib only (`tomllib`) — no Godot, no Emscripten, no GPU, runs in seconds.

### The checker is itself tested
A check that always passes is worse than none, so there are tests for the failure paths — modified patch, unlocked patch file, missing patch. Verified locally:

| case | exit |
|---|---|
| clean tree (14 patches) | 0 |
| patch file modified | 1 |
| unlocked patch added | 1 |
| patch file missing | 1 |

Runs under the existing `just engine-test` — **10/10 green**, no regressions.

### Not included
A GitHub Actions workflow to run this on every push is written and ready, but pushing `.github/workflows/` needs a token with `workflow` scope, which the current credentials lack. Happy to add it once that's granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)