### PR TITLE
webgpu: trust the shader's component type at the shadow-entry sites (patch 0022)

### DIFF
--- a/engine/engine-lock.toml
+++ b/engine/engine-lock.toml
@@ -79,6 +79,7 @@ series = [
   { file = "patches/0019-webgpu-integer-texture-sample-types.patch", sha256 = "2888377fe462ec8895f8f269e452b3c1296819f22e31d2be0cf5cc9d8fd3d75b" },
   { file = "patches/0020-webgpu-lod-clamp-and-storage-sample-type.patch", sha256 = "627a913efc6ee78a5ca4fc9ac562f29d0b015e3f44f25bc6d040e8af885c9131" },
   { file = "patches/0021-webgpu-storage-texture-formats.patch", sha256 = "3e1e4a1ce9283988c735846c0059293fb4820cdb522c7a0f8e0bc803a3a36ca8" },
+  { file = "patches/0022-webgpu-shadow-entry-sample-type.patch", sha256 = "74040ab292528f380aee705a41033322322e4a831f481b778c052f1fab00fa52" },
 ]
 
 [artifacts.export_templates]

--- a/engine/patches/0022-webgpu-shadow-entry-sample-type.patch
+++ b/engine/patches/0022-webgpu-shadow-entry-sample-type.patch
@@ -1,0 +1,50 @@
+Subject: [PATCH] webgpu: trust the shader's component type at the shadow-entry sites
+
+0019 and 0020 made the main bind-group-layout sites derive sampleType from the WGSL
+component type, but the two "shadow entry" sites still derived it from the texture
+FORMAT alone. _texture_sample_type_for_format() answers UnfilterableFloat wherever it
+has no better answer, while the shader declares texture_2d<i32>:
+
+  The shader's texture sample type (TextureSampleType::Sint) isn't compatible with
+  the layout's texture sample type (TextureSampleType::UnfilterableFloat)
+
+WebGPU validates a layout against the SHADER, so the scanned declaration wins and the
+format-derived value remains only as a fallback for bindings the scan missed. This is
+the same correction 0020 applied to the read-only-storage-to-sampled path; these two
+sites were simply missed.
+
+Measured on a Tesla P40 through Chrome/WebGPU, Chariot on Forward+:
+
+  Sint sample-type mismatches   4 -> 0
+  GPUValidationError           26 -> 18   (the extra 4 are cascading invalid-layout
+                                           errors that disappear with their cause)
+  aborts / wasm traps          still 0
+
+diff --git a/drivers/webgpu/rendering_device_driver_webgpu.cpp b/drivers/webgpu/rendering_device_driver_webgpu.cpp
+--- a/drivers/webgpu/rendering_device_driver_webgpu.cpp
++++ b/drivers/webgpu/rendering_device_driver_webgpu.cpp
+@@ -4752,7 +4752,12 @@
+ 			WGPUBindGroupLayoutEntry shadow_entry = {};
+ 			shadow_entry.binding = shadow_bnd;
+ 			shadow_entry.visibility = WGPUShaderStage_Compute;
+-			shadow_entry.texture.sampleType = _texture_sample_type_for_format(shadow_fmt);
++			// The shader's own declaration wins: WebGPU validates the layout against it,
++			// and the format-derived guess answers UnfilterableFloat where the WGSL says
++			// texture_2d<i32>.
++			shadow_entry.texture.sampleType = wgsl_tex_sample_type.has(shadow_key)
++					? wgsl_tex_sample_type[shadow_key]
++					: _texture_sample_type_for_format(shadow_fmt);
+ 			shadow_entry.texture.viewDimension = wgsl_tex_dims.has(shadow_key) ? wgsl_tex_dims[shadow_key] : WGPUTextureViewDimension_2D;
+ 			shadow_entry.texture.multisampled = false;
+ 			entries.push_back(shadow_entry);
+@@ -4885,7 +4890,9 @@
+ 					WGPUBindGroupLayoutEntry se = {};
+ 					se.binding = shadow_bnd;
+ 					se.visibility = WGPUShaderStage_Compute;
+-					se.texture.sampleType = _texture_sample_type_for_format(shadow_fmt);
++					se.texture.sampleType = wgsl_tex_sample_type.has(shadow_key)
++							? wgsl_tex_sample_type[shadow_key]
++							: _texture_sample_type_for_format(shadow_fmt);
+ 					se.texture.viewDimension = wgsl_tex_dims.has(shadow_key) ? wgsl_tex_dims[shadow_key] : WGPUTextureViewDimension_2D;
+ 					se.texture.multisampled = false;
+ 					merged_entries.push_back(se);

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -151,6 +151,14 @@ browser WebGPU template build. They apply to the official Godot commit in
     added (the 16-bit *norm* variants are not core WebGPU and do not compile).
     Measured on a Tesla P40: format mismatches 6 -> 0, `GPUValidationError` 38 -> 26.
 
+22. `0022-webgpu-shadow-entry-sample-type.patch` - the same correction `0020` made
+    to the read-only-storage path, applied to the two "shadow entry" sites that were
+    missed. They derived `sampleType` from the texture FORMAT, and
+    `_texture_sample_type_for_format()` answers `UnfilterableFloat` wherever it has
+    no better answer, while the shader declares `texture_2d<i32>`. WebGPU validates
+    a layout against the SHADER, so the scanned declaration wins. Measured on a
+    Tesla P40: Sint mismatches 4 -> 0, `GPUValidationError` 26 -> 18.
+
 The WebGPU implementation originated in `dwalter/godotwebgpu`. Studio
 Foundation owns the 4.7.1 port, scoped patch curation, preparation/build tooling,
 and validation. See `../../docs/architecture/webgpu-integration.md` for the


### PR DESCRIPTION
The same correction #31 made to the read-only-storage path, applied to the two shadow-entry sites that were missed.

They derived `sampleType` from the texture **format**, and `_texture_sample_type_for_format()` answers `UnfilterableFloat` wherever it has no better answer — while the shader declares `texture_2d<i32>`:

```
The shader's texture sample type (TextureSampleType::Sint) isn't compatible with
the layout's texture sample type (TextureSampleType::UnfilterableFloat)
```

WebGPU validates a layout against the **shader**, so the scanned declaration wins and the format-derived value stays as a fallback for bindings the scan missed.

## Measured on a Tesla P40

| | before | after |
|---|---|---|
| Sint sample-type mismatches | 4 | **0** |
| `GPUValidationError` | 26 | **18** |
| aborts / wasm traps | 0 | 0 |

The extra 4 are cascading invalid-layout errors that disappear along with their cause.

Cumulative across #29, #30, #31, #32 and this: **168 to 18**.

All 22 patches verified against a pristine `a13da4feb8d8` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)