### PR TITLE
asset-pipeline: cook straight into a consuming repo with --dest

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,6 +16,7 @@ NAME := ""
 DISPLAY_NAME := ""
 GAME := "templates/godot-game"
 PROFILE := "desktop_high"
+DEST := ""
 # bforge (ADR 0014): `just NAME=crate_a RECIPE=prop.crate bforge-make`
 RECIPE := "prop.crate"
 TAG := ""
@@ -108,6 +109,7 @@ test-python:
     {{PY}} -m unittest discover -s engine/scripts/tests -p "test_*.py" -v
     uv run --project tools python -m unittest discover -s tools/bforge/tests -p "test_schema.py" -v
     uv run --project tools python -m unittest discover -s tools/bforge/tests -p "test_mcp.py" -v
+    uv run --project tools python -m unittest discover -s tools/asset-pipeline/tests -p "test_*.py" -v
 
 # Cross-language protocol golden-fixture checks (Rust side runs in test-rust too)
 test-protocol:
@@ -177,6 +179,12 @@ asset-export:
 # Cook all assets of GAME for PROFILE (desktop_high|browser_webgpu|browser_webgl|mobile_high|mobile_low)
 asset-cook:
     uv run --project tools python tools/asset-pipeline/pipeline.py cook --profile "{{PROFILE}}" --game "{{GAME}}"
+
+# Cook GAME's assets and sync the pack + manifest into DEST (a consuming repo's
+# asset dir, ADR 0015) instead of the game's own project tree. Example:
+#   just PROFILE=browser_webgl GAME=games/asha_world DEST=../platosplaza/games/the-deep/assets asset-cook-to
+asset-cook-to:
+    uv run --project tools python tools/asset-pipeline/pipeline.py cook --profile "{{PROFILE}}" --game "{{GAME}}" --dest "{{DEST}}"
 
 asset-preview:
     uv run --project tools python tools/asset-pipeline/pipeline.py preview "{{FILE}}"

--- a/tools/asset-pipeline/pipeline.py
+++ b/tools/asset-pipeline/pipeline.py
@@ -3,13 +3,18 @@
 
   pipeline.py validate <file.blend>
   pipeline.py export   <file.blend>            # validate first, then GLB
