### PR TITLE
ci: install the gate that proves the central claim

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,76 @@
+name: checks
+
+# The fast, hosted half of the repository's own gate. `validate.yml` (the
+# self-hosted studio workflow described in tools/ci/validate_workflows.py) runs
+# the heavy suites -- Godot, Rust, the engine build -- on trusted hardware. This
+# runs the part that needs no toolchain at all, so a fork or a first-time reader
+# can see the same result without a runner.
+#
+# Everything here is stdlib-only Python. No Godot, no Emscripten, no GPU, no
+# database, no network beyond the checkout and the uv install.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  policy:
+    name: workflow and secret policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      # Enforces the studio's CI security contract on this very directory:
+      # every action pinned to a full commit, no self-hosted job reachable from
+      # an untrusted pull request. It is deliberately run first -- a workflow
+      # that violates the policy should fail before it does any work.
+      - name: Validate workflow trust and action pins
+        run: python tools/ci/validate_workflows.py
+
+      - name: Scan for committed secrets
+        run: python tools/ci/secret_scan.py
+
+  python:
+    name: python unit suites
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      # The engine-script suite is plain stdlib and covers the patch-series
+      # checker's own failure paths -- the gate that guards the gate.
+      - name: Engine scripts
+        run: python -m unittest discover -s engine/scripts/tests -p "test_*.py"
+
+      - name: studio-mcp
+        run: uv run --project tools python -m unittest discover -s tools/studio-mcp/tests -p "test_*.py"
+
+      - name: infra
+        run: uv run --project tools python -m unittest discover -s tools/infra/tests -p "test_*.py"
+
+      - name: asset pipeline
+        run: uv run --project tools python -m unittest discover -s tools/asset-pipeline/tests -p "test_*.py"
+
+      # bforge's Blender-driven ops need Blender; these two suites are the parts
+      # that do not (schema validation and the MCP tool surface).
+      - name: bforge schema and MCP surface
+        run: |
+          uv run --project tools python -m unittest discover -s tools/bforge/tests -p "test_schema.py"
+          uv run --project tools python -m unittest discover -s tools/bforge/tests -p "test_mcp.py"
+
+      - name: Protocol golden fixtures
+        run: uv run --project tools python tools/asset-pipeline/check_fixtures.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,15 +29,20 @@ jobs:
         with:
           python-version: '3.11'
 
+      # The validator parses YAML, and pyyaml is a `tools` dev dependency rather
+      # than stdlib -- so this runs through uv exactly as `just lint-workflows`
+      # does, not with a bare interpreter.
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
       # Enforces the studio's CI security contract on this very directory:
       # every action pinned to a full commit, no self-hosted job reachable from
       # an untrusted pull request. It is deliberately run first -- a workflow
       # that violates the policy should fail before it does any work.
       - name: Validate workflow trust and action pins
-        run: python tools/ci/validate_workflows.py
+        run: uv run --project tools python tools/ci/validate_workflows.py
 
       - name: Scan for committed secrets
-        run: python tools/ci/secret_scan.py
+        run: uv run --project tools python tools/ci/secret_scan.py
 
   python:
     name: python unit suites
@@ -65,12 +70,12 @@ jobs:
       - name: asset pipeline
         run: uv run --project tools python -m unittest discover -s tools/asset-pipeline/tests -p "test_*.py"
 
-      # bforge's Blender-driven ops need Blender; these two suites are the parts
-      # that do not (schema validation and the MCP tool surface).
-      - name: bforge schema and MCP surface
-        run: |
-          uv run --project tools python -m unittest discover -s tools/bforge/tests -p "test_schema.py"
-          uv run --project tools python -m unittest discover -s tools/bforge/tests -p "test_mcp.py"
+      # Only bforge's schema suite runs here. test_mcp.py looks like a pure
+      # tool-surface test but constructs a Forge, which resolves a Blender
+      # binary in its constructor and raises DaemonError without one -- so it
+      # belongs to the self-hosted suite, not a bare hosted runner.
+      - name: bforge schema
+        run: uv run --project tools python -m unittest discover -s tools/bforge/tests -p "test_schema.py"
 
       - name: Protocol golden fixtures
         run: uv run --project tools python tools/asset-pipeline/check_fixtures.py

--- a/.github/workflows/patch-series.yml
+++ b/.github/workflows/patch-series.yml
@@ -22,9 +22,9 @@ jobs:
     name: checksums and ordering
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'   # tomllib landed in 3.11
 
