### PR TITLE
webgpu: clamp negative LOD bounds and trust the shader on storage-to-sampled (patch 0020)

### DIFF
--- a/engine/engine-lock.toml
+++ b/engine/engine-lock.toml
@@ -77,6 +77,7 @@ series = [
   { file = "patches/0017-webgpu-ssr-filter-storage-format.patch", sha256 = "3fc9535c727dc81ba27acf60961d652a78bd0350654ab479dab4a968e583bd64" },
   { file = "patches/0018-webgpu-forward-plus-runtime.patch", sha256 = "e5321ec65b868de498796c368fa6dea319fa907c19952eb9d026b4cbb22597d1" },
   { file = "patches/0019-webgpu-integer-texture-sample-types.patch", sha256 = "2888377fe462ec8895f8f269e452b3c1296819f22e31d2be0cf5cc9d8fd3d75b" },
+  { file = "patches/0020-webgpu-lod-clamp-and-storage-sample-type.patch", sha256 = "627a913efc6ee78a5ca4fc9ac562f29d0b015e3f44f25bc6d040e8af885c9131" },
 ]
 
 [artifacts.export_templates]

--- a/engine/patches/0020-webgpu-lod-clamp-and-storage-sample-type.patch
+++ b/engine/patches/0020-webgpu-lod-clamp-and-storage-sample-type.patch
@@ -1,0 +1,53 @@
+Subject: [PATCH] webgpu: clamp negative LOD bounds and trust the shader on storage-to-sampled
+
+Two small conformance defects Forward+ exposes.
+
+1. Negative LOD clamp. Godot passes min_lod/max_lod through from sampler state,
+   and Forward+ creates samplers with a negative min_lod. Vulkan ignores it;
+   WebGPU rejects the sampler outright:
+
+     LOD clamp bounds [-N.N, N.N] contain a negative number.
+
+   A negative lower LOD bound has no meaning -- mip level 0 is the floor -- so
+   clamping to zero is exactly what the shader already assumes.
+
+2. Read-only-storage-to-sampled conversion picked its sampleType from the texture
+   FORMAT. Several formats map to UnfilterableFloat while the WGSL Tint emits is
+   texture_2d<i32>, and WebGPU validates the layout against the SHADER, not
+   against our idea of the format. The scanned WGSL component type now wins, with
+   the format-derived value kept only as a fallback for bindings the scan missed.
+
+Measured on a Tesla P40 through Chrome/WebGPU, Chariot on Forward+:
+GPUValidationError 42 -> 38, aborts and wasm traps still 0.
+
+diff --git a/drivers/webgpu/rendering_device_driver_webgpu.cpp b/drivers/webgpu/rendering_device_driver_webgpu.cpp
+--- a/drivers/webgpu/rendering_device_driver_webgpu.cpp
++++ b/drivers/webgpu/rendering_device_driver_webgpu.cpp
+@@ -2548,8 +2548,11 @@
+ 	desc.addressModeU = map_address(p_state.repeat_u);
+ 	desc.addressModeV = map_address(p_state.repeat_v);
+ 	desc.addressModeW = map_address(p_state.repeat_w);
+-	desc.lodMinClamp = p_state.min_lod;
+-	desc.lodMaxClamp = p_state.max_lod;
++	// WebGPU rejects a sampler whose LOD bounds go negative, where Vulkan simply
++	// ignores it. Mip level 0 is the floor, so a negative lower bound is
++	// meaningless and clamping preserves the intended behaviour.
++	desc.lodMinClamp = MAX(0.0f, p_state.min_lod);
++	desc.lodMaxClamp = MAX(0.0f, p_state.max_lod);
+ 
+ 	if (p_state.enable_compare) {
+ 		desc.compare = map_compare(p_state.compare_op);
+@@ -4529,7 +4532,12 @@
+ 						// Read-only storage texture was converted to sampled texture_2d.
+ 						// Create a sampled texture BGL entry instead of storage.
+ 						WGPUTextureFormat fmt = wgsl_storage_tex_format.has(k) ? wgsl_storage_tex_format[k] : WGPUTextureFormat_RGBA8Unorm;
+-						entry.texture.sampleType = _texture_sample_type_for_format(fmt);
++						// What the shader DECLARES is what WebGPU validates against, so it
++						// wins over the format-derived guess: several formats map to
++						// UnfilterableFloat while the WGSL is texture_2d<i32>.
++						entry.texture.sampleType = wgsl_tex_sample_type.has(k)
++								? wgsl_tex_sample_type[k]
++								: _texture_sample_type_for_format(fmt);
+ 						entry.texture.viewDimension = wgsl_tex_dims.has(k) ? wgsl_tex_dims[k] : WGPUTextureViewDimension_2D;
+ 						entry.texture.multisampled = false;
+ 					} else {

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -130,6 +130,17 @@ browser WebGPU template build. They apply to the official Godot commit in
     MSAA-float precedence preserved, and samplers paired with integer textures
     forced to NonFiltering. Measured on a Tesla P40: `GPUValidationError` 106 -> 42.
 
+20. `0020-webgpu-lod-clamp-and-storage-sample-type.patch` - two conformance
+    defects Forward+ exposes. Godot passes sampler `min_lod`/`max_lod` straight
+    through and Forward+ produces a negative one; Vulkan ignores that, WebGPU
+    rejects the sampler ("LOD clamp bounds contain a negative number"). Mip 0 is
+    the floor, so clamping to zero is what the shader already assumes. And the
+    read-only-storage-to-sampled conversion chose its `sampleType` from the
+    texture FORMAT, which yields `UnfilterableFloat` for formats whose WGSL is
+    `texture_2d<i32>` - WebGPU validates the layout against the SHADER, so the
+    scanned component type now wins. Measured on a Tesla P40:
+    `GPUValidationError` 42 -> 38.
+
 The WebGPU implementation originated in `dwalter/godotwebgpu`. Studio
 Foundation owns the 4.7.1 port, scoped patch curation, preparation/build tooling,
 and validation. See `../../docs/architecture/webgpu-integration.md` for the


### PR DESCRIPTION
Two small conformance defects Forward+ exposes.

**Negative LOD clamp.** Godot passes sampler `min_lod`/`max_lod` straight through, and Forward+ creates samplers with a negative `min_lod`. Vulkan ignores it; WebGPU rejects the sampler outright:

```
LOD clamp bounds [-N.N, N.N] contain a negative number.
```

Mip level 0 is the floor, so a negative lower bound is meaningless and clamping to zero is exactly what the shader already assumes.

**Storage-to-sampled sample type.** The read-only-storage-to-sampled conversion picked its `sampleType` from the texture *format*. Several formats map to `UnfilterableFloat` while the WGSL Tint emits is `texture_2d<i32>`, and **WebGPU validates the layout against the shader**, not against our idea of the format. The scanned WGSL component type now wins, with the format-derived value kept as a fallback for bindings the scan missed.

## Measured on a Tesla P40 (Chrome/WebGPU, Chariot on Forward+)

| | before | after |
|---|---|---|
| `GPUValidationError` | 42 | **38** |
| aborts / wasm traps | 0 | 0 |

Cumulative across #29, #30 and this: **168 to 38**.

All 20 patches verified against a pristine `a13da4feb8d8` checkout with `verify_patch_apply.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)