### PR TITLE
docs: stage the patch-series CI workflow for installation

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,0 +1,38 @@
+# Continuous integration
+
+## `patch-series.yml` — not yet installed
+
+[`patch-series.yml`](patch-series.yml) runs `engine/scripts/verify_patch_series.py`
+on every push and pull request: it fails the build if any patch in
+`engine/patches/` drifts from the SHA-256 recorded in `engine/engine-lock.toml`,
+if a patch file exists that the lock does not cover, or if the series stops being
+ordered and contiguous.
+
+That is the repository's central claim — a transparent, checksum-locked patch
+series over an official Godot commit — so it is worth enforcing mechanically
+rather than by habit.
+
+It lives here instead of `.github/workflows/` because GitHub refuses a push that
+creates or updates a workflow file unless the credentials carry the `workflow`
+OAuth scope, which the token used to land it did not have.
+
+To enable it:
+
+```sh
+mkdir -p .github/workflows
+git mv docs/ci/patch-series.yml .github/workflows/patch-series.yml
+git commit -m "ci: enforce the WebGPU patch series"
+git push
+```
+
+The job needs no toolchain — no Godot, no Emscripten, no GPU — and finishes in
+seconds, so it cannot become a flaky gate. You can run exactly what it runs at
+any time:
+
+```sh
+just engine-verify-patches
+```
+
+The checker's own failure paths are covered by
+`engine/scripts/tests/test_verify_patch_series.py`, which runs under
+`just engine-test`.

--- a/docs/ci/patch-series.yml
+++ b/docs/ci/patch-series.yml
@@ -1,0 +1,32 @@
+name: patch series
+
+# The project's central claim is that the WebGPU backend is a transparent,
+# checksum-locked patch series applied to an official Godot commit. This verifies
+# that claim on every change, so drift between the patch files and the lock cannot
+# land silently.
+#
+# Deliberately toolchain-free: no Godot, no Emscripten, no GPU. It finishes in
+# seconds and cannot be flaky.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: checksums and ordering
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'   # tomllib landed in 3.11
+
+      - name: Verify the WebGPU patch series
+        run: python engine/scripts/verify_patch_series.py


### PR DESCRIPTION
The workflow enforcing patch-series integrity is written and ready, but it cannot be pushed with the current credentials — GitHub rejects any push that creates `.github/workflows/**` unless the token carries the `workflow` OAuth scope.

Rather than drop it, it is staged at `docs/ci/patch-series.yml` with a README explaining why it is parked there and the one-command move to enable it:

    git mv docs/ci/patch-series.yml .github/workflows/patch-series.yml

The check itself already landed and is runnable now via `just engine-verify-patches`; its failure paths are covered by tests under `just engine-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)