### PR TITLE
ci(engine): verify the patch series actually applies to a clean tree

### DIFF
--- a/docs/ci/patch-series.yml
+++ b/docs/ci/patch-series.yml
@@ -30,3 +30,22 @@ jobs:
 
       - name: Verify the WebGPU patch series
         run: python engine/scripts/verify_patch_series.py
+
+  # Checksums cannot tell you a patch actually applies. Patch 0016 shipped a
+  # modification hunk for a file no patch creates -- it existed only as untracked
+  # local state in the tree it was generated from -- and the job above passed it
+  # while `git apply` failed on every clean checkout, taking engine-fetch with it.
+  # This job is slower because it needs the real base tree, which is precisely why
+  # it catches what the fast one structurally cannot.
+  apply:
+    name: applies to a clean tree
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Apply the series over pristine official Godot
+        run: python engine/scripts/verify_patch_apply.py

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -113,6 +113,13 @@ authorship and maintenance boundary.
 - Regenerate a patch from a reviewed candidate tree; do not silently hand-edit
   a locked patch.
 - Recalculate SHA-256 values and run release validation after regeneration.
+- **Verify a regenerated patch against a CLEAN tree**, not against the tree it
+  was generated from. `engine/scripts/verify_patch_apply.py` does this.
+  Reverse-applying a patch to its own source tree proves only self-consistency;
+  it cannot detect a hunk whose target exists solely because of uncommitted
+  local state. Patch 0016 shipped exactly that defect — checksums, ordering and
+  completeness all passed while `git apply` failed on every clean checkout and
+  `engine-fetch` stopped working entirely.
 - A checksum change requires review even when the filename is unchanged.
 
 `engine/.cache/studio-webgpu` is disposable output. This directory and

