### PR TITLE
fix(engine): patch 0016 broke engine-fetch by modifying a file no patch creates

### DIFF
--- a/engine/engine-lock.toml
+++ b/engine/engine-lock.toml
@@ -73,7 +73,7 @@ series = [
   { file = "patches/0013-webgpu-sampler-texture-stage-visibility.patch", sha256 = "ce1a89673a1079cb6bc83e51b3090877ba26a3c6bf3cb684830b6895c6e66ffc" },
   { file = "patches/0014-webgpu-lit-shadow-sampler-types.patch", sha256 = "0cc3be74445b94b123eab68131cb37968b6448211fe3506b93a28e3321a6f811" },
   { file = "patches/0015-webgpu-cluster-builder-no-subgroups.patch", sha256 = "b2ed5031c57499485ffb2d2bab74f09c0d2a6414c5de1568abe370960997b274" },
-  { file = "patches/0016-webgpu-offline-harness-engine-parity.patch", sha256 = "51910e65431e731fadb700e994a5755a2ed247a85cbd7bc6cb9362ea7b457f4c" },
+  { file = "patches/0016-webgpu-offline-harness-engine-parity.patch", sha256 = "b374826c0ce2b5b2b4c1300c5bf36635a4eafddf22eae096c698849835272364" },
   { file = "patches/0017-webgpu-ssr-filter-storage-format.patch", sha256 = "3fc9535c727dc81ba27acf60961d652a78bd0350654ab479dab4a968e583bd64" },
 ]
 

--- a/engine/patches/0016-webgpu-offline-harness-engine-parity.patch
+++ b/engine/patches/0016-webgpu-offline-harness-engine-parity.patch
@@ -189,23 +189,82 @@ index 0000000..3ed80f8
 +echo ""
 +echo "Built: bin/glsl2spv ($(du -h bin/glsl2spv | cut -f1))"
 diff --git a/drivers/webgpu/tint_cli/glsl2spv.cpp b/drivers/webgpu/tint_cli/glsl2spv.cpp
-index 1e8ea45..ef5d77e 100644
---- a/drivers/webgpu/tint_cli/glsl2spv.cpp
+new file mode 100644
+--- /dev/null
 +++ b/drivers/webgpu/tint_cli/glsl2spv.cpp
-@@ -3,6 +3,7 @@
- //   glsl2spv <vert|frag|comp> <in.glsl> <out.spv>
- //   tint_convert_cli <out.spv>            # hang == the runtime bug, no GPU needed
- #include <cstdio>
+@@ -0,0 +1,110 @@
++// Minimal GLSL -> SPIR-V compiler using Godot's vendored glslang (CPU only, no
++// GPU). Companion to tint_convert_cli for the offline WebGPU-3D-hang repro:
++//   glsl2spv <vert|frag|comp> <in.glsl> <out.spv>
++//   tint_convert_cli <out.spv>            # hang == the runtime bug, no GPU needed
++#include <cstdio>
 +#include <cstdlib>
- #include <fstream>
- #include <sstream>
- #include <string>
-@@ -69,8 +70,24 @@ int main(int argc, char **argv) {
- 	glslang::TShader shader(stage);
- 	shader.setStrings(srcs, 1);
- 	shader.setEnvInput(glslang::EShSourceGlsl, stage, glslang::EShClientVulkan, 100);
--	shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_0);
--	shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetSpv_1_0);
++#include <fstream>
++#include <sstream>
++#include <string>
++#include <vector>
++
++#include <glslang/Public/ResourceLimits.h>
++#include <glslang/Public/ShaderLang.h>
++#include <SPIRV/GlslangToSpv.h>
++
++static std::string read_file(const char *path) {
++	std::ifstream f(path, std::ios::binary);
++	std::stringstream ss;
++	ss << f.rdbuf();
++	return ss.str();
++}
++
++int main(int argc, char **argv) {
++	// Accept two arg styles:
++	//   positional:            glsl2spv <vert|frag|comp> <in.glsl> <out.spv>
++	//   glslangValidator-like: glsl2spv -V -S <stage> -o <out.spv> <in.glsl>
++	// The latter lets it drop in as `glslangValidator` for wgsl_precompile.py.
++	std::string stage_s, in_path, out_path;
++	bool glslang_style = false;
++	for (int i = 1; i < argc; i++) {
++		if (std::string(argv[i]).rfind("-", 0) == 0) glslang_style = true;
++	}
++	if (glslang_style) {
++		for (int i = 1; i < argc; i++) {
++			std::string a = argv[i];
++			if (a == "-S" && i + 1 < argc) { stage_s = argv[++i]; }
++			else if (a == "-o" && i + 1 < argc) { out_path = argv[++i]; }
++			else if (a.rfind("-", 0) == 0) { /* ignore -V, --target-env, etc. */ }
++			else { in_path = a; }
++		}
++	} else if (argc >= 4) {
++		stage_s = argv[1]; in_path = argv[2]; out_path = argv[3];
++	}
++	if (stage_s.empty() || in_path.empty() || out_path.empty()) {
++		fprintf(stderr, "Usage: glsl2spv <vert|frag|comp> <in.glsl> <out.spv>\n"
++		                "   or: glsl2spv -V -S <stage> -o <out.spv> <in.glsl>\n");
++		return 2;
++	}
++	EShLanguage stage;
++	std::string s = stage_s;
++	if (s == "vert") {
++		stage = EShLangVertex;
++	} else if (s == "frag") {
++		stage = EShLangFragment;
++	} else if (s == "comp") {
++		stage = EShLangCompute;
++	} else {
++		fprintf(stderr, "bad stage '%s' (want vert|frag|comp)\n", argv[1]);
++		return 2;
++	}
++
++	std::string src = read_file(in_path.c_str());
++	if (src.empty()) {
++		fprintf(stderr, "empty/missing input: %s\n", in_path.c_str());
++		return 2;
++	}
++	const char *srcs[1] = { src.c_str() };
++
++	glslang::InitializeProcess();
++	glslang::TShader shader(stage);
++	shader.setStrings(srcs, 1);
++	shader.setEnvInput(glslang::EShSourceGlsl, stage, glslang::EShClientVulkan, 100);
 +
 +	// Match the engine, not an arbitrary default. RenderingShaderContainerWebGPU
 +	// reports SHADER_LANGUAGE_VULKAN_VERSION_1_1 + SHADER_SPIRV_VERSION_1_3, and
@@ -224,9 +283,26 @@ index 1e8ea45..ef5d77e 100644
 +	}
 +	shader.setEnvClient(glslang::EShClientVulkan, client_ver);
 +	shader.setEnvTarget(glslang::EShTargetSpv, spv_ver);