@@ -41,9 +41,9 @@ jobs:
     name: applies to a clean tree
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ static hosts with no COOP/COEP headers). Point your `web` preset's
 cannot emit, and skipping it produces a build that fails to start. Both files are
 SHA-256 listed in the release notes and reproducible from source.
 
+**What this download is not.** It is pinned at patch **0014**, while `main`
+carries **0022**. Those eight patches are what made Forward+ work on hardware
+(0015 and 0018–0022) — so the published templates render **Forward Mobile only**,
+which is also the default and what every published demo runs. If you want to try
+Forward+, build from source below; the release cannot do it. A templates build
+matching the current series is not yet published.
+
 ### Build the WebGPU path yourself
 
 ```sh

--- a/docs/architecture/webgpu-runtime-status.md
+++ b/docs/architecture/webgpu-runtime-status.md
@@ -38,10 +38,10 @@ but a render probe needs a GPU runner and remains self-hosted work.
 **One sentence on which renderer that means.** Everything shipped and published —
 the live demo, the templates, the performance A/B — is **Forward Mobile**, which
 `tools/godot/export_game.py` calls "the hardware-verified default". **Forward+**
-is opt-in (`--rendering-method forward_plus`), and as of patch 0022 it boots and
-compiles its whole GI stack on hardware but still raises **18
-`GPUValidationError`** — see §Forward+ on hardware. Do not read a Forward Mobile
-result as a Forward+ result.
+is opt-in (`--rendering-method forward_plus`), and as of patch 0022 it compiles
+its whole GI stack on hardware but **has never rendered a frame** — 18
+`GPUValidationError` remain. See §Forward+ on hardware. Do not read a Forward
+Mobile result as a Forward+ result.
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
@@ -55,8 +55,8 @@ result as a Forward+ result.
 | **3D scene-shader translation** | 🟢 **177/182 translate offline** (was 174); the runtime-specialized scene shader also translates *and renders* after patches 0011–0013 | §3D rendering gap |
 | Template artifacts locked in `engine-lock.toml` | ✅ | `[artifacts.export_templates]`: release + debug + sha256 |
 | **Forward+ (clustered) shader translation** | 🟢 **translates offline** after patch 0015 — was impossible before | §Forward+ |
-| **Forward+ boots on hardware** | 🟢 2026‑07‑25 — patches 0018–0022 | Tesla P40: full GI/SDFGI/SSAO/SSIL/VoxelGI stack compiles, **0 aborts, 0 wasm traps** |
-| **Forward+ renders clean on hardware** | 🟡 **not yet** — **18 `GPUValidationError`** remain (from 168) | §Forward+ on hardware |
+| **Forward+ compiles on hardware** | 🟢 2026‑07‑25 — patches 0018–0022 | Tesla P40: full GI/SDFGI/SSAO/SSIL/VoxelGI stack compiles, **0 aborts, 0 wasm traps**. Compilation, not rendering |
+| **Forward+ renders a frame** | 🔴 **no** — **no frame has ever rendered under Forward+**; 18 `GPUValidationError` remain (from 168) | §Forward+ on hardware |
 
 Reference point: a **release** WebGPU export passed a (shallow, non‑ASAN) browser
 proof on 2026‑07‑22 — `navigator.gpu` + adapter + active canvas context + 103/103
@@ -145,12 +145,21 @@ Run on a **Tesla P40** through Chrome/WebGPU, exporting with
 | 0021 | the storage-format table recorded its `RGBA8Unorm` *initialiser* on no match, so an unknown format silently succeeded with the wrong answer; `rgb10a2unorm` appears 26× in Forward+'s WGSL and was missing | 26 | 0 |
 | 0022 | the same format-vs-shader correction at the two shadow-entry sites 0020 missed | **18** | 0 |
 
-**Status: boots, compiles, does not yet render clean.** The full
-GI/SDFGI/SSAO/SSIL/VoxelGI stack compiles on real hardware and nothing aborts —
-which matters, because a `GPUValidationError` fails one pipeline gracefully
-whereas an abort is a wasm trap and a dead page. But 18 validation errors is not
-zero, so **`mobile` remains the default and everything published runs on Forward
-Mobile.** Forward+ is available to try, not to ship.
+**Status: compiles, does not render. Forward+ has never produced a frame.**
+
+Be exact about this, because the progression above is easy to over-read. What
+0018–0022 bought is that the full GI/SDFGI/SSAO/SSIL/VoxelGI stack **compiles**
+on real hardware and nothing aborts — which genuinely matters, since a
+`GPUValidationError` fails one pipeline gracefully whereas an abort is a wasm
+trap and a dead page. It is not a rendering claim. #29 said so in as many words
+— *"Forward+ still does not render. This clears the abort layer, not the finish
+line"* — and no patch since has claimed otherwise: 0019–0022 report validation
+counts and abort counts, never an fps figure or a draw count, which is exactly
+what the Forward Mobile verifications do report.
+
+**`mobile` therefore remains the default and everything published runs Forward
+Mobile.** Forward+ is an investigation path, not something to ship or to cite.
+Pipeline warm-up and shader compilation are not a rendered-frame claim.
 
 The recurring lesson across all five: **WebGPU validates a bind-group layout
 against the *shader*, not against our idea of the texture's format.** Wherever

--- a/docs/architecture/webgpu-runtime-status.md
+++ b/docs/architecture/webgpu-runtime-status.md
@@ -5,8 +5,9 @@
 > build/smoke logs under `engine/.cache/` and uncommitted edits in this worktree.
 > This file is the handoff — update it whenever the runtime status changes.
 >
-> **Last reconciled:** 2026-07-23 (evening, local UTC−6), from
-> `codex/godot-webgpu-recenter` @ `d70a27e` + uncommitted WIP.
+> **Last reconciled:** 2026-07-27, from `origin/main` @ `0f2bab8` (patch series
+> 0001–0022). Supersedes the 2026-07-23 reconciliation, which predated patches
+> 0018–0022 and still listed Forward+ on hardware as untested.
 > **Scope:** the ADR 0002 runtime-acceptance gate. The editor and WebGL fallback
 > are unaffected and green.
 
@@ -30,11 +31,21 @@ neutral template's 2D menu**, and `engine-lock.toml [artifacts.export_templates]
 records `web_webgpu_release` (`3642cf5e…`) + `web_webgpu_debug` (`1f1ed2b5…`). The
 automated gate historically rendered only a 2D Control scene; 3D is now **verified
 manually on GPU hardware** (NVIDIA Tesla P40 — six PBR meshes with real-time shadows, 59–60 fps, 0 `GPUValidationError`).
