### PR TITLE
docs: say which demo is actually reproducible

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ WebGPU. Verified on an NVIDIA Tesla P40 at a locked 60 fps, ~490–630 draw call
 ~23M primitives per frame, with **0 `GPUValidationError`**. The published demo was
 re-rendered from its own public URL on that GPU as a final check.*
 
+> **What you can rebuild:** the engine, the patch series, and the minimal scene below
+> are checksum-locked and reproducible from this repository. The Chariot Club's *game
+> content* is not published here, so that specific demo cannot be rebuilt from source —
+> use the showcase scene to reproduce the render path end to end.
+
 <details>
 <summary>Also published: a ~100-line minimal scene, for reproducing the render path from scratch</summary>
 


### PR DESCRIPTION
The README invited readers to rebuild and re-verify **immediately below a screenshot of The Chariot Club** — whose game content is not in this repository. Only the engine, the patch series, and the minimal showcase scene are actually reproducible from here.

For a project whose entire argument is *don't take my word for it, rebuild it* — overstating what can be rebuilt undercuts the one thing it is selling, and it is exactly what a skeptical reader should catch first.

Now states the scope plainly and points at the showcase scene, which exercises the same render path end to end. The live demo page carries the same clarification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)