- 
- 	if (!shader.parse(GetDefaultResources(), 450, false, EShMsgDefault)) {
- 		fprintf(stderr, "GLSL parse error:\n%s\n%s\n", shader.getInfoLog(), shader.getInfoDebugLog());
++
++	if (!shader.parse(GetDefaultResources(), 450, false, EShMsgDefault)) {
++		fprintf(stderr, "GLSL parse error:\n%s\n%s\n", shader.getInfoLog(), shader.getInfoDebugLog());
++		return 3;
++	}
++	glslang::TProgram program;
++	program.addShader(&shader);
++	if (!program.link(EShMsgDefault)) {
++		fprintf(stderr, "link error:\n%s\n", program.getInfoLog());
++		return 4;
++	}
++	std::vector<unsigned int> spirv;
++	glslang::GlslangToSpv(*program.getIntermediate(stage), spirv);
++	glslang::FinalizeProcess();
++
++	std::ofstream out(out_path.c_str(), std::ios::binary);
++	out.write(reinterpret_cast<const char *>(spirv.data()), spirv.size() * sizeof(unsigned int));
++	fprintf(stderr, "OK: %zu SPIR-V words -> %s\n", spirv.size(), out_path.c_str());
++	return 0;
++}
 diff --git a/drivers/webgpu/tint_cli/probe_one.py b/drivers/webgpu/tint_cli/probe_one.py
 new file mode 100644
 index 0000000..b4379a3


### PR DESCRIPTION
## Regression

Patch `0016` (merged in #22) modifies `drivers/webgpu/tint_cli/glsl2spv.cpp` — but **no patch in the series ever creates that file.** On any clean tree the hunk resolves to:

```
error: drivers/webgpu/tint_cli/glsl2spv.cpp: No such file or directory
```

Because `engine.py` runs `git apply --check` across the whole series before applying, **`engine-fetch` aborts entirely.** This isn't a degraded harness — it's a hard stop on the front door. Nobody can prepare the patched source.

## Cause

I generated 0016 against my candidate tree, where `glsl2spv.cpp` already existed as an **untracked local file** left over from earlier work. I checked which patch introduced it with a grep whose alternation matched only the sibling path (`wgsl_precompile.py`) and concluded it came from 0001/0004. It doesn't.

## Fix

The hunk is now a file creation (`new file mode` / `--- /dev/null`) rather than a modification, which is what it should always have been for a file the series itself introduces. `engine-lock.toml` checksum updated; all 17 entries verify.

## Verification — on a machine that had never seen my working tree

Cloned official Godot `a13da4feb8` fresh on smeagol and applied the full series:

```
[fetch] checking patches/0015-webgpu-cluster-builder-no-subgroups.patch
[fetch] checking patches/0016-webgpu-offline-harness-engine-parity.patch
[fetch] checking patches/0017-webgpu-ssr-filter-storage-format.patch
[fetch] done — official source and Studio WebGPU patches are ready

  0015 USE_SUBGROUPS : 3 hits
  0016 glsl2spv.cpp  : present
  0017 SSR rgba16f   : 2 hits
```

## The lesson worth keeping

I validated the original patches by **reverse-applying them against the tree they were generated from**, and reported that as "round-trips clean". It does round-trip — but that only proves self-consistency. It structurally *cannot* detect a hunk whose target exists solely because of uncommitted local state.

Only a clean-tree apply catches this class of bug, and that's what the series check should be run against. Worth wiring into the staged patch-series CI workflow from #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