--- a/engine/scripts/verify_patch_apply.py
+++ b/engine/scripts/verify_patch_apply.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Apply the whole WebGPU patch series to a pristine official Godot tree.
+
+`verify_patch_series.py` checks that the patches are locked, complete, ordered and
+unmodified. It cannot check that they actually *apply*, and that gap has already
+cost us once: patch 0016 was generated against a working tree where
+`drivers/webgpu/tint_cli/glsl2spv.cpp` existed as an untracked local file, so it
+emitted a modification hunk for a path no patch creates. Checksums matched,
+ordering was contiguous, nothing was unlocked — and `git apply` failed on every
+clean tree, taking `engine-fetch` down with it entirely.
+
+Reverse-applying a patch against the tree it was generated from proves only
+self-consistency. It structurally cannot detect a hunk whose target exists solely
+because of uncommitted local state. Only a clean-tree apply can.
+
+Unlike its sibling this DOES need network and a git checkout, so it is a separate,
+slower job rather than something bolted onto the fast checksum gate.
+
+Usage:
+  python engine/scripts/verify_patch_apply.py                  # clone into a temp dir
+  python engine/scripts/verify_patch_apply.py --godot <path>   # reuse a local clone
+
+Exit status is 0 when the whole series applies, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from patch_series import PatchSeriesError, verified_patches  # noqa: E402
+
+ENGINE_DIR = Path(__file__).resolve().parents[1]
+LOCK_PATH = ENGINE_DIR / "engine-lock.toml"
+
+
+def run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True)
+
+
+def prepare_tree(base_commit: str, repo: str, godot: Path | None, workdir: Path) -> Path:
+    """Return a checkout of `base_commit`, cloning it if one was not supplied."""
+    if godot is not None:
+        tree = workdir / "tree"
+        print(f"[apply] using local clone {godot}")
+        res = run(["git", "worktree", "add", "--detach", str(tree), base_commit], godot)
+        if res.returncode != 0:
+            raise SystemExit(f"error: could not create worktree:\n{res.stderr}")
+        return tree
+
+    tree = workdir / "godot"
+    print(f"[apply] cloning {repo} @ {base_commit[:12]} (blobless, single commit)")
+    run(["git", "init", "-q", str(tree)], workdir)
+    run(["git", "remote", "add", "origin", repo], tree)
+    res = run(["git", "fetch", "-q", "--depth", "1", "--filter=blob:none",
+               "origin", base_commit], tree)
+    if res.returncode != 0:
+        raise SystemExit(f"error: fetch failed:\n{res.stderr}")
+    res = run(["git", "checkout", "-q", "FETCH_HEAD"], tree)
+    if res.returncode != 0:
+        raise SystemExit(f"error: checkout failed:\n{res.stderr}")
+    return tree
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--godot", type=Path, default=None,
+                        help="existing official-Godot clone to branch a worktree from")
+    parser.add_argument("--keep", action="store_true", help="leave the tree on disk")
+    args = parser.parse_args()
+
+    if not LOCK_PATH.is_file():
+        print(f"error: missing {LOCK_PATH}", file=sys.stderr)
+        return 1
+    with LOCK_PATH.open("rb") as handle:
+        lock = tomllib.load(handle)
+
+    try:
+        patches = verified_patches(lock, ENGINE_DIR)
+    except PatchSeriesError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    webgpu = lock["godot"]["webgpu"]
+    base_commit = str(webgpu["base_commit"])
+    repo = str(lock["godot"]["official"]["repo"])
+
+    workdir = Path(tempfile.mkdtemp(prefix="studio-patch-apply-"))
+    try:
+        tree = prepare_tree(base_commit, repo, args.godot, workdir)
+        for patch in patches:
+            check = run(["git", "apply", "--check", str(patch.path)], tree)
+            if check.returncode != 0:
+                print(f"\nerror: {patch.relative} does not apply to a clean "
+                      f"{base_commit[:12]} tree:", file=sys.stderr)
+                print(check.stderr.rstrip(), file=sys.stderr)
+                return 1
+            applied = run(["git", "apply", str(patch.path)], tree)
+            if applied.returncode != 0:
+                print(f"\nerror: {patch.relative} failed to apply:", file=sys.stderr)
+                print(applied.stderr.rstrip(), file=sys.stderr)
+                return 1
+            print(f"  applied {patch.relative}")
+        print(f"\npatch series applies cleanly — {len(patches)} patches over {base_commit[:12]}")
+        return 0
+    finally:
+        if args.godot is not None:
+            run(["git", "worktree", "prune"], args.godot)
+        if not args.keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

The checksum gate **passed** the 0016 regression fixed in #27. It had to — it verifies that patches are locked, complete, ordered and unmodified, and 0016 was all four. What it cannot verify is that they *apply*.

0016 modified `drivers/webgpu/tint_cli/glsl2spv.cpp`, a file no patch creates; it existed only as untracked local state in the tree the patch was generated from. `git apply` failed on every clean checkout and took `engine-fetch` down with it.

## What this adds

`verify_patch_apply.py` clones official Godot at the locked base commit (blobless, single commit) and applies the series over it — or reuses an existing clone via `--godot`. It is a **second CI job** rather than part of the first, because it needs network and a checkout, while the existing gate is deliberately toolchain-free and finishes in seconds.

## Demonstrated against the real regression

```
verify_patch_series  exit=0   <- does not catch it
verify_patch_apply   exit=1   <- catches it
  error: patches/0016-... does not apply to a clean a13da4feb8d8 tree:
  error: drivers/webgpu/tint_cli/glsl2spv.cpp: No such file or directory
```

On the fixed series: **17 patches apply cleanly over a13da4feb8d8**.

## A dead end worth recording

I first tried to catch this **offline**, by reasoning about which directories the series owns. That is unsound — the series adds files to directories that also contain upstream files, so it flagged legitimate patches like 0001's edit to `misc/dist/html/full-size.html`. You cannot determine offline whether a modified file exists upstream. Only the base tree knows, so the check uses it.

The rule is now written into `engine/patches/README.md`: verify a regenerated patch against a clean tree, never against the tree it came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)