### PR TITLE
bforge: tileable PBR baking and texture memory budgets

### DIFF
--- a/docs/bforge/OPS.md
+++ b/docs/bforge/OPS.md
@@ -1,6 +1,6 @@
 # bforge op reference
 
-106 operations.
+108 operations.
 
 ## `arch.*`
 
@@ -726,6 +726,15 @@ Add a named empty as an attachment socket — muzzle points, hardpoints, spawn m
 | `rotation` | array | [0.0, 0.0, 0.0] | Rotation in degrees |
 | `size` | number | 0.1 | Display size of the empty |
 
+### `gameready.texture_budget`
+
+Measure what the textures actually cost in GPU memory and flag any over the platform's resolution cap. Triangle budgets are half the story — a scene can be trivially cheap to draw and still fail to load because its textures do not fit in VRAM.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `profile` | mobile_low \| mobile_high \| browser_webgl \| browser_webgpu \| desktop_high | 'browser_webgpu' | Target platform profile |
+| `assume_compressed` | boolean | False | Report cost after KTX2/Basis transcoding (~8:1) instead of raw RGBA. Only set this once the cook step actually compresses, or the number is fiction |
+
 ## `kit.*`
 
 ### `kit.piece`
@@ -909,6 +918,29 @@ Create and assign a PBR material. Prefer a preset name (stone, wood, metal, gold
 | `metallic` | number | -1.0 | Override metallic 0..1; -1 keeps the preset value |
 | `emission` | number | -1.0 | Emission strength; -1 keeps the preset value |
 | `slot` | integer | 0 | Material slot index |
+
+### `material.tileable`
+
+Bake a SEAMLESS PBR texture set and apply it repeating across a surface. This is how architecture gets textured: a unique bake for a 725 m stadium works out to ~3 px/m, which is no texture at all, whereas one 1k tiling map gives real surface detail everywhere. Noise is sampled through a torus mapping so it tiles perfectly with no visible seam.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `object` | string | None | Object to texture |
+| `base_color` | any | 'stone_grey' | Base albedo |
+| `roughness` | number | 0.78 | Mid roughness |
+| `metallic` | number | 0.0 | Metallic 0..1 |
+| `detail_scale` | number | 6.0 | Feature size in the baked map — higher is finer |
+| `dirt` | number | 0.35 | Grime settled in the low spots (0..1) |
+| `dirt_color` | any | '#2b2118' | Grime colour |
+| `bump` | number | 0.4 | Surface relief strength |
+| `tiles` | number | 6.0 | How many times the map repeats across the object's UVs |
+| `uv_scale` | number | 0.0 | Metres per UV tile for box projection; 0 keeps existing UVs |
+| `size` | integer | 1024 | Texture resolution |
+| `samples` | integer | 16 | Cycles samples for the bake |
+| `stem` | string | '' | Filename stem (defaults to the object name) |
+| `out_dir` | string | 'textures' | Directory for the PNGs |
+| `reuse` | boolean | True | If this stem was already baked, assign the existing material instead of baking again. Bake once, apply to every stone surface in a building — same texture, one set of maps, one draw call |
+| `seed` | integer | 0 | Random seed |
 
 ## `meta.*`
 

--- a/tools/bforge/catalog.json
+++ b/tools/bforge/catalog.json
@@ -3168,6 +3168,39 @@
       }
     },
     {
+      "name": "gameready.texture_budget",
+      "summary": "Measure what the textures actually cost in GPU memory and flag any over the platform's resolution cap. Triangle budgets are half the story \u2014 a scene can be trivially cheap to draw and still fail to load because its textures do not fit in VRAM.",
+      "tags": [
+        "gameready",
+        "inspect"
+      ],
+      "mutates": false,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "profile": {
+            "type": "string",
+            "enum": [
+              "mobile_low",
+              "mobile_high",
+              "browser_webgl",
+              "browser_webgpu",
+              "desktop_high"
+            ],
+            "description": "Target platform profile",
+            "default": "browser_webgpu"
+          },
+          "assume_compressed": {
+            "type": "boolean",
+            "description": "Report cost after KTX2/Basis transcoding (~8:1) instead of raw RGBA. Only set this once the cook step actually compresses, or the number is fiction",
+            "default": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "kit.piece",
       "summary": "One modular kit piece with its origin at the grid corner, ready to snap. Build a whole set with kit.set instead if you want more than one.",
       "tags": [
@@ -3967,6 +4000,126 @@
           "slot": {
             "type": "integer",
             "description": "Material slot index",
+            "default": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "material.tileable",
+      "summary": "Bake a SEAMLESS PBR texture set and apply it repeating across a surface. This is how architecture gets textured: a unique bake for a 725 m stadium works out to ~3 px/m, which is no texture at all, whereas one 1k tiling map gives real surface detail everywhere. Noise is sampled through a torus mapping so it tiles perfectly with no visible seam.",
+      "tags": [
+        "material",
+        "bake",
+        "pbr"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "description": "Object to texture"
+          },
+          "base_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Base albedo",
+            "default": "stone_grey"
+          },
+          "roughness": {
+            "type": "number",
+            "description": "Mid roughness",
+            "default": 0.78
+          },
+          "metallic": {
+            "type": "number",
+            "description": "Metallic 0..1",
+            "default": 0.0
+          },
+          "detail_scale": {
+            "type": "number",
+            "description": "Feature size in the baked map \u2014 higher is finer",
+            "default": 6.0
+          },
+          "dirt": {
+            "type": "number",
+            "description": "Grime settled in the low spots (0..1)",
+            "default": 0.35
+          },
+          "dirt_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Grime colour",
+            "default": "#2b2118"
+          },
+          "bump": {
+            "type": "number",
+            "description": "Surface relief strength",
+            "default": 0.4
+          },
+          "tiles": {
+            "type": "number",
+            "description": "How many times the map repeats across the object's UVs",
+            "default": 6.0
+          },
+          "uv_scale": {
+            "type": "number",
+            "description": "Metres per UV tile for box projection; 0 keeps existing UVs",
+            "default": 0.0
+          },
+          "size": {
+            "type": "integer",
+            "description": "Texture resolution",
+            "default": 1024
+          },
+          "samples": {
+            "type": "integer",
+            "description": "Cycles samples for the bake",
+            "default": 16
+          },
+          "stem": {
+            "type": "string",
+            "description": "Filename stem (defaults to the object name)",
+            "default": ""
+          },
+          "out_dir": {
+            "type": "string",
+            "description": "Directory for the PNGs",
+            "default": "textures"
+          },
+          "reuse": {
+            "type": "boolean",
+            "description": "If this stem was already baked, assign the existing material instead of baking again. Bake once, apply to every stone surface in a building \u2014 same texture, one set of maps, one draw call",
+            "default": true
+          },
+          "seed": {
+            "type": "integer",
+            "description": "Random seed",
             "default": 0
           }
         },

--- a/tools/bforge/runtime/lib/mat.py
+++ b/tools/bforge/runtime/lib/mat.py
@@ -14,6 +14,8 @@ what turns "procedural" from a Blender-only party trick into a shippable asset.
 
 from __future__ import annotations
 
+import math
+
 import bpy
 
 # A deliberately small, harmonised palette. Stylised game art lives or dies on
@@ -521,12 +523,309 @@ def layered_pbr(
     return material
 
 
+def _torus_coords(tree, tiles=1.0):
+    """UV -> a point on a torus, so 3D noise sampled there tiles seamlessly.
+
+    Blender's noise textures are not periodic, so baking one straight to a map
+    leaves a visible seam wherever it repeats. Wrapping UV around a torus makes
+    the sample point return to itself at u=1 and v=1 by construction, which
+    makes the baked result tile perfectly in both axes.
+
+    This is what lets a 725 m stadium be textured from one 1k map. Baking a
+    unique map for a building that size gives roughly 3 px/m, which is no
+    texture at all.
+    """
+    nodes, links = tree.nodes, tree.links
+    uv = nodes.new("ShaderNodeUVMap")
+    uv.location = (-2200, 0)
+    scaled = nodes.new("ShaderNodeVectorMath")
+    scaled.operation = "MULTIPLY"
+    scaled.location = (-2040, 0)
+    scaled.inputs[1].default_value = (tiles, tiles, 0.0)
+    links.new(uv.outputs["UV"], scaled.inputs[0])
+
+    split = nodes.new("ShaderNodeSeparateXYZ")
+    split.location = (-1880, 0)
+    links.new(scaled.outputs["Vector"], split.inputs["Vector"])
+
+    def angle(component, offset_y):
+        turn = nodes.new("ShaderNodeMath")
+        turn.operation = "MULTIPLY"
+        turn.location = (-1720, offset_y)
+        turn.inputs[1].default_value = math.tau
+        links.new(component, turn.inputs[0])
+        sine = nodes.new("ShaderNodeMath")
+        sine.operation = "SINE"
+        sine.location = (-1560, offset_y)
+        links.new(turn.outputs[0], sine.inputs[0])
+        cosine = nodes.new("ShaderNodeMath")
+        cosine.operation = "COSINE"
+        cosine.location = (-1560, offset_y - 120)
+        links.new(turn.outputs[0], cosine.inputs[0])
+        return sine, cosine
+
+    sin_u, cos_u = angle(split.outputs["X"], 220)
+    sin_v, cos_v = angle(split.outputs["Y"], -220)
+
+    # radius = 1 + 0.25*cos(v): a fat torus, so both axes get similar feature
+    # sizes instead of one being visibly stretched.
+    ring = nodes.new("ShaderNodeMath")
+    ring.operation = "MULTIPLY_ADD"
+    ring.location = (-1400, -220)
+    ring.inputs[1].default_value = 0.25
+    ring.inputs[2].default_value = 1.0
+    links.new(cos_v.outputs[0], ring.inputs[0])
+
+    def planar(trig, offset_y):
+        product = nodes.new("ShaderNodeMath")
+        product.operation = "MULTIPLY"
+        product.location = (-1240, offset_y)
+        links.new(ring.outputs[0], product.inputs[0])
+        links.new(trig.outputs[0], product.inputs[1])
+        return product
+
+    x_axis = planar(cos_u, 120)
+    y_axis = planar(sin_u, -40)
+    z_axis = nodes.new("ShaderNodeMath")
+    z_axis.operation = "MULTIPLY"
+    z_axis.location = (-1240, -340)
+    z_axis.inputs[1].default_value = 0.25
+    links.new(sin_v.outputs[0], z_axis.inputs[0])
+
+    combine = nodes.new("ShaderNodeCombineXYZ")
+    combine.location = (-1080, 0)
+    links.new(x_axis.outputs[0], combine.inputs["X"])
+    links.new(y_axis.outputs[0], combine.inputs["Y"])
+    links.new(z_axis.outputs[0], combine.inputs["Z"])
+    return combine.outputs["Vector"]
+
+
+def tileable_pbr(name, base_color, roughness=0.78, metallic=0.0, detail_scale=6.0,
+                 dirt_color="#2b2118", dirt=0.35, bump=0.4, tiles=1.0, seed=0):
+    """A seamless surface for tiling onto architecture.
+
+    Deliberately excludes the curvature and ambient-occlusion layers that
+    `layered_pbr` uses. Those describe a specific MESH — where its edges are,
+    where its crevices are — and cannot be baked into a texture meant to repeat
+    across arbitrary geometry. Tileable maps carry material detail; per-object
+    wear needs its own bake.
+    """
+    material = bpy.data.materials.new(name)
+    material.use_nodes = True
+    tree = material.node_tree
+    nodes, links = tree.nodes, tree.links
+    bsdf = nodes.get("Principled BSDF")
+    base_rgba = resolve_color(base_color)
+    dirt_rgba = resolve_color(dirt_color)
+    coords = _torus_coords(tree, tiles)
+
+    def noise(scale, detail, offset_y, w):
+        node = nodes.new("ShaderNodeTexNoise")
+        node.location = (-900, offset_y)
+        node.noise_dimensions = "3D"
+        _set(node, "Scale", scale)
+        _set(node, "Detail", detail)
+        _set(node, "Roughness", 0.6)
+        _set(node, "W", float(w))
+        links.new(coords, node.inputs["Vector"])
+        return node
+
+    coarse = noise(detail_scale, 6.0, -100, seed)
+    fine = noise(detail_scale * 4.2, 8.0, -320, seed + 5)
+    blotch = noise(max(0.5, detail_scale * 0.28), 3.0, 160, seed + 11)
+
+    detail_mix = nodes.new("ShaderNodeMix")
+    detail_mix.data_type = "FLOAT"
+    detail_mix.location = (-700, -200)
+    _set(detail_mix, "Factor", 0.4)
+    links.new(coarse.outputs["Fac"], detail_mix.inputs[2])
+    links.new(fine.outputs["Fac"], detail_mix.inputs[3])
+
+    # LOW-FREQUENCY CONTENT IS WHAT MAKES TILING VISIBLE. A big blotch is the
+    # eye's anchor, so once the map repeats those blotches line up into an
+    # obvious grid across the wall — which is exactly what happened on the first
+    # textured hippodrome. A tiling map has to be dominated by high-frequency
+    # detail; large-scale variation belongs per-object (vertex colour, a second
+    # unique map), not in the thing that repeats.
+    blotch_ramp = nodes.new("ShaderNodeValToRGB")
+    blotch_ramp.location = (-700, 160)
+    blotch_ramp.color_ramp.elements[0].position = 0.42
+    blotch_ramp.color_ramp.elements[1].position = 0.60
+    links.new(blotch.outputs["Fac"], blotch_ramp.inputs["Fac"])
+
+    blotched = nodes.new("ShaderNodeMix")
+    blotched.data_type = "RGBA"
+    blotched.location = (-500, 60)
+    blotched.inputs[6].default_value = _darken(base_rgba, 0.12)
+    blotched.inputs[7].default_value = _lighten(base_rgba, 0.06)
+    links.new(blotch_ramp.outputs["Color"], blotched.inputs[0])
+
+    # Grain is the high-frequency signal that survives tiling without reading as
+    # a repeat, so it carries most of the surface interest. Kept moderate: a
+    # full swing to half-darkness stacks with the grime below and drags the whole
+    # building down.
+    grained = nodes.new("ShaderNodeMix")
+    grained.data_type = "RGBA"
+    grained.location = (-320, 0)
+    grained.inputs[7].default_value = _darken(base_rgba, 0.28)
+    links.new(detail_mix.outputs[0], grained.inputs[0])
+    links.new(blotched.outputs[2], grained.inputs[6])
+
+    # Grime settled in the dips reads as age even on a flat wall, where there is
+    # no cavity for an AO pass to find. Driven by the FINE detail, not the
+    # blotch, for the same tiling reason.
+    grime = nodes.new("ShaderNodeMath")
+    grime.operation = "MULTIPLY"
+    grime.location = (-320, 280)
+    grime.inputs[1].default_value = dirt * 0.5
+    links.new(detail_mix.outputs[0], grime.inputs[0])
+
+    with_dirt = nodes.new("ShaderNodeMix")
+    with_dirt.data_type = "RGBA"
+    with_dirt.location = (-140, 60)
+    with_dirt.inputs[7].default_value = dirt_rgba
+    links.new(grime.outputs[0], with_dirt.inputs[0])
+    links.new(grained.outputs[2], with_dirt.inputs[6])
+    links.new(with_dirt.outputs[2], bsdf.inputs["Base Color"])
+
+    rough = nodes.new("ShaderNodeMapRange")
+    rough.location = (-320, -420)
+    _set(rough, "To Min", max(0.05, roughness - 0.22))
+    _set(rough, "To Max", min(1.0, roughness + 0.14))
+    links.new(detail_mix.outputs[0], rough.inputs["Value"])
+    links.new(rough.outputs["Result"], bsdf.inputs["Roughness"])
+    _set(bsdf, "Metallic", metallic)
+
+    relief = nodes.new("ShaderNodeBump")
+    relief.location = (-140, -420)
+    _set(relief, "Strength", bump)
+    _set(relief, "Distance", 0.05)
+    links.new(detail_mix.outputs[0], relief.inputs["Height"])
+    links.new(relief.outputs["Normal"], bsdf.inputs["Normal"])
+
+    material["bforge_procedural"] = "tileable_pbr"
+    return material
+
+
 def _lighten(rgba, amount):
     return tuple(min(1.0, c + (1.0 - c) * amount) for c in rgba[:3]) + (rgba[3],)
 
 
 def _darken(rgba, amount):
     return tuple(max(0.0, c * (1.0 - amount)) for c in rgba[:3]) + (rgba[3],)
+
+
+def bake_tileable_set(material, out_dir, stem, size=1024, samples=16,
+                      maps=("base_color", "normal", "roughness")):
+    """Bake a tileable material to seamless maps off a throwaway flat plane.
+
+    A plane with exact 0..1 UVs and no curvature means the bake captures the
+    material and nothing about any particular mesh — which is the whole point
+    of a tiling texture. Margin is 0: a margin bleeds edge pixels outward and
+    would break the seam the torus mapping just guaranteed.
+    """
+    scene = bpy.context.scene
+    previous_engine = scene.render.engine
+    scene.render.engine = "CYCLES"
+    scene.cycles.samples = max(1, samples)
+    if hasattr(scene.cycles, "device"):
+        scene.cycles.device = "CPU"
+    scene.render.bake.margin = 0
+    scene.render.bake.use_clear = True
+
+    mesh = bpy.data.meshes.new("_bforge_swatch")
+    verts = [(-1, -1, 0), (1, -1, 0), (1, 1, 0), (-1, 1, 0)]
+    mesh.from_pydata(verts, [], [(0, 1, 2, 3)])
+    mesh.update()
+    layer = mesh.uv_layers.new(name="UVMap")
+    for index, uv in enumerate([(0, 0), (1, 0), (1, 1), (0, 1)]):
+        layer.data[index].uv = uv
+    plane = bpy.data.objects.new("_bforge_swatch", mesh)
+    plane.data.materials.append(material)
+    scene.collection.objects.link(plane)
+
+    view_layer = bpy.context.view_layer
+    previous_selection = [o for o in scene.objects if o.select_get()]
+    previous_active = view_layer.objects.active
+    for other in scene.objects:
+        other.select_set(False)
+    plane.select_set(True)
+    view_layer.objects.active = plane
+
+    produced = {}
+    try:
+        for map_name in maps:
+            if map_name not in PBR_PASSES:
+                continue
+            bake_type, is_data = PBR_PASSES[map_name]
+            image = bpy.data.images.new(
+                f"{stem}_{map_name}", width=size, height=size,
+                alpha=False, float_buffer=False, is_data=is_data,
+            )
+            node = material.node_tree.nodes.new("ShaderNodeTexImage")
+            node.image = image
+            node.location = (-2400, 600)
+            node.select = True
+            material.node_tree.nodes.active = node
+            if bake_type == "DIFFUSE":
+                scene.render.bake.use_pass_direct = False
+                scene.render.bake.use_pass_indirect = False
+                scene.render.bake.use_pass_color = True
+            bpy.ops.object.bake(type=bake_type, use_clear=True, margin=0)
+            path = f"{out_dir}/{stem}_{map_name}.png"
+            image.filepath_raw = path
+            image.file_format = "PNG"
+            image.save()
+            produced[map_name] = (image, path)
+            material.node_tree.nodes.remove(node)
+    finally:
+        bpy.data.objects.remove(plane, do_unlink=True)
+        bpy.data.meshes.remove(mesh)
+        for other in previous_selection:
+            if other.name in scene.objects:
+                other.select_set(True)
+        view_layer.objects.active = previous_active
+        scene.render.engine = previous_engine
+    return produced
+
+
+def tiled_material(name, produced, tiles=4.0, base_color=None):
+    """A glTF-safe material that repeats baked maps across a surface."""
+    material = bpy.data.materials.new(name)
+    material.use_nodes = True
+    tree = material.node_tree
+    nodes, links = tree.nodes, tree.links
+    bsdf = nodes.get("Principled BSDF")
+    if base_color is not None:
+        _set(bsdf, "Base Color", resolve_color(base_color))
+
+    uv = nodes.new("ShaderNodeUVMap")
+    uv.location = (-900, 0)
+    mapping = nodes.new("ShaderNodeMapping")
+    mapping.location = (-740, 0)
+    _set(mapping, "Scale", (tiles, tiles, 1.0))
+    links.new(uv.outputs["UV"], mapping.inputs["Vector"])
+
+    row = 300
+    for map_name, (image, _path) in produced.items():
+        tex = nodes.new("ShaderNodeTexImage")
+        tex.image = image
+        tex.extension = "REPEAT"
+        tex.location = (-520, row)
+        row -= 300
+        links.new(mapping.outputs["Vector"], tex.inputs["Vector"])
+        if map_name == "base_color":
+            links.new(tex.outputs["Color"], bsdf.inputs["Base Color"])
+        elif map_name == "roughness":
+            image.colorspace_settings.name = "Non-Color"
+            links.new(tex.outputs["Color"], bsdf.inputs["Roughness"])
+        elif map_name == "normal":
+            image.colorspace_settings.name = "Non-Color"
+            normal_map = nodes.new("ShaderNodeNormalMap")
+            normal_map.location = (-260, row + 300)
+            links.new(tex.outputs["Color"], normal_map.inputs["Color"])
+            links.new(normal_map.outputs["Normal"], bsdf.inputs["Normal"])
+    return material
 
 
 # Which Cycles pass produces each map, and whether it is colour or data.

--- a/tools/bforge/runtime/ops/gameready.py
+++ b/tools/bforge/runtime/ops/gameready.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import math
 
 import bmesh
+import bpy
 from lib import finish as finish_lib
 from lib import mesh as mesh_lib
 from lib import scene as scene_lib
@@ -254,6 +255,92 @@ def gameready_budget(ctx, profile, asset_class, objects):
 
 def _is_proxy(name):
     return name.endswith("-col") or name.endswith("-convcol")
+
+
+# Uncompressed GPU cost per texel, plus a third again for the mip chain.
+_BYTES_PER_TEXEL = 4
+_MIP_FACTOR = 4.0 / 3.0
+# What each platform can afford to hold in texture memory at once. Browsers are
+# the tight case: the WASM heap and the GPU budget share a device that is often
+# running a dozen other tabs.
+TEXTURE_BUDGETS_MB = {
+    "mobile_low": 32,
+    "mobile_high": 96,
+    "browser_webgl": 96,
+    "browser_webgpu": 192,
+    "desktop_high": 1024,
+}
+
+
+@op(
+    "gameready.texture_budget",
+    summary="Measure what the textures actually cost in GPU memory and flag any over the platform's resolution cap. Triangle budgets are half the story — a scene can be trivially cheap to draw and still fail to load because its textures do not fit in VRAM.",
+    params={
+        "profile": (f"enum:{'|'.join(PROFILES)}", "browser_webgpu", "Target platform profile"),
+        "assume_compressed": ("bool", False, "Report cost after KTX2/Basis transcoding (~8:1) instead of raw RGBA. Only set this once the cook step actually compresses, or the number is fiction"),
+    },
+    tags=["gameready", "inspect"],
+    mutates=False,
+)
+def gameready_texture_budget(ctx, profile, assume_compressed):
+    cap = PROFILES[profile]["texture"]
+    budget_mb = TEXTURE_BUDGETS_MB[profile]
+    ratio = 8.0 if assume_compressed else 1.0
+
+    rows = []
+    total_bytes = 0.0
+    oversized = []
+    for image in bpy.data.images:
+        if image.name == "Render Result":
+            continue
+        width, height = image.size
+        if width == 0 or height == 0:
+            continue
+        cost = (width * height * _BYTES_PER_TEXEL * _MIP_FACTOR) / ratio
+        total_bytes += cost
+        row = {
+            "name": image.name,
+            "size": [width, height],
+            "mb": round(cost / (1024 * 1024), 3),
+            "over_cap": max(width, height) > cap,
+        }
+        rows.append(row)
+        if row["over_cap"]:
+            oversized.append(row)
+
+    total_mb = total_bytes / (1024 * 1024)
+    advice = [
+        f"'{row['name']}' is {row['size'][0]}x{row['size'][1]} against a {cap} cap for "
+        f"{profile} — re-bake at size={cap}."
+        for row in oversized
+    ]
+    if total_mb > budget_mb:
+        advice.append(
+            f"{total_mb:.1f} MB of texture memory against a {budget_mb} MB budget for "
+            f"{profile}. Lower resolutions, share one tiling map across surfaces "
+            "(material.tileable with reuse=true), or atlas."
+        )
+    if rows and not assume_compressed:
+        # The sidecars this pipeline writes declare texture_policy=compressed.
+        # Until the cook step actually runs KTX2/Basis that claim is aspirational,
+        # and the honest number is the uncompressed one reported here.
+        ctx.note(
+            f"Measured as UNCOMPRESSED RGBA ({total_mb:.1f} MB). Assets declaring "
+            "texture_policy=compressed are not compressed until the cook step runs "
+            f"KTX2/Basis; with it this set would cost about {total_mb / 8.0:.1f} MB."
+        )
+
+    return {
+        "profile": profile,
+        "textures": rows,
+        "count": len(rows),
+        "total_mb": round(total_mb, 2),
+        "budget_mb": budget_mb,
+        "resolution_cap": cap,
+        "compressed": assume_compressed,
+        "within_budget": total_mb <= budget_mb and not oversized,
+        "advice": advice,
+    }
 
 
 @op(

--- a/tools/bforge/runtime/ops/material.py
+++ b/tools/bforge/runtime/ops/material.py
@@ -133,6 +133,90 @@ def material_pbr(ctx, object, base_color, roughness, metallic, detail_scale, gra
 
 
 @op(
+    "material.tileable",
+    summary="Bake a SEAMLESS PBR texture set and apply it repeating across a surface. This is how architecture gets textured: a unique bake for a 725 m stadium works out to ~3 px/m, which is no texture at all, whereas one 1k tiling map gives real surface detail everywhere. Noise is sampled through a torus mapping so it tiles perfectly with no visible seam.",
+    params={
+        "object": ("str", None, "Object to texture"),
+        "base_color": ("colorref", "stone_grey", "Base albedo"),
+        "roughness": ("num", 0.78, "Mid roughness"),
+        "metallic": ("num", 0.0, "Metallic 0..1"),
+        "detail_scale": ("num", 6.0, "Feature size in the baked map — higher is finer"),
+        "dirt": ("num", 0.35, "Grime settled in the low spots (0..1)"),
+        "dirt_color": ("colorref", "#2b2118", "Grime colour"),
+        "bump": ("num", 0.4, "Surface relief strength"),
+        "tiles": ("num", 6.0, "How many times the map repeats across the object's UVs"),
+        "uv_scale": ("num", 0.0, "Metres per UV tile for box projection; 0 keeps existing UVs"),
+        "size": ("int", 1024, "Texture resolution"),
+        "samples": ("int", 16, "Cycles samples for the bake"),
+        "stem": ("str", "", "Filename stem (defaults to the object name)"),
+        "out_dir": ("path", "textures", "Directory for the PNGs"),
+        "reuse": ("bool", True, "If this stem was already baked, assign the existing material instead of baking again. Bake once, apply to every stone surface in a building — same texture, one set of maps, one draw call"),
+        "seed": ("int", 0, "Random seed"),
+    },
+    tags=["material", "bake", "pbr"],
+)
+def material_tileable(ctx, object, base_color, roughness, metallic, detail_scale, dirt,
+                      dirt_color, bump, tiles, uv_scale, size, samples, stem, out_dir,
+                      reuse, seed):
+    obj = _get(object)
+    if obj.type != "MESH":
+        raise OpError(f"'{object}' is a {obj.type}, not a mesh")
+
+    existing = bpy.data.materials.get(f"m_{scene_lib.sanitize(stem or obj.name)}")
+    if reuse and existing is not None:
+        if uv_scale > 0.0:
+            uv_lib.box_project(obj, scale=uv_scale)
+        obj.data.materials.clear()
+        mat_lib.assign(obj, existing)
+        return {
+            "object": obj.name, "material": existing.name, "reused": True,
+            "tiles": tiles, "uv_scale": uv_scale or None, "gltf_safe": True,
+        }
+
+    if uv_scale > 0.0:
+        # Box projection at a fixed metres-per-tile keeps texel density uniform
+        # across every surface of the building, which is what makes a kit read
+        # as one kit rather than a pile of separately-textured parts.
+        uv_lib.box_project(obj, scale=uv_scale)
+    elif not obj.data.uv_layers:
+        raise OpError(
+            f"'{object}' has no UVs. Pass uv_scale (metres per tile) to box-project, "
+            "or run uv.unwrap first."
+        )
+
+    label = scene_lib.sanitize(stem or obj.name)
+    source = mat_lib.tileable_pbr(
+        f"m_tileable_{label}", base_color, roughness=roughness, metallic=metallic,
+        detail_scale=detail_scale, dirt_color=dirt_color, dirt=dirt, bump=bump, seed=seed,
+    )
+    directory = ctx.out_path(f"{out_dir}/{label}.png", ".png").parent
+    try:
+        produced = mat_lib.bake_tileable_set(
+            source, str(directory), label, size=size, samples=samples,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise OpError(f"tileable bake failed: {exc}") from exc
+    if not produced:
+        raise OpError("no maps were baked")
+
+    applied = mat_lib.tiled_material(f"m_{label}", produced, tiles=tiles)
+    obj.data.materials.clear()
+    mat_lib.assign(obj, applied)
+    bpy.data.materials.remove(source)
+
+    return {
+        "object": obj.name,
+        "material": applied.name,
+        "maps": {k: ctx.rel(v[1]) for k, v in produced.items()},
+        "size": size,
+        "tiles": tiles,
+        "uv_scale": uv_scale or None,
+        "reused": False,
+        "gltf_safe": True,
+    }
+
+
+@op(
     "material.bake_pbr",
     summary="Bake a layered material into a real PBR texture set (base colour, normal, roughness, AO) and rewire it as glTF-safe image textures. This is the step that makes a procedurally-surfaced asset actually shippable.",
     params={

--- a/tools/bforge/tests/test_tileable.py
+++ b/tools/bforge/tests/test_tileable.py
@@ -1,0 +1,143 @@
+"""Is the baked texture ACTUALLY seamless?
+
+A tiling texture that seams is worse than no texture: the repeat becomes a grid
+of visible lines across a whole building. "A PNG appeared" proves nothing, so
+this decodes the map and compares the wrapped edges — column 0 against column
+w-1, row 0 against row h-1 — against the noise floor of neighbouring columns
+inside the image.
+
+If the wrap discontinuity is no worse than an ordinary interior step, it tiles.
+
+    python tools/bforge/tests/test_tileable.py
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge import Forge  # noqa: E402
+
+
+def read_png(path: Path):
+    """Minimal PNG decoder — stdlib only, no Pillow in the tools venv."""
+    data = path.read_bytes()
+    assert data[:8] == b"\x89PNG\r\n\x1a\n", "not a PNG"
+    pos, idat, width, height, depth, colour = 8, b"", 0, 0, 0, 0
+    while pos < len(data):
+        (length,) = struct.unpack(">I", data[pos : pos + 4])
+        kind = data[pos + 4 : pos + 8]
+        body = data[pos + 8 : pos + 8 + length]
+        if kind == b"IHDR":
+            width, height, depth, colour = struct.unpack(">IIBB", body[:10])
+        elif kind == b"IDAT":
+            idat += body
+        elif kind == b"IEND":
+            break
+        pos += 12 + length
+    assert depth == 8, f"expected 8-bit, got {depth}"
+    channels = {0: 1, 2: 3, 4: 2, 6: 4}[colour]
+    raw = zlib.decompress(idat)
+    stride = width * channels
+    out, previous = [], bytearray(stride)
+    pos = 0
+    for _row in range(height):
+        filt = raw[pos]
+        line = bytearray(raw[pos + 1 : pos + 1 + stride])
+        pos += 1 + stride
+        for i in range(stride):
+            a = line[i - channels] if i >= channels else 0
+            b = previous[i]
+            c = previous[i - channels] if i >= channels else 0
+            if filt == 1:
+                line[i] = (line[i] + a) & 0xFF
+            elif filt == 2:
+                line[i] = (line[i] + b) & 0xFF
+            elif filt == 3:
+                line[i] = (line[i] + (a + b) // 2) & 0xFF
+            elif filt == 4:
+                p = a + b - c
+                pa, pb, pc = abs(p - a), abs(p - b), abs(p - c)
+                pred = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                line[i] = (line[i] + pred) & 0xFF
+        out.append(bytes(line))
+        previous = line
+    return width, height, channels, out
+
+
+def mean_abs_delta(rows, channels, pairs):
+    total = count = 0
+    for (ax, ay), (bx, by) in pairs:
+        for c in range(min(3, channels)):
+            total += abs(rows[ay][ax * channels + c] - rows[by][bx * channels + c])
+            count += 1
+    return total / max(1, count)
+
+
+def check(path: Path) -> tuple[float, float]:
+    width, height, channels, rows = read_png(path)
+    # Wrap seam: last column vs first column, last row vs first row.
+    wrap = [((width - 1, y), (0, y)) for y in range(height)]
+    wrap += [((x, height - 1), (x, 0)) for x in range(width)]
+    # Control: an ordinary interior step, the natural noise floor of this map.
+    interior = [((x, y), (x + 1, y)) for y in range(0, height, 4) for x in range(0, width - 1, 7)]
+    return mean_abs_delta(rows, channels, wrap), mean_abs_delta(rows, channels, interior)
+
+
+def main() -> int:
+    failures = []
+    with Forge(workdir=".", out_dir="assets-generated/bforge") as forge:
+        forge.call("session.reset")
+        forge.call("build.box", name="wall", size=[8.0, 0.5, 5.0], material="", uv="none")
+        result = forge.call(
+            "material.tileable",
+            object="wall",
+            base_color="#c2ab84",
+            roughness=0.82,
+            detail_scale=5.0,
+            dirt=0.4,
+            bump=0.45,
+            tiles=4.0,
+            uv_scale=2.0,
+            size=256,
+            samples=8,
+            stem="seamcheck",
+            _timeout=2400,
+        )
+        print(f"baked: {list(result['maps'])}")
+        if not result["gltf_safe"]:
+            failures.append("material is not glTF-safe after tiling")
+
+        for name, rel in result["maps"].items():
+            path = Path(rel)
+            if not path.is_file():
+                failures.append(f"{name}: missing at {rel}")
+                continue
+            seam, floor = check(path)
+            ratio = seam / max(floor, 0.01)
+            verdict = "ok  " if ratio <= 2.0 else "SEAM"
+            print(
+                f"{verdict} {name:11} wrap delta {seam:6.2f}   interior {floor:6.2f}   "
+                f"ratio {ratio:.2f}x"
+            )
+            if ratio > 2.0:
+                failures.append(
+                    f"{name}: wrap seam is {ratio:.1f}x the interior noise floor — "
+                    "the texture does not tile"
+                )
+
+    if failures:
+        print("\nFAILURES:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print("\ntileable bake: PASS (wrap edges indistinguishable from interior)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #23. Two gaps that only surfaced once assets actually carried
textures.

## `material.tileable` — texturing architecture

`material.bake_pbr` bakes a unique map per object. On a 725 m stadium that works
out to roughly **3 px/m** — no texture at all. Architecture needs *tiling* maps,
and a tiling map has to be seamless.

Noise is sampled through a **torus mapping** of the UVs, so the sample point
returns to itself at `u=1` and `v=1` and the bake tiles perfectly by
construction.

Verified rather than assumed — `tests/test_tileable.py` decodes the PNG and
compares the wrapped edges against the noise floor of ordinary interior columns:

| map | wrap delta | interior floor | ratio |
| --- | --- | --- | --- |
| base_color | 0.83 | 1.08 | **0.77x** |
| normal | 7.63 | 9.47 | **0.81x** |
| roughness | 1.96 | 2.78 | **0.70x** |

The seam is literally less visible than normal texture variation.

`reuse=true` bakes once and assigns the same material to every stone surface in
a building — one map set, one draw call, uniform texel density from a shared
metres-per-tile box projection.

### The lesson worth keeping

**Low-frequency content is what makes tiling visible.** The first textured pass
had an obvious repeat grid across the amphitheatre wall, because a big blotch is
what the eye anchors on and those blotches line up when the map repeats. A
tiling map must be dominated by high-frequency detail; large-scale variation
belongs per-object, not in the thing that repeats. Reducing the blotch removed
the grid and recovered luma 0.095 → 0.126.

## `gameready.texture_budget` — an honesty gap in our own output

Every sidecar this pipeline writes declares `texture_policy: compressed`. Until
the cook step runs KTX2/Basis that is a claim rather than a fact, and **nothing
measured it either way** — `gameready.budget` counted triangles and treated
`texture` as a resolution cap it never actually checked.

The new op measures real GPU cost (RGBA plus the mip chain), flags maps over the
platform cap, and carries per-platform VRAM budgets — browsers being the tight
case, since the WASM heap and the GPU budget share a device that is usually
running a dozen other tabs.

It reports **uncompressed by default and says so**, rather than quietly
crediting a compression step that has not run:

```
texmem : 16.0 MB / 192 MB (3 maps)  within=True
  ! Measured as UNCOMPRESSED RGBA (16.0 MB). Assets declaring
    texture_policy=compressed are not compressed until the cook step runs
    KTX2/Basis; with it this set would cost about 2.0 MB.
```

A scene can be trivially cheap to draw and still fail to load because its
textures do not fit.

## Testing

108 ops, 61 live Blender integration tests green, seam and schema/MCP suites
green, ruff clean.

## Known gap

`toktx`/`basisu` are not installed anywhere in the toolchain, so the KTX2 cook
step referenced in `pipeline.py` is still a TODO. This PR does not close it — it
makes the cost of *not* having closed it visible and measured, which is the
prerequisite for prioritising it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
