### PR TITLE
bforge: what Riftline's hellenic pack paid to learn

### DIFF
--- a/tools/bforge/runtime/lib/scene.py
+++ b/tools/bforge/runtime/lib/scene.py
@@ -60,6 +60,12 @@ def unique_name(name: str) -> str:
 
 
 def get_object(name: str):
+    # Guard before touching bpy: bpy_prop_collection.get(None) raises a raw
+    # SystemError from C, which surfaces as an inscrutable daemon error
+    # instead of the helpful message below (found via Riftline's asset pack,
+    # where an op reached here with a missing name argument).
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"object name must be a non-empty string, got {name!r}")
     obj = bpy.data.objects.get(name)
     if obj is None:
         available = sorted(o.name for o in bpy.context.scene.objects)[:25]

--- a/tools/bforge/runtime/ops/gameready.py
+++ b/tools/bforge/runtime/ops/gameready.py
@@ -90,7 +90,7 @@ def gameready_lod(ctx, name, levels, ratios, keep_uvs, layout):
 
 @op(
     "gameready.collision",
-    summary="Generate a physics collision proxy. Convex hulls are what you want for anything a character walks into; box is cheapest; simplified trimesh is for concave shapes like arenas and rooms. Named <object>-convcol / <object>-col per the studio import convention.",
+    summary="Generate a physics collision proxy. Convex hulls are what you want for anything a character walks into; box is cheapest; simplified trimesh is for concave shapes like arenas and rooms. Named <object>-convcol / <object>-col per the studio import convention. SKIP for hulls that ride inside a moving body: Godot imports the proxy as a StaticBody3D child, and a static collider inside a CharacterBody3D blocks its own vehicle.",
     params={
         "name": ("str", None, "Source object"),
         "mode": ("enum:box|convex|simplified|cylinder|sphere|capsule", "convex", "Proxy shape"),

--- a/tools/bforge/runtime/ops/material.py
+++ b/tools/bforge/runtime/ops/material.py
@@ -530,7 +530,7 @@ def material_list(ctx):
         "object": ("str", None, "Object name"),
         "preset": ("str", "gold", "Material preset for the selected faces"),
         "select": ("enum:up|down|sides|top_band|bottom_band", "up", "Face selection rule"),
-        "band_min": ("num", 0.0, "top_band/bottom_band: lower bound as a fraction of height"),
+        "band_min": ("num", 0.0, "top_band/bottom_band: lower bound as a fraction of height. Bands select by face CENTER, so a thin band needs real face rows at that height - one tall quad (e.g. a column shaft) has its centre near the middle and a thin band elsewhere matches nothing"),
         "band_max": ("num", 1.0, "top_band/bottom_band: upper bound as a fraction of height"),
         "color": ("str", "", "Override colour"),
     },

--- a/tools/bforge/runtime/ops/material.py
+++ b/tools/bforge/runtime/ops/material.py
@@ -533,10 +533,13 @@ def material_list(ctx):
         "band_min": ("num", 0.0, "top_band/bottom_band: lower bound as a fraction of height. Bands select by face CENTER, so a thin band needs real face rows at that height - one tall quad (e.g. a column shaft) has its centre near the middle and a thin band elsewhere matches nothing"),
         "band_max": ("num", 1.0, "top_band/bottom_band: upper bound as a fraction of height"),
         "color": ("str", "", "Override colour"),
+        "roughness": ("num", -1.0, "Override roughness 0..1; -1 keeps the preset value"),
+        "metallic": ("num", -1.0, "Override metallic 0..1; -1 keeps the preset value. Metals read black without something bright to reflect - painted trim (metallic ~0.15) survives dark environments"),
     },
     tags=["material"],
 )
-def material_face_assign(ctx, object, preset, select, band_min, band_max, color):
+def material_face_assign(ctx, object, preset, select, band_min, band_max, color, roughness,
+                         metallic):
     obj = _get(object)
     mesh = obj.data
     zs = [v.co.z for v in mesh.vertices] or [0.0]
@@ -560,7 +563,12 @@ def material_face_assign(ctx, object, preset, select, band_min, band_max, color)
     if not picked:
         raise OpError(f"no faces on '{object}' matched selection '{select}'")
     try:
-        material = mat_lib.from_preset(preset, color=color or None)
+        material = mat_lib.from_preset(
+            preset,
+            color=color or None,
+            roughness=None if roughness < 0 else roughness,
+            metallic=None if metallic < 0 else metallic,
+        )
     except ValueError as exc:
         raise OpError(str(exc)) from exc
     slot = mat_lib.assign_to_faces(obj, material, picked)

--- a/tools/bforge/tests/test_forge.py
+++ b/tools/bforge/tests/test_forge.py
@@ -92,6 +92,15 @@ class Daemon(ForgeCase):
             self.forge.call("object.inspect", name="does_not_exist")
         self.assertEqual(self.forge.call("build.box", name="after")["name"], "after")
 
+    def test_missing_object_name_is_a_clean_error_not_a_systemerror(self):
+        # bpy_prop_collection.get(None) raises a raw SystemError from C; the
+        # object lookup must guard before bpy so the caller gets the normal
+        # helpful message (found by Riftline's hellenic pack build).
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("object.inspect", name=None)
+        self.assertIn("name", str(ctx.exception).lower())
+        self.assertNotIn("SystemError", str(ctx.exception))
+
 
 class Geometry(ForgeCase):
     def test_box_dimensions_are_exact(self):


### PR DESCRIPTION
## What this is

Riftline: Warshards became the third real game authored with bforge (platosplaza #573: an 11-master Futuristic-Greek pack, both vehicle hulls and the chrono-anchor rosettes wired). Three things surfaced; this PR pays them back:

- **`get_object(None)` reached `bpy_prop_collection.get`, which raises a raw `SystemError` from C** instead of the helpful lookup error (ops that declare `name: ("str", None, ...)` pass `None` straight through — the registry's REQUIRED machinery only fires when the spec says REQUIRED). Guarded before bpy; regression test beside the other daemon error-shape tests.
- **`gameready.collision`'s `-convcol` proxy imports into Godot as a StaticBody3D child.** Perfect for static props; inside a moving CharacterBody3D it blocks its own vehicle — Riftline's Aether Dart could no longer descend to its dismount altitude (caught by the game's smoke suite, not the contact sheet). The summary now says when to skip it.
- **`material.face_assign` bands select by face CENTER**, so a thin band on one tall quad (a doric column shaft) matches nothing. The band_min doc now warns.

## Verification

`python tests/test_forge.py Daemon`: **7/7 pass** including the new regression test, on this branch (origin/main + this commit), against live Blender 5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)