-  pipeline.py cook     --profile P [--game G]  # export all + sync into project + manifests
+  pipeline.py cook     --profile P [--game G] [--dest DIR]
   pipeline.py preview  <file.blend> [--frames N]
   pipeline.py report
 
 Sources live in assets-source/; ALL outputs land in assets-generated/ (repo
-level, hash-cached) and are synced into <game>/project/assets/generated/ by
-cook. Nothing here ever writes into assets-source/.
+level, hash-cached) and are synced by cook into <game>/project/assets/generated/,
+or into --dest when a consuming repo outside this one wants the cooked pack
+(ADR 0015: games consume the foundation, so cooked output must be able to land
+in THEIR tree; without --dest the sync would also resurrect a project/ dir for
+asset-only games that deliberately have none). --dest gets the runtime files
+plus asset_manifest.json and skips the project-only content_manifest.json.
+Nothing here ever writes into assets-source/.
 """
 
 from __future__ import annotations
@@ -176,10 +181,36 @@ def game_root(game: str) -> Path:
     return path
 
 
-def cmd_cook(profile: str, game: str) -> int:
+def cooked_relative(out_path: Path, game: str) -> Path:
+    """Where a cooked file sits relative to the sync root.
+
+    Exports land under assets-generated/<game>/<category>/<file>; the game's
+    own path segments are stripped so the synced tree starts at the category
+    (deep/deep_ore_vein.glb), whichever root it is synced into.
+    """
+    relative = out_path.relative_to(GENERATED)
+    parts = [p for p in relative.parts if p not in Path(game).parts]
+    return Path(*parts)
+
+
+def cook_sync_root(root: Path, dest: str | None) -> Path:
+    """The directory cooked files and the manifest sync into.
+
+    Default is the game's own gitignored project dir. --dest points anywhere,
+    typically a consuming repo's asset directory (ADR 0015) -- also the only
+    way to cook an asset-only game without conjuring a project/ dir it does
+    not have.
+    """
+    if dest:
+        return Path(dest).expanduser().resolve()
+    return root / "project" / "assets" / "generated"
+
+
+def cmd_cook(profile: str, game: str, dest: str | None = None) -> int:
     if profile not in PROFILES:
         raise SystemExit(f"unknown profile '{profile}' (choose from {', '.join(PROFILES)})")
     root = game_root(game)
+    sync_root = cook_sync_root(root, dest)
     sources = sorted((root / "assets-source").rglob("*.blend"))
     if not sources:
         print(f"cook: no source assets under {game}/assets-source")
@@ -191,32 +222,36 @@ def cmd_cook(profile: str, game: str) -> int:
             failures += 1
             continue
         meta = load_meta(blend)
-        # Sync runtime file into the game project (generated dir, gitignored).
-        relative = out_path.relative_to(GENERATED)
-        parts = [p for p in relative.parts if p not in Path(game).parts]
-        dest = root / "project" / "assets" / "generated" / Path(*parts)
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_bytes(out_path.read_bytes())
+        # Sync runtime file into the chosen root (gitignored project dir, or
+        # a consuming repo's tree via --dest).
+        relative = cooked_relative(out_path, game)
+        target = sync_root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(out_path.read_bytes())
         manifest["assets"][meta["asset_id"]] = {
-            "file": str(Path(*parts)).replace("\\", "/"),
+            "file": str(relative).replace("\\", "/"),
             "category": meta.get("category", "prop"),
             "source_hash": source_hash(blend),
             "texture_policy": meta.get("texture_policy", "compressed"),
             # Texture conversion hook: per-profile KTX2/Basis + platform compression
             # lands here when texture-bearing assets arrive (tracked in docs/asset-pipeline).
         }
-    manifest_path = root / "project" / "assets" / "generated" / "asset_manifest.json"
+    manifest_path = sync_root / "asset_manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
-    content_path = root / "project" / "content_manifest.json"
-    content_path.write_text(
-        json.dumps(
-            {"schema": 1, "packs": {"base": {"version": "0.1.0", "profile": profile}}},
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    print(f"cook: {len(sources) - failures}/{len(sources)} assets for profile {profile} -> {game}")
+    if dest is None:
+        # The content manifest describes a Godot project's packs; an external
+        # destination is not a project, so it only gets the asset manifest.
+        content_path = root / "project" / "content_manifest.json"
+        content_path.write_text(
+            json.dumps(
+                {"schema": 1, "packs": {"base": {"version": "0.1.0", "profile": profile}}},
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    where = str(sync_root) if dest else game
+    print(f"cook: {len(sources) - failures}/{len(sources)} assets for profile {profile} -> {where}")
     return 1 if failures else 0
 
 
@@ -274,13 +309,21 @@ def main() -> int:
     cook = sub.add_parser("cook")
     cook.add_argument("--profile", required=True)
     cook.add_argument("--game", default="templates/godot-game")
+    cook.add_argument(
+        "--dest",
+        default=None,
+        help=(
+            "sync cooked files + asset_manifest.json into this directory instead of "
+            "<game>/project/assets/generated (for consuming repos, ADR 0015)"
+        ),
+    )
     sub.add_parser("report")
     args = parser.parse_args()
 
     if args.command == "report":
         return cmd_report()
     if args.command == "cook":
-        return cmd_cook(args.profile, args.game)
+        return cmd_cook(args.profile, args.game, args.dest)
     blend = Path(args.file).resolve()
     if not blend.is_file():
         raise SystemExit(f"not found: {blend}")

--- a/tools/asset-pipeline/tests/test_cook_sync.py
+++ b/tools/asset-pipeline/tests/test_cook_sync.py
@@ -1,0 +1,55 @@
+"""Sync-path rules for `pipeline.py cook` — pure, no Blender required.
+
+The cook's export step needs Blender; where its outputs land does not. These
+tests pin the path math that decides the synced tree's shape and the --dest
+routing that lets a consuming repo (ADR 0015) receive a cooked pack without
+the foundation conjuring a project/ directory inside an asset-only game.
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+PIPELINE_PATH = Path(__file__).resolve().parents[1] / "pipeline.py"
+spec = importlib.util.spec_from_file_location("asset_pipeline", PIPELINE_PATH)
+pipeline = importlib.util.module_from_spec(spec)
+sys.modules.setdefault("asset_pipeline", pipeline)
+spec.loader.exec_module(pipeline)
+
+
+class CookedRelativeTests(unittest.TestCase):
+    def test_strips_game_segments_and_keeps_category_tree(self) -> None:
+        out = pipeline.GENERATED / "games" / "asha_world" / "deep" / "deep_ore_vein.glb"
+        relative = pipeline.cooked_relative(out, "games/asha_world")
+        self.assertEqual(relative, Path("deep") / "deep_ore_vein.glb")
+
+    def test_nested_categories_survive(self) -> None:
+        out = pipeline.GENERATED / "games" / "asha_world" / "props" / "crate_a" / "crate_a.glb"
+        relative = pipeline.cooked_relative(out, "games/asha_world")
+        self.assertEqual(relative, Path("props") / "crate_a" / "crate_a.glb")
+
+    def test_template_game_path(self) -> None:
+        out = pipeline.GENERATED / "templates" / "godot-game" / "props" / "box.glb"
+        relative = pipeline.cooked_relative(out, "templates/godot-game")
+        self.assertEqual(relative, Path("props") / "box.glb")
+
+
+class CookSyncRootTests(unittest.TestCase):
+    def test_default_is_the_game_project_generated_dir(self) -> None:
+        root = Path("/repo/games/asha_world")
+        self.assertEqual(
+            pipeline.cook_sync_root(root, None),
+            root / "project" / "assets" / "generated",
+        )
+
+    def test_dest_overrides_and_resolves(self) -> None:
+        root = Path("/repo/games/asha_world")
+        dest = pipeline.cook_sync_root(root, "external/pack")
+        self.assertTrue(dest.is_absolute())
+        self.assertEqual(dest.name, "pack")
+        self.assertNotIn("project", dest.parts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Consuming the Deep asset pack from platosplaza (PR lxsolutions/platosplaza#571) meant cooking here and copying GLBs by hand -- and the cook's sync also resurrects a `project/` directory for asset-only games that deliberately have none (asha_world after the product-neutral split).

`cook --dest DIR` syncs the cooked files plus `asset_manifest.json` into any directory -- typically a consuming repo's asset tree per ADR 0015 -- and skips the project-only `content_manifest.json`. The default path is unchanged.

The sync path math moves into pure functions (`cooked_relative`, `cook_sync_root`) with the pipeline's first unit tests (5, wired into `test-python`), and `just asset-cook-to` wraps it:

    just PROFILE=browser_webgl GAME=games/asha_world DEST=../platosplaza/games/the-deep/assets asset-cook-to

Proven end to end: 8/8 deep assets plus manifest landed in an external directory from the hash cache, no `project/` dir conjured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)