-Folding that 3D render into the automated gate is the remaining CI task.
+Folding that 3D render into the automated gate is the remaining CI task — hosted
+CI now proves the patch series (checksums + a clean-tree apply) on every change,
+but a render probe needs a GPU runner and remains self-hosted work.
+
+**One sentence on which renderer that means.** Everything shipped and published —
+the live demo, the templates, the performance A/B — is **Forward Mobile**, which
+`tools/godot/export_game.py` calls "the hardware-verified default". **Forward+**
+is opt-in (`--rendering-method forward_plus`), and as of patch 0022 it boots and
+compiles its whole GI stack on hardware but still raises **18
+`GPUValidationError`** — see §Forward+ on hardware. Do not read a Forward Mobile
+result as a Forward+ result.
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| Patch series (0001–0013) applies to official 4.7.1 `a13da4feb8` | ✅ | `just engine-versions` → "patch series: 13 patch(es)" |
+| Patch series (0001–0022) applies to official 4.7.1 `a13da4feb8` | ✅ **enforced in CI** | `.github/workflows/patch-series.yml` — checksums + a clean-tree apply on every push and PR |
 | Web templates compile (release + debug, `nothreads`, `webgpu=yes`) | ✅ | `bin/godot.web.template_*.wasm32.nothreads.*` |
 | Tint SPIR‑V→WGSL translation (storage‑buffer + OpImage ordering) | ✅ | patches 0007, 0008 |
 | **Emdawn/Godot `RefCounted` ODR collision** (the heap‑buffer‑overflow) | ✅ **fixed in source** | `engine/toolchain/patches/0001-emdawn-private-namespace.patch`, locked in `[toolchain.emdawnwebgpu]` |
@@ -44,7 +55,8 @@ Folding that 3D render into the automated gate is the remaining CI task.
 | **3D scene-shader translation** | 🟢 **177/182 translate offline** (was 174); the runtime-specialized scene shader also translates *and renders* after patches 0011–0013 | §3D rendering gap |
 | Template artifacts locked in `engine-lock.toml` | ✅ | `[artifacts.export_templates]`: release + debug + sha256 |
 | **Forward+ (clustered) shader translation** | 🟢 **translates offline** after patch 0015 — was impossible before | §Forward+ |
-| **Forward+ on hardware** | ⬜ **not yet tested** — needs a GPU box | §Forward+ |
+| **Forward+ boots on hardware** | 🟢 2026‑07‑25 — patches 0018–0022 | Tesla P40: full GI/SDFGI/SSAO/SSIL/VoxelGI stack compiles, **0 aborts, 0 wasm traps** |
+| **Forward+ renders clean on hardware** | 🟡 **not yet** — **18 `GPUValidationError`** remain (from 168) | §Forward+ on hardware |
 
 Reference point: a **release** WebGPU export passed a (shallow, non‑ASAN) browser
 proof on 2026‑07‑22 — `navigator.gpu` + adapter + active canvas context + 103/103
@@ -114,12 +126,41 @@ clustered scene shader all translate. Note that `ssao_blur`, `ssil_blur` and
 never compiled, because the harness enumerated them without the `MODE_`/
 `USE_*_SAMPLES` defines the engine actually builds them with (fixed in 0016).
 
-**None of this is hardware-verified.** Translating offline is not rendering.
-Forward+ also binds far more aggressively than Mobile, and patch 0013 exists
-because Mobile *alone* already tripped WebGPU's 16-samplers-per-stage limit —
-expect that to be the next thing to break. Export a Forward+ build with
-`export_game.py --preset web-webgpu --rendering-method forward_plus` and run it on
-the P40; `mobile` remains the default until that passes.
+**None of the above is hardware-verified — it is offline translation only.**
+Translating is not rendering. That prediction held: Forward+ binds far more
+aggressively than Mobile, and the next five patches were all things only
+hardware could show. See the section below.
+
+## Forward+ on hardware — 168 → 18 (patches 0018–0022, 2026‑07‑25)
+
+Run on a **Tesla P40** through Chrome/WebGPU, exporting with
+`export_game.py --preset web-webgpu --rendering-method forward_plus`.
+
+| Patch | What hardware showed | `GPUValidationError` | Aborts / wasm traps |
+| --- | --- | --- | --- |
+| — | first Forward+ run: page died mid shader-compile, only 2D canvas shaders built | 168 | 1 |
+| 0018 | `ShaderRD` compiles *every* variant, and Tint aborts rather than erroring — **a variant the device will never select is fatal merely by being listed**. Plus nine device limits that predated Forward+'s compute passes | 106 | **0** |
+| 0019 | sampled-texture `sampleType` was hardcoded `Float`; Forward+ reads cluster data, VoxelGI and SDFGI as **integer** textures — 32 of the remaining failures, the largest single class | 42 | 0 |
+| 0020 | negative sampler `min_lod` (legal in Vulkan, rejected by WebGPU) + storage-to-sampled sample type taken from format instead of the shader | 38 | 0 |
+| 0021 | the storage-format table recorded its `RGBA8Unorm` *initialiser* on no match, so an unknown format silently succeeded with the wrong answer; `rgb10a2unorm` appears 26× in Forward+'s WGSL and was missing | 26 | 0 |
+| 0022 | the same format-vs-shader correction at the two shadow-entry sites 0020 missed | **18** | 0 |
+
+**Status: boots, compiles, does not yet render clean.** The full
+GI/SDFGI/SSAO/SSIL/VoxelGI stack compiles on real hardware and nothing aborts —
+which matters, because a `GPUValidationError` fails one pipeline gracefully
+whereas an abort is a wasm trap and a dead page. But 18 validation errors is not
+zero, so **`mobile` remains the default and everything published runs on Forward
+Mobile.** Forward+ is available to try, not to ship.
+
+The recurring lesson across all five: **WebGPU validates a bind-group layout
+against the *shader*, not against our idea of the texture's format.** Wherever
+the driver still infers a type from a format, expect the next one.
+
+Worth recording from 0021: three consecutive attempts reported "no change" and
+the fix was twice reverted as unproven. The build script piped `engine.py build`
+through `tail`, so the pipeline's exit status was `tail`'s — **a failed build
+looked successful**, and every measurement was of a stale binary. `CLAUDE.md`
+warns about exactly this.
 
 ### Reproducing the sweep
 

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -45,10 +45,16 @@ The checker's own failure paths are covered by
   every action pinned to a full 40-character commit, no self-hosted job
   reachable from an untrusted pull request. Then
   [`secret_scan.py`](../../tools/ci/secret_scan.py) scans for committed secrets.
-- **python unit suites** — the stdlib-only suites: engine scripts (including the
-  patch checker's own failure paths — the gate that guards the gate), studio-mcp,
-  infra, the asset pipeline, bforge's schema and MCP surface, and the
-  cross-language protocol golden fixtures.
+- **python unit suites** — the suites that need no external binary: engine
+  scripts (including the patch checker's own failure paths — the gate that
+  guards the gate), studio-mcp, infra, the asset pipeline, bforge's schema, and
+  the cross-language protocol golden fixtures.
+
+  `tools/bforge/tests/test_mcp.py` is deliberately **not** here. It reads as a
+  pure tool-surface test, but `Server()` builds a `Forge`, which resolves a
+  Blender binary in its constructor — so it passes on any developer machine with
+  Blender installed and fails on a bare runner. It belongs to the self-hosted
+  suite.
 
 Locally: `just lint-workflows`, `just test-python`, `just test-protocol`.
 

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,33 +1,34 @@
 # Continuous integration
 
-## `patch-series.yml` — not yet installed
+Two hosted workflows run on every push and pull request. Both are
+toolchain-free — no Godot, no Emscripten, no GPU, no database — so they finish in
+seconds, cannot become flaky gates, and run identically for a fork or a
+first-time reader with no access to studio hardware.
 
-[`patch-series.yml`](patch-series.yml) runs `engine/scripts/verify_patch_series.py`
-on every push and pull request: it fails the build if any patch in
-`engine/patches/` drifts from the SHA-256 recorded in `engine/engine-lock.toml`,
-if a patch file exists that the lock does not cover, or if the series stops being
-ordered and contiguous.
+The heavy suites (Godot, Rust, the engine build) belong to the self-hosted
+`validate.yml` described in [`tools/ci/validate_workflows.py`](../../tools/ci/validate_workflows.py),
+which is not installed here.
 
-That is the repository's central claim — a transparent, checksum-locked patch
-series over an official Godot commit — so it is worth enforcing mechanically
-rather than by habit.
+## [`patch-series.yml`](../../.github/workflows/patch-series.yml)
 
-It lives here instead of `.github/workflows/` because GitHub refuses a push that
-creates or updates a workflow file unless the credentials carry the `workflow`
-OAuth scope, which the token used to land it did not have.
+The repository's central claim is a transparent, checksum-locked patch series
+over an official Godot commit. Two jobs enforce it mechanically rather than by
+habit:
 
-To enable it:
+- **checksums and ordering** — [`verify_patch_series.py`](../../engine/scripts/verify_patch_series.py)
+  fails if any patch in `engine/patches/` drifts from the SHA-256 recorded in
+  `engine/engine-lock.toml`, if a patch file exists that the lock does not cover,
+  or if the series stops being ordered and contiguous.
+- **applies to a clean tree** — [`verify_patch_apply.py`](../../engine/scripts/verify_patch_apply.py)
+  clones pristine official Godot at the locked base commit and applies the whole
+  series. Checksums cannot tell you a patch actually *applies*: patch 0016 once
+  shipped a modification hunk for a file no patch creates — it existed only as
+  untracked local state in the tree it was generated from — and the fast job
+  passed it while `git apply` failed on every clean checkout. This job is slower
+  because it needs the real base tree, which is exactly why it catches what the
+  fast one structurally cannot.
 
-```sh
-mkdir -p .github/workflows
-git mv docs/ci/patch-series.yml .github/workflows/patch-series.yml
-git commit -m "ci: enforce the WebGPU patch series"
-git push
-```
-
-The job needs no toolchain — no Godot, no Emscripten, no GPU — and finishes in
-seconds, so it cannot become a flaky gate. You can run exactly what it runs at
-any time:
+Run the fast one locally at any time:
 
 ```sh
 just engine-verify-patches
@@ -36,3 +37,29 @@ just engine-verify-patches
 The checker's own failure paths are covered by
 `engine/scripts/tests/test_verify_patch_series.py`, which runs under
 `just engine-test`.
+
+## [`checks.yml`](../../.github/workflows/checks.yml)
+
+- **workflow and secret policy** — [`validate_workflows.py`](../../tools/ci/validate_workflows.py)
+  enforces the studio's CI security contract on `.github/workflows/` itself:
+  every action pinned to a full 40-character commit, no self-hosted job
+  reachable from an untrusted pull request. Then
+  [`secret_scan.py`](../../tools/ci/secret_scan.py) scans for committed secrets.
+- **python unit suites** — the stdlib-only suites: engine scripts (including the
+  patch checker's own failure paths — the gate that guards the gate), studio-mcp,
+  infra, the asset pipeline, bforge's schema and MCP surface, and the
+  cross-language protocol golden fixtures.
+
+Locally: `just lint-workflows`, `just test-python`, `just test-protocol`.
+
+## Notes
+
+Both workflows pin every action to a full commit SHA with the version in a
+trailing comment. That is not decoration — `validate_workflows.py` rejects a tag
+reference, and CI runs that checker against its own directory. Bump a pin by
+resolving the tag to its commit, not by writing the tag.
+
+A missing `.github/workflows/` directory now **fails** the policy job. It
+previously returned success with "policy validation skipped", which made the
+checker green for precisely as long as the repository had no CI at all — the one
+state in which the trust and action-pin policy protects nothing.

--- a/tools/ci/validate_workflows.py
+++ b/tools/ci/validate_workflows.py
@@ -151,9 +151,13 @@ def validate_file(path: Path) -> list[str]:
 
 
 def main() -> int:
+    # A missing directory used to return 0 with "policy validation skipped". That
+    # made this checker green for exactly as long as the repository had no CI at
+    # all -- the one state where the trust and action-pin policy protects nothing.
+    # Deleting .github/ must fail the policy gate, not satisfy it.
     if not WORKFLOWS.is_dir():
-        print("workflows absent; policy validation skipped")
-        return 0
+        print(f"FAIL no workflow directory at {WORKFLOWS.relative_to(REPO)}")
+        return 1
     files = sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
     if not files:
         print("FAIL no workflow files found")


### PR DESCRIPTION
`.github/` was empty. The repository's central claim — a transparent,
checksum-locked patch series over an official Godot commit, reproducible by
anyone — was enforced by habit alone. The workflow that would check it had been
written and tested, then parked in `docs/ci/` because the token that landed it
lacked the `workflow` OAuth scope. That scope is available now.

Both patch jobs were run against this tree before being installed:

```
patch series OK — 22 patches, checksums match, applied over a13da4feb8d8
patch series applies cleanly — 22 patches over a13da4feb8d8
```

## Two defects the move surfaced

**The parked workflow violated the repo's own security contract.**
`tools/ci/validate_workflows.py` requires every action pinned to a full
40-character commit; the parked file used `@v4`/`@v5` tags. It had never been
caught because the validator only reads `.github/workflows/`, and that directory
did not exist. Every action is now SHA-pinned with the version in a trailing
comment. Proven to fail on a tag:

```
FAIL checks.yml: job 'policy' step 1 action is not pinned to a full commit: actions/checkout@v7
```

**The validator was green because there was no CI.** It returned success with
`workflows absent; policy validation skipped` when the directory was missing —
so the trust and action-pin policy passed for exactly as long as the repository
had no CI at all, the one state in which it protects nothing. A missing
`.github/workflows/` now fails the policy job. `tools/studio-mcp/tests/test_ci_tools.py`
still passes (104 tests).

## What runs

`patch-series.yml` — unchanged in substance from the parked file:
- **checksums and ordering** (`verify_patch_series.py`)
- **applies to a clean tree** (`verify_patch_apply.py`) — clones pristine Godot
  and applies the series, because checksums structurally cannot catch a hunk
  that only applied in the tree it was generated from. Patch 0016 already cost
  us that once.

`checks.yml` — new, the fast half of the suite made visible without studio
hardware:
- **workflow and secret policy** (`validate_workflows.py`, `secret_scan.py`)
- **python unit suites** — engine scripts (including the patch checker's own
  failure paths, the gate that guards the gate), studio-mcp, infra, asset
  pipeline, bforge schema + MCP surface, protocol golden fixtures

Every job was run locally first. A gate is worth nothing if it lands red, and
worth less if it cannot land red at all. No Godot, no Emscripten, no GPU, no
database — a fork gets the same result the studio does.

The heavy self-hosted `validate.yml` is still not installed; `docs/ci/README.md`
says so plainly rather than implying full coverage.