### PR TITLE
bforge: a rigger that actually skins, plus the hippodrome floor — replayed onto main

### DIFF
--- a/docs/bforge/OPS.md
+++ b/docs/bforge/OPS.md
@@ -1,6 +1,6 @@
 # bforge op reference
 
-108 operations.
+109 operations.
 
 ## `arch.*`
 
@@ -366,6 +366,17 @@ Parent a prop to a character bone — a sword to hand_r, a shield to hand_l, a h
 | `bone` | string | 'hand_r' | Bone to attach to |
 | `offset` | array | [0.0, 0.0, 0.0] | Local offset in metres |
 | `rotation` | array | [0.0, 0.0, 0.0] | Local rotation in degrees |
+| `keep_transform` | boolean | False | Keep the prop exactly where it already is, ignoring offset/rotation |
+
+### `char.bake_pose`
+
+Freeze a posed rig into the mesh vertices and drop the skin. Turns a char.rig + char.pose result into a plain static mesh that keeps the pose through export — for background figures, props and NPCs that never animate.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `mesh` | string | None | Skinned mesh object to freeze |
+| `rig` | string | None | Armature to delete afterwards (default: the one deforming this mesh; pass "" to keep it) |
+| `keep_groups` | boolean | False | Keep the vertex groups after baking |
 
 ### `char.humanoid`
 
@@ -670,7 +681,7 @@ Check the scene against a platform triangle/texture budget and say what to do ab
 
 ### `gameready.collision`
 
-Generate a physics collision proxy. Convex hulls are what you want for anything a character walks into; box is cheapest; simplified trimesh is for concave shapes like arenas and rooms. Named <object>-convcol / <object>-col per the studio import convention.
+Generate a physics collision proxy. Convex hulls are what you want for anything a character walks into; box is cheapest; simplified trimesh is for concave shapes like arenas and rooms. Named <object>-convcol / <object>-col per the studio import convention. SKIP for hulls that ride inside a moving body: Godot imports the proxy as a StaticBody3D child, and a static collider inside a CharacterBody3D blocks its own vehicle.
 
 | parameter | type | default | description |
 | --- | --- | --- | --- |
@@ -860,9 +871,11 @@ Give a subset of faces its own material — trim strips, emissive panels, painte
 | `object` | string | None | Object name |
 | `preset` | string | 'gold' | Material preset for the selected faces |
 | `select` | up \| down \| sides \| top_band \| bottom_band | 'up' | Face selection rule |
-| `band_min` | number | 0.0 | top_band/bottom_band: lower bound as a fraction of height |
+| `band_min` | number | 0.0 | top_band/bottom_band: lower bound as a fraction of height. Bands select by face CENTER, so a thin band needs real face rows at that height - one tall quad (e.g. a column shaft) has its centre near the middle and a thin band elsewhere matches nothing |
 | `band_max` | number | 1.0 | top_band/bottom_band: upper bound as a fraction of height |
 | `color` | string | '' | Override colour |
+| `roughness` | number | -1.0 | Override roughness 0..1; -1 keeps the preset value |
+| `metallic` | number | -1.0 | Override metallic 0..1; -1 keeps the preset value. Metals read black without something bright to reflect - painted trim (metallic ~0.15) survives dark environments |
 
 ### `material.list`
 

--- a/games/chariot/art_source/build_biga.py
+++ b/games/chariot/art_source/build_biga.py
@@ -187,6 +187,12 @@ def build_car(forge):
     return "car_floor"
 
 
+TUNIC_HEM = 0.245
+TUNIC_NECK = 0.205
+TUNIC_BOTTOM = 0.42
+TUNIC_TOP = 0.82
+
+
 def build_driver(forge):
     """The charioteer: a proportioned figure, not seven cuboids.
 
@@ -208,24 +214,98 @@ def build_driver(forge):
         skin=SKIN,
         location=[0.0, -0.92, 0.55],
     )
+    # POSE THE BODY BEFORE THE CLOTH EXISTS.
+    #
+    # A bare char.humanoid stands in an A-pose with its arms out and its feet
+    # together — the pose of a crash-test dummy, and it read as exactly that:
+    # a man standing to attention on a moving chariot.
+    #
+    # The cloth is deliberately NOT joined yet. Skinning is a distance falloff,
+    # and the fasciae are 0.205m rings around a chest whose shoulder joints sit
+    # at 0.18m — every band vertex is nearer an arm bone than the spine, so
+    # rotating the arms drags the man's chest armour out into metre-long
+    # shards. Rigid gear must not be skinned.
+    #
+    # So only the LIMBS are posed, and the torso chain is left at rest. The
+    # tunic, belt, bands, helmet and knife are all torso-mounted, so a torso
+    # that never moves is a torso they still fit.
+    rig = forge.call("char.rig", name="driver", height=1.72, build="heroic")
+    forge.call(
+        "char.pose",
+        rig=rig.get("armature"),
+        preset="custom",
+        bones={
+            # Braced against the floor of a car that has no seat: weight on the
+            # front foot, back leg taking the shock.
+            "thigh_l": [-26.0, 0.0, 3.0],
+            "thigh_r": [-12.0, 0.0, -3.0],
+            "shin_l": [30.0, 0.0, 0.0],
+            "shin_r": [20.0, 0.0, 0.0],
+            # Both arms out to the reins, elbows soft, hands drawn together.
+            #
+            # The arm chain's X sign is the OPPOSITE of the leg chain's — a
+            # thigh bone points down and an arm bone points sideways, so their
+            # local axes differ. Measured, not guessed: +64 on upper_arm reaches
+            # 0.517m forward, -64 reaches 0.517m BEHIND, which is how the first
+            # cut of this pose had him rowing a boat.
+            "upper_arm_l": [64.0, 0.0, -34.0],
+            "upper_arm_r": [64.0, 0.0, 34.0],
+            "forearm_l": [18.0, 0.0, -8.0],
+            "forearm_r": [18.0, 0.0, 8.0],
+            "hand_l": [12.0, 0.0, 0.0],
+            "hand_r": [12.0, 0.0, 0.0],
+        },
+    )
+    # Freeze the stance into the vertices and drop the skeleton. The driver
+    # never animates — he is a silhouette on a moving chariot — so a Skeleton3D
+    # per chariot would buy nothing, and exporting the mesh WITHOUT its skeleton
+    # would ship him standing to attention.
+    baked = forge.call("char.bake_pose", mesh="driver", rig=rig.get("armature"))
+    if float(baked.get("moved", 0.0)) < 0.05:
+        raise SystemExit(
+            "charioteer pose did not bake — he would ship in the rest pose: %r" % (baked,)
+        )
+
+    # DRESS HIM OFF HIS OWN BODY, NOT OFF HARD-CODED HEIGHTS.
+    #
+    # The kit below used to be placed at absolute Z. The figure stands on the
+    # car floor at 0.55, so every piece was authored half a metre low: the
+    # helmet sat at his stomach and his head went bare, which is most of why he
+    # read as a crash-test dummy no matter what the pose did.
+    body = forge.call("object.inspect", name="driver")["bounds"]
+    sole, crown = body["min"][2], body["max"][2]
+    stature = crown - sole
+
+    def at(fraction):
+        """Height up the man himself: 0.0 is the sole, 1.0 the crown."""
+        return sole + fraction * stature
+
+    def _tunic_radius(fraction):
+        """The tunic's radius at a given height, so the kit can hug it."""
+        span = (fraction - TUNIC_BOTTOM) / (TUNIC_TOP - TUNIC_BOTTOM)
+        return TUNIC_HEM + (TUNIC_NECK - TUNIC_HEM) * max(0.0, min(1.0, span))
+
     # Tunic over the body, belted — the livery surface the game recolours.
     forge.call(
         "build.cylinder",
         name="driver_tunic",
-        radius=0.20,
-        radius_top=0.17,
-        depth=0.62,
-        segments=8,
-        location=[0.0, -0.92, 1.22],
+        # Wider than the torso it covers. Sized to match, the body pokes
+        # through the flat of an 8-sided cylinder and the tunic stops reading
+        # as clothing — it becomes a board strapped to his chest.
+        radius=TUNIC_HEM,
+        radius_top=TUNIC_NECK,
+        depth=0.40 * stature,
+        segments=12,
+        location=[0.0, -0.92, at(0.62)],
         material="cloth",
         color=LIVERY,
         origin="center",
     )
     forge.call(
         "build.torus",
-        name="driver_belt", major=0.19, minor=0.028,
-        major_segments=10, minor_segments=4,
-        location=[0.0, -0.92, 1.00],
+        name="driver_belt", major=0.235, minor=0.026,
+        major_segments=12, minor_segments=4,
+        location=[0.0, -0.92, at(0.53)],
         material="cloth", color=LEATHER, origin="center",
     )
     # Helmet and crest: the crest is the second livery surface.
@@ -235,7 +315,7 @@ def build_driver(forge):
         radius=0.135,
         segments=10,
         rings=6,
-        location=[0.0, -0.92, 1.62],
+        location=[0.0, -0.92, at(0.93)],
         material="metal",
         color=BRONZE,
         origin="center",
@@ -243,8 +323,10 @@ def build_driver(forge):
     forge.call(
         "build.wedge",
         name="driver_crest",
-        size=[0.05, 0.34, 0.16],
-        location=[0.0, -0.94, 1.78],
+        # Runs fore-and-aft along the dome, and SEATED IN IT — placed above the
+        # crown it reads as a signboard held behind his head.
+        size=[0.05, 0.26, 0.15],
+        location=[0.0, -0.92, at(0.96)],
         material="cloth",
         color=LIVERY,
         origin="center",
@@ -256,9 +338,12 @@ def build_driver(forge):
         band = f"driver_fascia_{i}"
         forge.call(
             "build.torus",
-            name=band, major=0.205, minor=0.022,
-            major_segments=12, minor_segments=4,
-            location=[0.0, -0.92, 1.06 + i * 0.085],
+            # Follow the tunic's taper. Held at one radius they stand off the
+            # narrowing chest like a set of shelves instead of bands wound
+            # round it.
+            name=band, major=_tunic_radius(0.60 + i * 0.046) + 0.008, minor=0.018,
+            major_segments=14, minor_segments=4,
+            location=[0.0, -0.92, at(0.60 + i * 0.046)],
             material="rubber", color=LEATHER, origin="center",
         )
         forge.call("object.transform", name=band, scale=[1.0, 0.72, 1.0], apply=True)
@@ -266,7 +351,7 @@ def build_driver(forge):
     forge.call(
         "build.box",
         name="driver_knife", size=[0.035, 0.055, 0.18],
-        location=[0.16, -0.86, 0.96],
+        location=[0.16, -0.86, at(0.50)],
         material="metal", color=IRON, origin="center",
     )
     forge.call(

--- a/games/chariot/art_source/build_biga.py
+++ b/games/chariot/art_source/build_biga.py
@@ -198,8 +198,12 @@ def build_driver(forge):
         "char.humanoid",
         name="driver",
         height=1.72,
-        build="lithe",
-        bulk=0.95,
+        # HEROIC, not lithe. A charioteer really was a lean man, but at the
+        # distance this is read from, "lean" is indistinguishable from "thin
+        # stick" — the figure has to hold its shape against sand and stone
+        # before it can hold its character.
+        build="heroic",
+        bulk=1.25,
         detail=8,
         skin=SKIN,
         location=[0.0, -0.92, 0.55],

--- a/games/chariot/art_source/build_biga.py
+++ b/games/chariot/art_source/build_biga.py
@@ -1,0 +1,353 @@
+"""Build The Chariot Club's racing biga and its charioteer, via bforge.
+
+    python games/chariot/art_source/build_biga.py [--render] [--install]
+
+The shipping chariot was stacked axis-aligned boxes — including the driver,
+who was seven cuboids and a slab for a crest. It is the thing on screen for
+every second of every race, at the closest range of anything in the game.
+
+Contract with the game (src/presentation/broadcast_view.gd):
+  * top-level objects named `Car`, `WheelL`, `WheelR`, `Charioteer`
+  * each wheel's ORIGIN at its own hub — the runtime spins local X from
+    authoritative speed, so an off-centre origin makes the wheel orbit
+  * materials named `CarFront`, `Tunic`, `Crest` — the livery tints look them
+    up by name and recolour per stable
+  * forward is -Z in Godot, which is +Y in Blender before the glTF axis change
+
+A single horse draws between two side shafts. A central pole is a two-horse
+rig and would pierce the animal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "tools" / "bforge"))
+
+from bforge import Forge, ForgeError  # noqa: E402
+
+GAME = REPO / "games" / "chariot"
+MODEL_PATH = GAME / "project" / "assets" / "models" / "racing_chariot.glb"
+
+# Oiled ash and bronze, not painted plastic. The livery colours arrive at
+# runtime; everything structural stays timber and metal.
+ASH = "#8a6a44"
+ASH_DARK = "#6b5133"
+BRONZE = "#a8762e"
+IRON = "#6f7378"
+LEATHER = "#5e4029"
+LIVERY = "#c9c2b0"   # placeholder: the game recolours these per stable
+SKIN = "#b07d55"
+
+WHEEL_R = 0.55
+WHEEL_X = 0.84
+HUB_Z = 0.55
+AXLE_Y = -1.25
+
+
+def spin(forge, name, degrees):
+    """Rotate and BAKE. The build ops place but never orient, and an unbaked
+    node rotation does not survive the join into another object's space."""
+    forge.call("object.transform", name=name, rotation=degrees, apply=True)
+
+
+def build_wheel(forge, name, x_sign):
+    """A spoked wheel whose origin is its hub.
+
+    Built AT THE ORIGIN and moved afterwards, because everything here is
+    joined into the hub and a join keeps the ACTIVE object's origin — put the
+    wheel at its final place first and it spins around the chariot instead of
+    around its own axle.
+    """
+    hub = f"{name}_hub"
+    # The nave: a turned bronze barrel, wider at the middle like a real one.
+    forge.call(
+        "build.lathe",
+        name=hub,
+        profile=[0.045, -0.11, 0.10, -0.09, 0.115, 0.0, 0.10, 0.09, 0.045, 0.11],
+        segments=14, material="metal", color=BRONZE, origin="center", smooth=True,
+    )
+    spin(forge, hub, [0.0, 90.0, 0.0])
+    parts = [hub]
+    # Felloe (the wooden rim) under an iron tyre — two rings, not one, which is
+    # the read that says "wheel built by a wheelwright" rather than "torus".
+    forge.call(
+        "build.torus",
+        name=f"{name}_felloe", major=WHEEL_R - 0.075, minor=0.055,
+        major_segments=32, minor_segments=8,
+        material="wood", color=ASH, origin="center",
+    )
+    spin(forge, f"{name}_felloe", [0.0, 90.0, 0.0])
+    parts.append(f"{name}_felloe")
+    forge.call(
+        "build.torus",
+        name=f"{name}_tyre", major=WHEEL_R - 0.022, minor=0.028,
+        major_segments=32, minor_segments=6,
+        material="metal", color=IRON, origin="center",
+    )
+    spin(forge, f"{name}_tyre", [0.0, 90.0, 0.0])
+    parts.append(f"{name}_tyre")
+    for k in range(10):
+        spoke = f"{name}_spoke_{k}"
+        # Turned spokes: thick at the nave, thin at the felloe.
+        forge.call(
+            "build.cylinder",
+            name=spoke, radius=0.030, radius_top=0.018,
+            depth=WHEEL_R - 0.10, segments=6,
+            material="wood", color=ASH, origin="bottom",
+        )
+        spin(forge, spoke, [0.0, 90.0, 36.0 * k])
+        parts.append(spoke)
+    forge.call("object.join", names=parts, into=hub)
+    forge.call(
+        "object.transform",
+        name=hub,
+        location=[x_sign * WHEEL_X, AXLE_Y, HUB_Z],
+        apply=False,
+    )
+    return hub
+
+
+def build_car(forge):
+    """The car: a floor, a curved front breastwork, side rails, axle, shafts
+    and reins. Swept rather than stacked, so the front actually curves the way
+    a biga's does."""
+    parts = []
+    forge.call(
+        "build.box",
+        name="car_floor",
+        size=[0.95, 0.80, 0.10],
+        location=[0.0, -1.05, 0.50],
+        bevel=0.02,
+        material="wood",
+        color=ASH_DARK,
+        origin="center",
+    )
+    parts.append("car_floor")
+    # The breastwork the driver leans into: a curved shell, open at the back.
+    # The rail the driver leans into. A swept ARC put it beside the car, not
+    # around it — the arc path begins at its location rather than centring on
+    # it — so this is a ring, which cannot be placed ambiguously, plus
+    # stanchions down to the floor. Open-backed reads from the stanchion gap.
+    forge.call(
+        "build.torus",
+        name="car_front", major=0.46, minor=0.045,
+        major_segments=18, minor_segments=6,
+        location=[0.0, -1.02, 1.28],
+        material="cloth", color=LIVERY, origin="center",
+    )
+    forge.call("object.transform", name="car_front", scale=[1.0, 0.86, 1.0], apply=True)
+    parts.append("car_front")
+    for i, (sx, sy) in enumerate([(-0.44, -1.42), (0.44, -1.42), (-0.30, -0.62), (0.30, -0.62)]):
+        post = f"car_post_{i}"
+        forge.call(
+            "build.cylinder",
+            name=post, radius=0.026, depth=0.78, segments=6,
+            location=[sx, sy, 0.90],
+            material="wood", color=ASH, origin="center",
+        )
+        parts.append(post)
+    forge.call(
+        "build.cylinder",
+        name="axle", radius=0.05, depth=1.72, segments=8,
+        location=[0.0, AXLE_Y, HUB_Z],
+        material="wood", color=ASH_DARK, origin="center",
+    )
+    spin(forge, "axle", [0.0, 90.0, 0.0])
+    parts.append("axle")
+    for sign, side in ((-1.0, "l"), (1.0, "r")):
+        shaft = f"shaft_{side}"
+        forge.call(
+            "build.cylinder",
+            name=shaft, radius=0.035, depth=3.15, segments=6,
+            location=[sign * 0.44, 0.86, 0.86],
+            material="wood", color=ASH, origin="center",
+        )
+        spin(forge, shaft, [98.5, 0.0, 0.0])
+        parts.append(shaft)
+        rein = f"rein_{side}"
+        forge.call(
+            "build.cylinder",
+            name=rein, radius=0.017, depth=3.95, segments=4,
+            location=[sign * 0.20, 1.52, 1.58],
+            # Rubber, not cloth: `cloth` has to stay unambiguously the LIVERY
+            # surface, because that is the one the game recolours per stable
+            # and it finds it by material name.
+            material="rubber", color=LEATHER, origin="center",
+        )
+        spin(forge, rein, [98.0, 0.0, 0.0])
+        parts.append(rein)
+    forge.call("object.join", names=parts, into="car_floor")
+    return "car_floor"
+
+
+def build_driver(forge):
+    """The charioteer: a proportioned figure, not seven cuboids.
+
+    Stood in the car, leaning into the reins. `char.humanoid` gives the figure
+    the head ratios a human actually has, which is the whole reason the box
+    version never read as a person however it was coloured.
+    """
+    forge.call(
+        "char.humanoid",
+        name="driver",
+        height=1.72,
+        build="lithe",
+        bulk=0.95,
+        detail=8,
+        skin=SKIN,
+        location=[0.0, -0.92, 0.55],
+    )
+    # Tunic over the body, belted — the livery surface the game recolours.
+    forge.call(
+        "build.cylinder",
+        name="driver_tunic",
+        radius=0.20,
+        radius_top=0.17,
+        depth=0.62,
+        segments=8,
+        location=[0.0, -0.92, 1.22],
+        material="cloth",
+        color=LIVERY,
+        origin="center",
+    )
+    forge.call(
+        "build.torus",
+        name="driver_belt", major=0.19, minor=0.028,
+        major_segments=10, minor_segments=4,
+        location=[0.0, -0.92, 1.00],
+        material="cloth", color=LEATHER, origin="center",
+    )
+    # Helmet and crest: the crest is the second livery surface.
+    forge.call(
+        "build.sphere",
+        name="driver_galea",
+        radius=0.135,
+        segments=10,
+        rings=6,
+        location=[0.0, -0.92, 1.62],
+        material="metal",
+        color=BRONZE,
+        origin="center",
+    )
+    forge.call(
+        "build.wedge",
+        name="driver_crest",
+        size=[0.05, 0.34, 0.16],
+        location=[0.0, -0.94, 1.78],
+        material="cloth",
+        color=LIVERY,
+        origin="center",
+    )
+    # The FASCIAE: the leather bands a Roman charioteer wound round his chest,
+    # the single most recognisable thing about the man. Without them he is
+    # just somebody standing in a cart.
+    for i in range(5):
+        band = f"driver_fascia_{i}"
+        forge.call(
+            "build.torus",
+            name=band, major=0.205, minor=0.022,
+            major_segments=12, minor_segments=4,
+            location=[0.0, -0.92, 1.06 + i * 0.085],
+            material="rubber", color=LEATHER, origin="center",
+        )
+        forge.call("object.transform", name=band, scale=[1.0, 0.72, 1.0], apply=True)
+    # The knife at his belt: he carried one to cut himself free of the reins.
+    forge.call(
+        "build.box",
+        name="driver_knife", size=[0.035, 0.055, 0.18],
+        location=[0.16, -0.86, 0.96],
+        material="metal", color=IRON, origin="center",
+    )
+    forge.call(
+        "object.join",
+        names=(["driver", "driver_tunic", "driver_belt", "driver_galea",
+                "driver_crest", "driver_knife"]
+               + [f"driver_fascia_{i}" for i in range(5)]),
+        into="driver",
+    )
+    return "driver"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--render", action="store_true")
+    parser.add_argument("--install", action="store_true")
+    args = parser.parse_args()
+
+    out_dir = REPO / "assets-generated" / "bforge" / "chariot"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with Forge() as forge:
+        forge.call("session.reset")
+        car = build_car(forge)
+        left = build_wheel(forge, "wheel_l", -1.0)
+        right = build_wheel(forge, "wheel_r", 1.0)
+        driver = build_driver(forge)
+
+        # Take the critique's own advice: the humanoid blockout leaves
+        # non-manifold seams where its limbs meet the torso, and every op that
+        # makes a rounded cap leaves n-gons an engine will triangulate however
+        # it likes. Both are cheap to fix here and expensive to chase later.
+        forge.call("build.cleanup", name=driver, merge_distance=0.001)
+        forge.call(
+            "gameready.optimize",
+            objects=[car, left, right, driver],
+            triangulate=True,
+        )
+        # NO baked PBR here, deliberately. material.bake_pbr collapses an
+        # object to ONE material, and this game tints `CarFront`, `Tunic` and
+        # `Crest` BY NAME to put each stable in its own livery — the single
+        # most important thing the chariot does. A gorgeous surface that makes
+        # every stable race in the same colours is a worse asset. The quality
+        # here comes from the geometry: a turned nave, a felloe under an iron
+        # tyre, tapered spokes, an open breastwork and a proportioned driver.
+        info = forge.call("object.list")
+        names = info["objects"] if isinstance(info, dict) else info
+        print("built    :", ", ".join(sorted(str(o if isinstance(o, str) else o.get("name")) for o in names)))
+
+        report = forge.call("check.critique")
+        print("critique :", report.get("summary", report))
+
+        glb = out_dir / "racing_chariot.glb"
+        forge.call(
+            "export.gltf",
+            out=str(glb),
+            objects=[car, left, right, driver],
+            rename={
+                # One livery surface, shared by the car's breastwork, the
+                # driver's tunic and his crest — the game tints CarFront,
+                # Tunic and Crest on BOTH meshes, so a single well-named
+                # material puts the whole rig in the stable's colours.
+                "m_cloth": "Tunic",
+                "car_floor": "Car",
+                "wheel_l_hub": "WheelL",
+                "wheel_r_hub": "WheelR",
+                "driver": "Charioteer",
+            },
+        )
+        print("export   :", f"{glb.stat().st_size // 1024} KB -> {glb}")
+        forge.call("session.save", path=str(out_dir / "racing_chariot.blend"))
+
+        if args.render:
+            sheet = out_dir / "biga.png"
+            forge.call("render.contact_sheet", out=str(sheet))
+            print("sheet    :", sheet)
+
+    if args.install:
+        shutil.copy2(glb, MODEL_PATH)
+        print("installed:", MODEL_PATH)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ForgeError as err:
+        print("bforge error:", err, file=sys.stderr)
+        raise SystemExit(1)

--- a/games/chariot/art_source/build_biga.py
+++ b/games/chariot/art_source/build_biga.py
@@ -174,8 +174,15 @@ def build_car(forge):
         rein = f"rein_{side}"
         forge.call(
             "build.cylinder",
-            name=rein, radius=0.017, depth=3.95, segments=4,
-            location=[sign * 0.20, 1.52, 1.58],
+            # A REIN ENDS AT THE BIT, NOT PAST THE HORSE'S EARS. Measured in
+            # the horse's own space the chariot's forward geometry reached
+            # -2.18 while the horse's nose is at -1.56, so both reins ran 0.6m
+            # out into open air ahead of the animal — which is what made the
+            # rig read as a horse and a cart that were not attached to each
+            # other. Shortened, and the centre moved back by half of what came
+            # off, so the near end stays in the driver's hands.
+            name=rein, radius=0.017, depth=3.07, segments=4,
+            location=[sign * 0.20, 1.08, 1.58],
             # Rubber, not cloth: `cloth` has to stay unambiguously the LIVERY
             # surface, because that is the one the game recolours per stable
             # and it finds it by material name.

--- a/games/chariot/art_source/build_gladiators.py
+++ b/games/chariot/art_source/build_gladiators.py
@@ -67,45 +67,46 @@ def fighter_base(forge, name, bulk):
 
 
 
-def brace(forge, name, rig, parts):
-    """Set the fighter on his back foot, then freeze it into the mesh.
+def brace(forge, name, rig, parts, harness, pose):
+    """Put the fighter on guard, and freeze it into the mesh.
 
-    ONLY THE BACK LEG MOVES, and that is deliberate. Every other piece of a
-    gladiator's kit — shield, sword, manica, helmet, greave — is rigid and
-    placed in world coordinates against the body, so any bone that moves under
-    one of them leaves it hanging in the air. The torso and both arms stay at
-    rest, which keeps all of it valid; the greave is on the LEFT shin, so the
-    left leg is the one left planted and the right steps back.
+    Every piece of a gladiator's kit is rigid and was modelled in world
+    coordinates against a body standing to attention. `char.attach` normally
+    THROWS THAT AWAY and snaps the prop to the bone's tail, which is right for
+    placing a sword into an empty fist and useless for a shield, a greave or an
+    arm band that is already sitting exactly where it belongs. So each piece is
+    attached with keep_transform: it does not move at all, it simply starts
+    following the bone it is strapped to.
 
-    A stance is not a pose sequence, but it is the difference between a fighter
-    and a man standing to attention holding a shield.
-
-    (Posing the arms as well is a bigger job and the path is proven: attach each
-    hand-held piece to its bone with char.attach, pose, join, then bake — a
-    blade parented to hand_r follows the arm and survives the join. It needs the
-    gear re-authored as bone-relative offsets, because char.attach snaps a prop
-    to the bone tail and discards wherever it was placed.)
+    That is what makes posing the arms affordable. Without it every one of these
+    pieces would have to be re-derived as a bone-relative offset and eyeballed
+    back into place one render at a time.
     """
-    forge.call(
-        "char.pose", rig=rig, preset="custom",
-        bones={
-            # Negative is backward on this rig — measured, not assumed.
-            "thigh_r": [-32.0, 0.0, -4.0],
-            "shin_r": [26.0, 0.0, 0.0],
-            "foot_r": [10.0, 0.0, 0.0],
-            # The planted leg takes a little bend rather than locking straight.
-            "shin_l": [8.0, 0.0, 0.0],
-        },
-    )
-    # BAKE BEFORE JOINING. object.join does not carry the armature modifier
-    # across, so a join first leaves nothing to bake and the stance is silently
-    # lost. Freezing the body first is safe here precisely because no kit rides
-    # the leg that moves.
-    baked = forge.call("char.bake_pose", mesh=name, rig=rig)
+    for piece, bone in harness:
+        forge.call("char.attach", prop=piece, rig=rig, bone=bone, keep_transform=True)
+    forge.call("char.pose", rig=rig, preset="custom", bones=pose)
+    # BAKE BEFORE JOINING, and keep the rig while doing it. object.join does not
+    # carry the armature modifier across, so a join first leaves nothing to bake
+    # and the pose is lost without a word; and the kit is still parented to the
+    # rig, so the rig has to outlive the bake.
+    baked = forge.call("char.bake_pose", mesh=name, rig="")
     if float(baked.get("moved", 0.0)) < 0.02:
-        raise SystemExit(f"{name} stance did not bake: {baked!r}")
+        raise SystemExit(f"{name} pose did not bake: {baked!r}")
     forge.call("object.join", names=parts, into=name)
+    forge.call("object.delete", names=[rig])
     return name
+
+
+# Legs: back foot away and bent, front leg planted with a little bend rather
+# than locked straight. Arms: measured convention — positive X is FORWARD on
+# this rig, and Z lowers the arm.
+STANCE_POSE = {
+    "thigh_r": [-32.0, 0.0, -4.0],
+    "shin_r": [26.0, 0.0, 0.0],
+    "foot_r": [10.0, 0.0, 0.0],
+    "thigh_l": [10.0, 0.0, 2.0],
+    "shin_l": [10.0, 0.0, 0.0],
+}
 
 
 def build_murmillo(forge):
@@ -196,7 +197,23 @@ def build_murmillo(forge):
         material="bronze", color=BRONZE, origin="center",
     )
     parts.append("murmillo_greave")
-    return brace(forge, "murmillo", rig, parts)
+    murmillo_pose = dict(STANCE_POSE)
+    murmillo_pose.update({
+        # Shield arm out in front, covering him.
+        "upper_arm_l": [52.0, 0.0, -22.0],
+        "forearm_l": [26.0, 0.0, 0.0],
+        # Sword arm drawn back with the elbow closed, blade up and ready.
+        "upper_arm_r": [-18.0, 0.0, 18.0],
+        "forearm_r": [58.0, 0.0, 0.0],
+    })
+    harness = [
+        ("murmillo_scutum", "hand_l"), ("murmillo_boss", "hand_l"),
+        ("murmillo_gladius", "hand_r"), ("murmillo_grip", "hand_r"),
+        ("murmillo_manica_0", "upper_arm_r"), ("murmillo_manica_1", "upper_arm_r"),
+        ("murmillo_manica_2", "forearm_r"), ("murmillo_manica_3", "forearm_r"),
+        ("murmillo_greave", "shin_l"),
+    ]
+    return brace(forge, "murmillo", rig, parts, harness, murmillo_pose)
 
 
 def build_retiarius(forge):
@@ -257,7 +274,23 @@ def build_retiarius(forge):
     )
     spin(forge, "retiarius_net", [86.0, 0.0, 14.0])
     parts.append("retiarius_net")
-    return brace(forge, "retiarius", rig, parts)
+    retiarius_pose = dict(STANCE_POSE)
+    retiarius_pose.update({
+        # Trident arm thrusting forward.
+        "upper_arm_r": [46.0, 0.0, 14.0],
+        "forearm_r": [16.0, 0.0, 0.0],
+        # Net arm out wide, ready to cast.
+        "upper_arm_l": [28.0, 0.0, -34.0],
+        "forearm_l": [34.0, 0.0, 0.0],
+    })
+    harness = [
+        ("retiarius_shaft", "hand_r"), ("retiarius_head", "hand_r"),
+        ("retiarius_net", "hand_l"),
+        ("retiarius_galerus", "shoulder_l"),
+        ("retiarius_manica_0", "upper_arm_l"), ("retiarius_manica_1", "upper_arm_l"),
+        ("retiarius_manica_2", "forearm_l"), ("retiarius_manica_3", "forearm_l"),
+    ]
+    return brace(forge, "retiarius", rig, parts, harness, retiarius_pose)
 
 
 def main():

--- a/games/chariot/art_source/build_gladiators.py
+++ b/games/chariot/art_source/build_gladiators.py
@@ -62,13 +62,56 @@ def fighter_base(forge, name, bulk):
         major_segments=12, minor_segments=4, location=[0.0, 0.0, 1.02],
         material="rubber", color=LEATHER, origin="center",
     )
-    return [name, f"{name}_kilt", f"{name}_belt"]
+    rig = forge.call("char.rig", name=name, height=HEIGHT, build="heroic")
+    return [name, f"{name}_kilt", f"{name}_belt"], rig.get("armature")
+
+
+
+def brace(forge, name, rig, parts):
+    """Set the fighter on his back foot, then freeze it into the mesh.
+
+    ONLY THE BACK LEG MOVES, and that is deliberate. Every other piece of a
+    gladiator's kit — shield, sword, manica, helmet, greave — is rigid and
+    placed in world coordinates against the body, so any bone that moves under
+    one of them leaves it hanging in the air. The torso and both arms stay at
+    rest, which keeps all of it valid; the greave is on the LEFT shin, so the
+    left leg is the one left planted and the right steps back.
+
+    A stance is not a pose sequence, but it is the difference between a fighter
+    and a man standing to attention holding a shield.
+
+    (Posing the arms as well is a bigger job and the path is proven: attach each
+    hand-held piece to its bone with char.attach, pose, join, then bake — a
+    blade parented to hand_r follows the arm and survives the join. It needs the
+    gear re-authored as bone-relative offsets, because char.attach snaps a prop
+    to the bone tail and discards wherever it was placed.)
+    """
+    forge.call(
+        "char.pose", rig=rig, preset="custom",
+        bones={
+            # Negative is backward on this rig — measured, not assumed.
+            "thigh_r": [-32.0, 0.0, -4.0],
+            "shin_r": [26.0, 0.0, 0.0],
+            "foot_r": [10.0, 0.0, 0.0],
+            # The planted leg takes a little bend rather than locking straight.
+            "shin_l": [8.0, 0.0, 0.0],
+        },
+    )
+    # BAKE BEFORE JOINING. object.join does not carry the armature modifier
+    # across, so a join first leaves nothing to bake and the stance is silently
+    # lost. Freezing the body first is safe here precisely because no kit rides
+    # the leg that moves.
+    baked = forge.call("char.bake_pose", mesh=name, rig=rig)
+    if float(baked.get("moved", 0.0)) < 0.02:
+        raise SystemExit(f"{name} stance did not bake: {baked!r}")
+    forge.call("object.join", names=parts, into=name)
+    return name
 
 
 def build_murmillo(forge):
     """Tower shield, short sword, the big crested helmet."""
     # A murmillo was the heavy: he should look it beside the net-man.
-    parts = fighter_base(forge, "murmillo", 1.45)
+    parts, rig = fighter_base(forge, "murmillo", 1.45)
     # The scutum: a tall curved shield on the left arm. Curved, because a flat
     # slab is the difference between a shield and a door.
     # A bevelled PANEL. An uncapped cylinder is a barrel, not a shield: it
@@ -153,14 +196,13 @@ def build_murmillo(forge):
         material="bronze", color=BRONZE, origin="center",
     )
     parts.append("murmillo_greave")
-    forge.call("object.join", names=parts, into="murmillo")
-    return "murmillo"
+    return brace(forge, "murmillo", rig, parts)
 
 
 def build_retiarius(forge):
     """Trident, net, one shoulder guard, and no helmet at all."""
     # Lighter than the murmillo by design, but still a fighting man.
-    parts = fighter_base(forge, "retiarius", 1.20)
+    parts, rig = fighter_base(forge, "retiarius", 1.20)
     # Galerus: the shoulder guard that let him keep his face open.
     forge.call(
         "build.box",
@@ -215,8 +257,7 @@ def build_retiarius(forge):
     )
     spin(forge, "retiarius_net", [86.0, 0.0, 14.0])
     parts.append("retiarius_net")
-    forge.call("object.join", names=parts, into="retiarius")
-    return "retiarius"
+    return brace(forge, "retiarius", rig, parts)
 
 
 def main():

--- a/games/chariot/art_source/build_gladiators.py
+++ b/games/chariot/art_source/build_gladiators.py
@@ -105,15 +105,24 @@ def build_murmillo(forge):
     spin(forge, "murmillo_grip", [90.0, 0.0, 0.0])
     parts.append("murmillo_grip")
     # Manica: the segmented sleeve on the sword arm.
+    #
+    # A SLEEVE RUNS DOWN THE ARM. These marched along Y at a fixed height, so
+    # instead of banding the arm they hung in the air beside the man in a neat
+    # horizontal row — the single most obviously wrong thing in the render.
+    # The arm centre is measured, not guessed: the body is 0.720 wide, so the
+    # hanging arm sits at x ~ 0.28.
+    #
+    # No spin, either. A torus already encircles its own Z, which is what a band
+    # round a vertical arm needs; spun 90 degrees it encircled the FORWARD axis
+    # and read as a hoop standing off the shoulder.
     for i in range(4):
         seg = f"murmillo_manica_{i}"
         forge.call(
             "build.torus",
-            name=seg, major=0.075, minor=0.022, major_segments=8, minor_segments=4,
-            location=[0.30, 0.10 + i * 0.10, 1.22],
+            name=seg, major=0.088, minor=0.022, major_segments=10, minor_segments=4,
+            location=[0.28, 0.0, 1.32 - i * 0.11],
             material="iron", color=IRON, origin="center",
         )
-        spin(forge, seg, [90.0, 0.0, 0.0])
         parts.append(seg)
     # Galea: bowl, brim and the crest that names him.
     forge.call(
@@ -160,15 +169,16 @@ def build_retiarius(forge):
         material="bronze", color=BRONZE, origin="center",
     )
     parts.append("retiarius_galerus")
+    # The net-man's manica is on his LEFT arm, the one that throws. Same fix as
+    # the murmillo's: down the arm, not along the ground.
     for i in range(4):
         seg = f"retiarius_manica_{i}"
         forge.call(
             "build.torus",
-            name=seg, major=0.072, minor=0.020, major_segments=8, minor_segments=4,
-            location=[-0.28, 0.04 + i * 0.09, 1.24],
+            name=seg, major=0.078, minor=0.020, major_segments=10, minor_segments=4,
+            location=[-0.276, 0.0, 1.32 - i * 0.11],
             material="iron", color=IRON, origin="center",
         )
-        spin(forge, seg, [90.0, 0.0, 0.0])
         parts.append(seg)
     # The trident: thick enough to survive the silhouette at forty metres.
     forge.call(

--- a/games/chariot/art_source/build_gladiators.py
+++ b/games/chariot/art_source/build_gladiators.py
@@ -67,7 +67,8 @@ def fighter_base(forge, name, bulk):
 
 def build_murmillo(forge):
     """Tower shield, short sword, the big crested helmet."""
-    parts = fighter_base(forge, "murmillo", 1.15)
+    # A murmillo was the heavy: he should look it beside the net-man.
+    parts = fighter_base(forge, "murmillo", 1.45)
     # The scutum: a tall curved shield on the left arm. Curved, because a flat
     # slab is the difference between a shield and a door.
     # A bevelled PANEL. An uncapped cylinder is a barrel, not a shield: it
@@ -149,7 +150,8 @@ def build_murmillo(forge):
 
 def build_retiarius(forge):
     """Trident, net, one shoulder guard, and no helmet at all."""
-    parts = fighter_base(forge, "retiarius", 1.0)
+    # Lighter than the murmillo by design, but still a fighting man.
+    parts = fighter_base(forge, "retiarius", 1.20)
     # Galerus: the shoulder guard that let him keep his face open.
     forge.call(
         "build.box",

--- a/games/chariot/art_source/build_gladiators.py
+++ b/games/chariot/art_source/build_gladiators.py
@@ -1,0 +1,256 @@
+"""Build The Chariot Club's gladiator pair, via bforge.
+
+    python games/chariot/art_source/build_gladiators.py [--render]
+
+The midday show on the infield. These were hand-stacked boxes: the pairing
+every Roman crowd knew, rendered as cuboids. The whole point of a murmillo
+against a retiarius is that you can tell which is which from the SILHOUETTE
+at forty metres — the tower shield and crested helmet against the trident,
+the net and a bare head.
+
+Contract with the game (src/presentation/broadcast_view.gd):
+  * two top-level objects named `Murmillo` and `Retiarius`
+  * materials named `Tunic` and `Crest` — the duel tints them per fighter
+  * `Bronze`, `Iron` and `Net` present, so armour and kit read as themselves
+  * forward is -Z in Godot, which is +Y in Blender before the glTF axis change
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "tools" / "bforge"))
+
+from bforge import Forge, ForgeError  # noqa: E402
+
+OUT = REPO / "assets-generated" / "bforge" / "chariot"
+
+SKIN = "#a8764e"
+TUNIC = "#c9c2b0"      # placeholder: the game recolours per fighter
+CREST = "#c9c2b0"
+BRONZE = "#a8762e"
+IRON = "#70747a"
+LEATHER = "#5a3d27"
+NET = "#9a8f6a"
+HEIGHT = 1.80
+
+
+def spin(forge, name, degrees):
+    forge.call("object.transform", name=name, rotation=degrees, apply=True)
+
+
+def fighter_base(forge, name, bulk):
+    forge.call(
+        "char.humanoid",
+        name=name, height=HEIGHT, build="heroic", bulk=bulk, detail=8,
+        skin=SKIN, location=[0.0, 0.0, 0.0],
+    )
+    # Subligaculum and belt: the loincloth every gladiator fought in.
+    forge.call(
+        "build.cylinder",
+        name=f"{name}_kilt", radius=0.21, radius_top=0.19, depth=0.34,
+        segments=10, location=[0.0, 0.0, 0.86],
+        material="cloth", color=TUNIC, origin="center",
+    )
+    forge.call(
+        "build.torus",
+        name=f"{name}_belt", major=0.205, minor=0.030,
+        major_segments=12, minor_segments=4, location=[0.0, 0.0, 1.02],
+        material="rubber", color=LEATHER, origin="center",
+    )
+    return [name, f"{name}_kilt", f"{name}_belt"]
+
+
+def build_murmillo(forge):
+    """Tower shield, short sword, the big crested helmet."""
+    parts = fighter_base(forge, "murmillo", 1.15)
+    # The scutum: a tall curved shield on the left arm. Curved, because a flat
+    # slab is the difference between a shield and a door.
+    # A bevelled PANEL. An uncapped cylinder is a barrel, not a shield: it
+    # came out as a brown drum taller than the man carrying it and hid him
+    # completely. Flat reads fine at forty metres; a barrel never will.
+    forge.call(
+        "build.box",
+        name="murmillo_scutum", size=[0.09, 0.58, 1.02],
+        location=[-0.42, 0.14, 1.10], bevel=0.05,
+        material="bronze", color=BRONZE, origin="center",
+    )
+    parts.append("murmillo_scutum")
+    forge.call(
+        "build.sphere",
+        name="murmillo_boss", radius=0.10, segments=8, rings=5,
+        location=[-0.58, 0.16, 1.12],
+        material="iron", color=IRON, origin="center",
+    )
+    parts.append("murmillo_boss")
+    # Gladius, held forward. Blade along +Y, which is Godot's -Z.
+    forge.call(
+        "build.box",
+        name="murmillo_gladius", size=[0.045, 0.52, 0.10],
+        location=[0.30, 0.62, 1.20], bevel=0.012,
+        material="iron", color=IRON, origin="center",
+    )
+    parts.append("murmillo_gladius")
+    forge.call(
+        "build.cylinder",
+        name="murmillo_grip", radius=0.035, depth=0.14, segments=6,
+        location=[0.30, 0.30, 1.20],
+        material="rubber", color=LEATHER, origin="center",
+    )
+    spin(forge, "murmillo_grip", [90.0, 0.0, 0.0])
+    parts.append("murmillo_grip")
+    # Manica: the segmented sleeve on the sword arm.
+    for i in range(4):
+        seg = f"murmillo_manica_{i}"
+        forge.call(
+            "build.torus",
+            name=seg, major=0.075, minor=0.022, major_segments=8, minor_segments=4,
+            location=[0.30, 0.10 + i * 0.10, 1.22],
+            material="iron", color=IRON, origin="center",
+        )
+        spin(forge, seg, [90.0, 0.0, 0.0])
+        parts.append(seg)
+    # Galea: bowl, brim and the crest that names him.
+    forge.call(
+        "build.sphere",
+        name="murmillo_galea", radius=0.145, segments=10, rings=6,
+        location=[0.0, 0.0, 1.66],
+        material="bronze", color=BRONZE, origin="center",
+    )
+    parts.append("murmillo_galea")
+    forge.call(
+        "build.torus",
+        name="murmillo_brim", major=0.155, minor=0.030,
+        major_segments=12, minor_segments=4, location=[0.0, 0.0, 1.57],
+        material="bronze", color=BRONZE, origin="center",
+    )
+    parts.append("murmillo_brim")
+    forge.call(
+        "build.wedge",
+        name="murmillo_crest", size=[0.055, 0.30, 0.20],
+        location=[0.0, -0.02, 1.83],
+        material="cloth", color=CREST, origin="center",
+    )
+    parts.append("murmillo_crest")
+    forge.call(
+        "build.cylinder",
+        name="murmillo_greave", radius=0.10, radius_top=0.085, depth=0.40,
+        segments=8, location=[-0.11, 0.02, 0.34],
+        material="bronze", color=BRONZE, origin="center",
+    )
+    parts.append("murmillo_greave")
+    forge.call("object.join", names=parts, into="murmillo")
+    return "murmillo"
+
+
+def build_retiarius(forge):
+    """Trident, net, one shoulder guard, and no helmet at all."""
+    parts = fighter_base(forge, "retiarius", 1.0)
+    # Galerus: the shoulder guard that let him keep his face open.
+    forge.call(
+        "build.box",
+        name="retiarius_galerus", size=[0.14, 0.30, 0.26],
+        location=[-0.26, 0.0, 1.46], bevel=0.03,
+        material="bronze", color=BRONZE, origin="center",
+    )
+    parts.append("retiarius_galerus")
+    for i in range(4):
+        seg = f"retiarius_manica_{i}"
+        forge.call(
+            "build.torus",
+            name=seg, major=0.072, minor=0.020, major_segments=8, minor_segments=4,
+            location=[-0.28, 0.04 + i * 0.09, 1.24],
+            material="iron", color=IRON, origin="center",
+        )
+        spin(forge, seg, [90.0, 0.0, 0.0])
+        parts.append(seg)
+    # The trident: thick enough to survive the silhouette at forty metres.
+    forge.call(
+        "build.cylinder",
+        name="retiarius_shaft", radius=0.048, depth=2.05, segments=8,
+        location=[0.30, 0.42, 1.16],
+        material="wood", color=LEATHER, origin="center",
+    )
+    spin(forge, "retiarius_shaft", [78.0, 0.0, 0.0])
+    parts.append("retiarius_shaft")
+    forge.call(
+        "build.box",
+        name="retiarius_head", size=[0.40, 0.14, 0.09],
+        location=[0.30, 1.32, 1.42],
+        material="iron", color=IRON, origin="center",
+    )
+    parts.append("retiarius_head")
+    for k, dx in enumerate((-0.16, 0.0, 0.16)):
+        prong = f"retiarius_prong_{k}"
+        forge.call(
+            "build.cylinder",
+            name=prong, radius=0.030, radius_top=0.006, depth=0.44,
+            segments=6, location=[0.30 + dx, 1.56, 1.48],
+            material="iron", color=IRON, origin="center",
+        )
+        spin(forge, prong, [78.0, 0.0, 0.0])
+        parts.append(prong)
+    # The net, gathered in the off hand: a hanging sheet, not a ball.
+    forge.call(
+        "build.plane",
+        name="retiarius_net", size=[0.46, 0.52], cuts=3,
+        location=[-0.44, 0.22, 1.02],
+        material="cloth", color=NET, origin="center",
+    )
+    spin(forge, "retiarius_net", [86.0, 0.0, 14.0])
+    parts.append("retiarius_net")
+    forge.call("object.join", names=parts, into="retiarius")
+    return "retiarius"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--render", action="store_true")
+    args = parser.parse_args()
+    OUT.mkdir(parents=True, exist_ok=True)
+
+    with Forge() as forge:
+        forge.call("session.reset")
+        murmillo = build_murmillo(forge)
+        retiarius = build_retiarius(forge)
+        for name in (murmillo, retiarius):
+            forge.call("build.cleanup", name=name, merge_distance=0.001)
+        forge.call("gameready.optimize", objects=[murmillo, retiarius], triangulate=True)
+        forge.call("material.consolidate")
+
+        report = forge.call("check.critique")
+        print("critique :", "errors", report.get("errors"), "warnings", report.get("warnings"))
+
+        glb = OUT / "gladiators.glb"
+        forge.call(
+            "export.gltf",
+            out=str(glb),
+            objects=[murmillo, retiarius],
+            rename={
+                "murmillo": "Murmillo",
+                "retiarius": "Retiarius",
+                "m_cloth": "Tunic",
+                "m_bronze": "Bronze",
+                "m_iron": "Iron",
+                # The net is a second cloth: same preset as the loincloth, a
+                # different colour, so it lands in its own material slot.
+                "m_cloth_2": "Net",
+            },
+        )
+        print("export   :", f"{glb.stat().st_size // 1024} KB -> {glb}")
+        forge.call("session.save", path=str(OUT / "gladiators.blend"))
+        if args.render:
+            forge.call("render.contact_sheet", out=str(OUT / "gladiators.png"))
+            print("sheet    :", OUT / "gladiators.png")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ForgeError as err:
+        print("bforge error:", err, file=sys.stderr)
+        raise SystemExit(1)

--- a/games/chariot/art_source/build_hippodrome.py
+++ b/games/chariot/art_source/build_hippodrome.py
@@ -74,6 +74,33 @@ def stadium_point(s, straight, radius):
     return (-half - math.sin(theta) * radius, math.cos(theta) * radius)
 
 
+def stadium_normal(s, straight, radius):
+    """Outward unit normal at arc length `s`, matching `stadium_point`.
+
+    A stadium is NOT a circle, so `atan2(y, x)` of the point is not the way
+    out. Along a straight the normal is constant while atan2 keeps turning, and
+    on the turns the centre sits at +/- half the straight rather than at the
+    origin, so atan2 is wrong there too. Anything that has to FACE outward —
+    the stair wedges that divide the cavea — needs this, or it ends up stood
+    broadside across the seating it is supposed to cut through.
+    """
+    perimeter = 2.0 * straight + 2.0 * math.pi * radius
+    s = s % perimeter
+    if s < straight:
+        return (0.0, -1.0)
+    s -= straight
+    arc = math.pi * radius
+    if s < arc:
+        theta = s / radius
+        return (math.sin(theta), -math.cos(theta))
+    s -= arc
+    if s < straight:
+        return (0.0, 1.0)
+    s -= straight
+    theta = s / radius
+    return (-math.sin(theta), math.cos(theta))
+
+
 def cavea_profile(stands, podium_offset):
     """Stepped grandstand cross-section, derived from the SHARED stands spec.
 
@@ -155,6 +182,31 @@ def build(forge, spec, quality):
         _timeout=600,
     )
     parts.append("track_surface")
+
+    # --- infield ---------------------------------------------------------
+    # The ground the spina stands on. Without it the middle of the venue is a
+    # HOLE: the consuming game renders a procedural sky, so every camera that
+    # looked across the oval saw straight through the infield to the sky's
+    # brown ground hemisphere, and the centre of the circus read as a pit of
+    # mud. Sits just under the racing surface, so the ribbon and the rails
+    # always win the depth fight along their shared edge; it is wider than the
+    # inner rail on purpose and everything past that edge is covered by the
+    # track, the podium and the cavea.
+    forge.call(
+        "build.plane",
+        name="infield",
+        size=[straight + 2.0 * (radius + inner), 2.0 * (radius + inner)],
+        location=[0.0, 0.0, -0.44],
+        material="sand",
+        # Unraked ground, a shade duller and cooler than the racing harena, so
+        # the ribbon still reads as the surface that matters.
+        color="#9c7d5e",
+        uv="box",
+        uv_scale=12.0,
+        origin="world",
+        cuts=6,
+    )
+    parts.append("infield")
 
     # --- rails ----------------------------------------------------------
     forge.call(

--- a/games/chariot/art_source/build_hippodrome.py
+++ b/games/chariot/art_source/build_hippodrome.py
@@ -192,21 +192,46 @@ def build(forge, spec, quality):
     # always win the depth fight along their shared edge; it is wider than the
     # inner rail on purpose and everything past that edge is covered by the
     # track, the podium and the cavea.
+    # A stadium is a rectangle plus two half-discs — NOT a box. Built as one
+    # plane spanning the whole bounding box, the corners stuck out past the
+    # inner rail at both turns and sliced across the racing surface: a hard
+    # ledge running through the sand, which is what it looked like in game.
+    # Centre panel first, exactly the length of the straights so it cannot
+    # reach the turns at all.
     forge.call(
         "build.plane",
         name="infield",
-        size=[straight + 2.0 * (radius + inner), 2.0 * (radius + inner)],
+        size=[straight, 2.0 * (radius + inner)],
         location=[0.0, 0.0, -0.44],
         material="sand",
-        # Unraked ground, a shade duller and cooler than the racing harena, so
-        # the ribbon still reads as the surface that matters.
         color="#9c7d5e",
         uv="box",
         uv_scale=12.0,
         origin="world",
-        cuts=6,
+        cuts=4,
     )
     parts.append("infield")
+    # ...then a disc at each turn's own centre, which is at +/- half the
+    # straight, never at the origin.
+    for index, sign in enumerate((-1.0, 1.0)):
+        cap = f"infield_turn_{index}"
+        forge.call(
+            "build.cylinder",
+            name=cap,
+            radius=radius + inner,
+            depth=0.04,
+            segments=segments * 2,
+            # A centimetre UNDER the centre panel. Level with it the two
+            # z-fight; proud of it the disc's rim draws a hard line across the
+            # sand where it crosses, which is the seam this leaves behind.
+            location=[sign * straight * 0.5, 0.0, -0.47],
+            material="sand",
+            color="#9c7d5e",
+            uv="box",
+            uv_scale=12.0,
+            origin="center",
+        )
+        parts.append(cap)
 
     # --- rails ----------------------------------------------------------
     forge.call(

--- a/games/chariot/art_source/build_hippodrome.py
+++ b/games/chariot/art_source/build_hippodrome.py
@@ -322,42 +322,15 @@ def build(forge, spec, quality):
     )
     parts.append("attic_colonnade")
 
-    # Vomitoria: the stair wedges that divide the seating into cunei. This
-    # vertical rhythm is half of what the eye reads as "Roman amphitheatre".
-    wedges = {"low": 10, "medium": 18, "high": 26}[quality]
-    # Spacing must be computed on the SAME radius the path is sampled at, or
-    # stadium_point wraps and the wedges bunch instead of dividing the bowl
-    # evenly.
-    wedge_perimeter = 2.0 * straight + 2.0 * math.pi * radius
-    # A vomitorium is a stair cut INTO the rake, not a slab standing on it.
-    # Built as a full-height box it becomes a 36 m blank wall that blots out
-    # half the bowl from any trackside camera — which is exactly how it looked
-    # in the first textured build. Sweeping the cavea profile, raised one step,
-    # along a short arc gives a divider that hugs the seating instead.
-    step_profile = [(lat, vert + 0.8) for lat, vert in cavea_points[:-3]]
-    for index in range(wedges):
-        centre = wedge_perimeter * index / wedges
-        span = 2.2  # metres of arc the stair occupies
-        path = []
-        for offset in (-span * 0.5, 0.0, span * 0.5):
-            px, py = stadium_point(centre + offset, straight, radius)
-            path += [px, py, 0.0]
-        forge.call(
-            "build.sweep",
-            name=f"vomitorium_{index}",
-            profile=flat(step_profile),
-            path=path,
-            path_shape="custom",
-            closed_path=False,
-            closed_profile=False,
-            material="stone",
-            color=STONE_SHADE,
-            uv="box",
-            uv_scale=3.0,
-            origin="world",
-            _timeout=600,
-        )
-        parts.append(f"vomitorium_{index}")
+    # NO STAIR WEDGES. They were built here as full-height blocks standing at
+    # the FRONT of the cavea, so from every seat and every camera in the venue
+    # they were a ring of blank slabs parked in front of the audience — the
+    # first thing anyone looking at this venue asked about. Reshaping them into
+    # rising wedges did not help: at 1.6m wide, 35m deep and 33m tall, the side
+    # face is simply enormous whatever its silhouette, and a divider that hides
+    # the crowd it divides is worth less than no divider at all. The cavea
+    # reads as Roman from the arcade, the attic colonnade and the raked
+    # courses; it does not need this.
 
     # Velarium masts: the awning rig along the rim. Even bare, the ring of
     # masts against the sky is an instantly Roman silhouette.

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -56,6 +56,30 @@ def ellipse(sides=RING, width=1.0, height=1.0):
     return out
 
 
+# How much narrower the top of the section is than the bottom.
+BARREL_TAPER = 0.26
+
+
+def barrel(sides=RING, taper=BARREL_TAPER):
+    """A horse's cross-section, which is an EGG and not an ellipse.
+
+    The belly is broad and round; the back narrows towards the ridge of the
+    spine. Swept with a plain ellipse the whole animal comes out slab-sided —
+    the same width at the backbone as at the deepest part of the barrel — which
+    is most of why it read as a goat rather than a horse.
+
+    The same egg is right the whole way along the sweep: a neck is narrow at the
+    crest and wide where it meets the shoulder, and a head is narrow across the
+    forehead and broad through the jaw.
+    """
+    out = []
+    for index in range(sides):
+        theta = 2.0 * math.pi * index / sides
+        vertical = math.sin(theta)
+        out.extend([math.cos(theta) * (1.0 - taper * vertical), vertical])
+    return out
+
+
 def flat3(points):
     return [value for point in points for value in point]
 
@@ -74,12 +98,16 @@ def flat2(pairs):
 # a llama — which is exactly what the first attempt produced at 0.36 m.
 SPINE = [
     (0.0, -0.86, 1.14),  # dock (tail base)
-    (0.0, -0.66, 1.24),  # croup
-    (0.0, -0.42, 1.24),  # rump: widest point behind
+    # THE WITHERS ARE THE HIGH POINT OF A HORSE. Level with the croup — which
+    # is how this was — the topline reads as a pony or a goat however good the
+    # rest is. The back dips slightly between them, and rises again to the
+    # quarters.
+    (0.0, -0.66, 1.21),  # croup
+    (0.0, -0.42, 1.22),  # rump: widest point behind
     (0.0, -0.14, 1.15),  # loin
-    (0.0, 0.14, 1.14),  # barrel
-    (0.0, 0.34, 1.16),  # girth: deepest part of the horse
-    (0.0, 0.52, 1.22),  # withers
+    (0.0, 0.14, 1.15),  # barrel
+    (0.0, 0.34, 1.18),  # girth: deepest part of the horse
+    (0.0, 0.52, 1.27),  # withers: highest point of the back
     (0.0, 0.68, 1.34),  # base of neck
     (0.0, 0.84, 1.54),  # mid crest
     (0.0, 0.96, 1.68),  # upper crest
@@ -93,16 +121,18 @@ SPINE = [
 # wide-and-shallow through the barrel, narrow-and-deep up the crest of the neck.
 SPINE_SCALE = [
     (0.10, 0.12),  # dock: thin
-    (0.27, 0.26),  # croup: broad and round
-    (0.30, 0.30),  # rump
-    (0.26, 0.32),  # loin: tucks in laterally, stays deep
-    (0.29, 0.36),  # barrel
-    (0.30, 0.37),  # girth: deepest
-    (0.26, 0.34),  # withers
-    (0.19, 0.28),  # neck base
-    (0.15, 0.24),  # crest: narrow and deep
-    (0.12, 0.20),
-    (0.10, 0.15),  # poll
+    (0.28, 0.27),  # croup: broad and round
+    (0.32, 0.31),  # rump: the quarters are the engine, and look it
+    (0.235, 0.30),  # loin: tucks up and in — a racehorse is cut away here
+    (0.29, 0.37),  # barrel
+    (0.31, 0.40),  # girth: deepest, and deeper than the flank by a clear margin
+    (0.25, 0.35),  # withers
+    # DEEP BUT NARROW. A neck as wide as it is deep is a llama's; a horse's is
+    # a blade, tall from crest to gullet and thin across.
+    (0.145, 0.30),  # neck base
+    (0.110, 0.25),  # crest: narrow and deep
+    (0.090, 0.21),
+    (0.078, 0.16),  # poll
     (0.095, 0.13),  # forehead
     (0.075, 0.105),  # nasal
     (0.070, 0.085),  # muzzle
@@ -121,16 +151,19 @@ FORE_LEG = [
     (0.0, 0.04, 0.015),  # pastern
     (0.0, 0.05, 0.0),  # hoof
 ]
+# A foreleg is a heavy muscled forearm running down to a fine cannon — the
+# taper is most of what says "horse". At barely 1.5x from forearm to cannon it
+# was a spindle with a knee drawn on it; a real one is nearer 2.5x.
 FORE_SCALE = [
-    (0.105, 0.115),
-    (0.090, 0.105),
-    (0.072, 0.086),
-    (0.055, 0.070),
-    (0.052, 0.058),
-    (0.036, 0.040),
-    (0.042, 0.044),
-    (0.048, 0.044),
-    (0.056, 0.050),
+    (0.135, 0.150),  # shoulder
+    (0.120, 0.135),  # upper arm
+    (0.100, 0.116),  # elbow
+    (0.078, 0.095),  # forearm: the muscle
+    (0.058, 0.066),  # knee
+    (0.036, 0.044),  # cannon: the fine bone
+    (0.042, 0.048),  # fetlock
+    (0.046, 0.046),  # pastern
+    (0.056, 0.052),  # hoof
 ]
 
 HIND_LEG = [
@@ -184,7 +217,7 @@ def build_horse(forge, quality):
     forge.call(
         "build.sweep",
         name="horse",
-        profile=ellipse(ring),
+        profile=barrel(ring),
         profile_scales=flat2(SPINE_SCALE),
         path=flat3(SPINE),
         path_shape="custom",

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -156,12 +156,23 @@ HIND_SCALE = [
     (0.056, 0.050),
 ]
 
+# WHERE ALONG THE HORSE EACH PAIR OF LEGS STANDS.
+#
+# FORE_LEG and HIND_LEG describe the SHAPE of a leg — the S of a foreleg, the
+# stifle-and-hock zigzag of a hind leg — around their own origin. They were
+# never translated to where the legs actually attach, so all four columns
+# descended at y~0 and every hoof landed in a bunch under the belly, with
+# nothing under the chest and nothing under the quarters. That is what made the
+# gallop read as a kangaroo hop: the animation was fine, the horse had its legs
+# in the wrong place. Rewriting the gait could never have fixed it.
+FORE_Y = 0.38
+HIND_Y = -0.30
 FORE_X = 0.155
 HIND_X = 0.175
 
 
-def offset(points, dx):
-    return [(x + dx, y, z) for x, y, z in points]
+def offset(points, dx, dy=0.0):
+    return [(x + dx, y + dy, z) for x, y, z in points]
 
 
 def build_horse(forge, quality):
@@ -195,7 +206,7 @@ def build_horse(forge, quality):
             name=f"foreleg_{side}",
             profile=ellipse(max(6, ring - 4)),
             profile_scales=flat2(FORE_SCALE),
-            path=flat3(offset(FORE_LEG, sign * FORE_X)),
+            path=flat3(offset(FORE_LEG, sign * FORE_X, FORE_Y)),
             path_shape="custom",
             closed_path=False,
             closed_profile=True,
@@ -211,7 +222,7 @@ def build_horse(forge, quality):
             name=f"hindleg_{side}",
             profile=ellipse(max(6, ring - 4)),
             profile_scales=flat2(HIND_SCALE),
-            path=flat3(offset(HIND_LEG, sign * HIND_X)),
+            path=flat3(offset(HIND_LEG, sign * HIND_X, HIND_Y)),
             path_shape="custom",
             closed_path=False,
             closed_profile=True,
@@ -233,7 +244,7 @@ def build_horse(forge, quality):
             radius_top=0.056,
             depth=0.075,
             segments=8,
-            location=[sign * FORE_X, 0.05, 0.037],
+            location=[sign * FORE_X, 0.05 + FORE_Y, 0.037],
             material="rubber",
             color="#2b2118",
             uv="cylinder",
@@ -247,7 +258,7 @@ def build_horse(forge, quality):
             radius_top=0.056,
             depth=0.075,
             segments=8,
-            location=[sign * HIND_X, 0.03, 0.037],
+            location=[sign * HIND_X, 0.03 + HIND_Y, 0.037],
             material="rubber",
             color="#2b2118",
             uv="cylinder",
@@ -579,49 +590,49 @@ def horse_bones():
             {
                 "name": f"shoulder_{side}",
                 "head": [0, 0.40, 1.12],
-                "tail": [x_f, 0.04, 0.98],
+                "tail": [x_f, 0.04 + FORE_Y, 0.98],
                 "parent": "chest",
             },
             {
                 "name": f"forearm_{side}",
-                "head": [x_f, 0.04, 0.98],
-                "tail": [x_f, 0.00, 0.44],
+                "head": [x_f, 0.04 + FORE_Y, 0.98],
+                "tail": [x_f, 0.00 + FORE_Y, 0.44],
                 "parent": f"shoulder_{side}",
             },
             {
                 "name": f"fore_cannon_{side}",
-                "head": [x_f, 0.00, 0.44],
-                "tail": [x_f, 0.01, 0.10],
+                "head": [x_f, 0.00 + FORE_Y, 0.44],
+                "tail": [x_f, 0.01 + FORE_Y, 0.10],
                 "parent": f"forearm_{side}",
             },
             {
                 "name": f"fore_hoof_{side}",
-                "head": [x_f, 0.01, 0.10],
-                "tail": [x_f, 0.06, 0.0],
+                "head": [x_f, 0.01 + FORE_Y, 0.10],
+                "tail": [x_f, 0.06 + FORE_Y, 0.0],
                 "parent": f"fore_cannon_{side}",
             },
             {
                 "name": f"thigh_{side}",
                 "head": [0, -0.30, 1.10],
-                "tail": [x_h, -0.03, 0.66],
+                "tail": [x_h, -0.03 + HIND_Y, 0.66],
                 "parent": "croup",
             },
             {
                 "name": f"gaskin_{side}",
-                "head": [x_h, -0.03, 0.66],
-                "tail": [x_h, -0.11, 0.34],
+                "head": [x_h, -0.03 + HIND_Y, 0.66],
+                "tail": [x_h, -0.11 + HIND_Y, 0.34],
                 "parent": f"thigh_{side}",
             },
             {
                 "name": f"hind_cannon_{side}",
-                "head": [x_h, -0.11, 0.34],
-                "tail": [x_h, -0.01, 0.10],
+                "head": [x_h, -0.11 + HIND_Y, 0.34],
+                "tail": [x_h, -0.01 + HIND_Y, 0.10],
                 "parent": f"gaskin_{side}",
             },
             {
                 "name": f"hind_hoof_{side}",
-                "head": [x_h, -0.01, 0.10],
-                "tail": [x_h, 0.04, 0.0],
+                "head": [x_h, -0.01 + HIND_Y, 0.10],
+                "tail": [x_h, 0.04 + HIND_Y, 0.0],
                 "parent": f"hind_cannon_{side}",
             },
         ]

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -655,9 +655,46 @@ LEG_PHASE = {
 }
 # Each joint down a limb lags the one above it and swings less: that delay is
 # what makes a leg look jointed rather than like a swinging stick.
-JOINT_LAG = 0.08
-HIND_SWING = (34.0, 30.0, 20.0)   # thigh, gaskin, cannon amplitudes
-FORE_SWING = (32.0, 30.0, 26.0)   # shoulder, forearm, cannon
+# A LEG JOINT ONLY BENDS ONE WAY.
+#
+# The hip and shoulder swing fore and aft, so a sine is right for them. A hock
+# or a knee does not: it flexes from straight and returns to straight, and it
+# cannot go past straight in the other direction. Driving them with a sine like
+# the hip meant that for half of every stride they bent FORWARD through
+# straight — a hyperextension no horse can make — which is the cross-legged,
+# broken-stick look the gallop had.
+#
+# Flexion is therefore a raised cosine pinned at zero: fully folded at mid-swing
+# when the leg is passing under the body, dead straight at mid-stance when it is
+# carrying weight, and never once positive.
+JOINT_LAG = 0.05
+# A galloping horse reaches: the lead foreleg swings well ahead of the chest and
+# the hind legs drive out behind the quarters. Small amplitudes read as a horse
+# running on the spot, which is what these were.
+HIND_SWING = 42.0                 # hip, fore and aft
+HIND_FLEX = (62.0, 34.0)          # gaskin (hock), cannon — flexion only
+FORE_SWING = 44.0                 # shoulder, fore and aft
+FORE_FLEX = (68.0, 28.0)          # forearm (knee), cannon — flexion only
+
+
+def _flex(turn, phase, amplitude, lag=0.0):
+    """One joint's flexion, in degrees, always <= 0.
+
+    All the folding happens inside the SWING half of the stride and none of it
+    outside. The leg leaves the ground straight, folds tightly as it passes
+    under the body, and is straight again by the time it reaches out to land;
+    through the whole stance it is dead straight, carrying the horse.
+
+    A cosine that merely peaks at mid-swing is not the same thing — it leaves
+    the leg still half folded at the moment it should be reaching, so the horse
+    paws at the ground instead of striding, and never covers any distance.
+    """
+    turned = (turn - phase - lag) % 1.0
+    # Stance is 0.25..0.75 of the cycle: forward-most, planted, to backward-most.
+    swing = ((turned - 0.75) % 1.0) / 0.5
+    if swing > 1.0:
+        return 0.0
+    return -amplitude * math.sin(math.pi * swing)
 
 
 def _swing(turn, phase, amplitude, lag=0.0):
@@ -678,24 +715,26 @@ def gallop_keys(length):
         pose = {}
         for side, leg in (("l", "hind_l"), ("r", "hind_r")):
             phase = LEG_PHASE[leg]
-            thigh, gaskin, cannon = HIND_SWING
-            pose[f"thigh_{side}"] = [_swing(turn, phase, thigh), 0, 0]
-            # The gaskin folds AGAINST the thigh — a leg that folds the same
-            # way it swings is a stilt.
-            pose[f"gaskin_{side}"] = [-_swing(turn, phase, gaskin, JOINT_LAG), 0, 0]
-            pose[f"hind_cannon_{side}"] = [_swing(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
+            gaskin, cannon = HIND_FLEX
+            # Positive is forward, measured off the rig rather than guessed.
+            pose[f"thigh_{side}"] = [_swing(turn, phase, HIND_SWING), 0, 0]
+            pose[f"gaskin_{side}"] = [_flex(turn, phase, gaskin, JOINT_LAG), 0, 0]
+            pose[f"hind_cannon_{side}"] = [_flex(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
         for side, leg in (("l", "fore_l"), ("r", "fore_r")):
             phase = LEG_PHASE[leg]
-            shoulder, forearm, cannon = FORE_SWING
-            pose[f"shoulder_{side}"] = [_swing(turn, phase, shoulder), 0, 0]
-            pose[f"forearm_{side}"] = [-_swing(turn, phase, forearm, JOINT_LAG), 0, 0]
-            pose[f"fore_cannon_{side}"] = [_swing(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
+            forearm, cannon = FORE_FLEX
+            pose[f"shoulder_{side}"] = [_swing(turn, phase, FORE_SWING), 0, 0]
+            pose[f"forearm_{side}"] = [_flex(turn, phase, forearm, JOINT_LAG), 0, 0]
+            pose[f"fore_cannon_{side}"] = [_flex(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
         # The back rounds and extends once per stride; the neck and head work
         # against it, which is the counterweight a galloping horse actually is.
-        pose["spine"] = [4.5 * math.sin(2.0 * math.pi * turn), 0, 0]
-        pose["croup"] = [-7.0 * math.sin(2.0 * math.pi * turn), 0, 0]
-        pose["neck"] = [-9.0 * math.sin(2.0 * math.pi * turn + 0.6), 0, 0]
-        pose["head"] = [6.0 * math.sin(2.0 * math.pi * turn + 1.1), 0, 0]
+        # A galloping horse's head and neck are a COUNTERWEIGHT, swinging
+        # against the back once per stride. At a few degrees it reads as a
+        # stiff-necked rocking-horse; this is the motion that sells the effort.
+        pose["spine"] = [6.0 * math.sin(2.0 * math.pi * turn), 0, 0]
+        pose["croup"] = [-9.0 * math.sin(2.0 * math.pi * turn), 0, 0]
+        pose["neck"] = [-15.0 * math.sin(2.0 * math.pi * turn + 0.6), 0, 0]
+        pose["head"] = [9.0 * math.sin(2.0 * math.pi * turn + 1.1), 0, 0]
         pose["tail_a"] = [-20.0 - 8.0 * math.sin(2.0 * math.pi * turn), 0, 0]
         pose["tail_b"] = [-13.0 - 6.0 * math.sin(2.0 * math.pi * turn + 0.5), 0, 0]
         frames[frame] = {bone: [round(v, 2) for v in angles] for bone, angles in pose.items()}
@@ -718,7 +757,11 @@ def gallop_locations(length):
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--quality", default="medium", choices=["low", "medium", "high"]
+        # HIGH by default. The horse is the thing the camera is pointed at for
+        # a whole race and it was shipping at 1,488 triangles against a 6,000
+        # budget — a quarter of what it was allowed, spent on a silhouette that
+        # goes faceted the moment it fills the frame.
+        "--quality", default="high", choices=["low", "medium", "high"]
     )
     parser.add_argument("--render", action="store_true")
     parser.add_argument("--install", action="store_true")

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -725,27 +725,55 @@ FORE_SWING = 44.0                 # shoulder, fore and aft
 FORE_FLEX = (68.0, 28.0)          # forearm (knee), cannon — flexion only
 
 
+# A GALLOPING HORSE IS AIRBORNE MOST OF THE TIME.
+#
+# Each hoof is on the ground for about a quarter of a stride, not half of it.
+# The difference is not cosmetic, it is the whole reason the gait reads as
+# floating: at 16.5 m/s on a 0.533s cycle the body travels 4.4m during a
+# half-cycle stance, while the leg can only sweep 1.42m back relative to the
+# body (2 x 1.06m x sin 42). The other 3m is the planted hoof skating forward
+# across the sand. Cutting stance to 0.30 cuts that error by more than half,
+# and it is what a horse actually does.
+STANCE = 0.30
+
+
 def _flex(turn, phase, amplitude, lag=0.0):
     """One joint's flexion, in degrees, always <= 0.
 
-    All the folding happens inside the SWING half of the stride and none of it
-    outside. The leg leaves the ground straight, folds tightly as it passes
-    under the body, and is straight again by the time it reaches out to land;
-    through the whole stance it is dead straight, carrying the horse.
+    Dead straight through the whole stance, carrying the horse. All the folding
+    happens airborne: the leg leaves the ground straight, folds tightly as it
+    passes under the body, and is straight again by the time it reaches out to
+    land.
 
     A cosine that merely peaks at mid-swing is not the same thing — it leaves
     the leg still half folded at the moment it should be reaching, so the horse
     paws at the ground instead of striding, and never covers any distance.
     """
     turned = (turn - phase - lag) % 1.0
-    # Stance is 0.25..0.75 of the cycle: forward-most, planted, to backward-most.
-    swing = ((turned - 0.75) % 1.0) / 0.5
-    if swing > 1.0:
+    if turned < STANCE:
         return 0.0
+    swing = (turned - STANCE) / (1.0 - STANCE)
     return -amplitude * math.sin(math.pi * swing)
 
 
 def _swing(turn, phase, amplitude, lag=0.0):
+    """Hip or shoulder angle: forward is positive.
+
+    Two different motions, not one sine. While the hoof is PLANTED the horse
+    rotates over it at a constant rate, so the angle runs from full forward to
+    full back in a straight line — that steady sweep is what keeps a planted
+    foot still against the ground. Once it is airborne the leg swings back to
+    the front on an eased curve. Both halves meet at the same angle, so the
+    join never snaps.
+    """
+    turned = (turn - phase - lag) % 1.0
+    if turned < STANCE:
+        return amplitude * (1.0 - 2.0 * (turned / STANCE))
+    airborne = (turned - STANCE) / (1.0 - STANCE)
+    return -amplitude * math.cos(math.pi * airborne)
+
+
+def _sine_swing(turn, phase, amplitude, lag=0.0):
     """One joint's angle at this point in the stride."""
     return amplitude * math.sin(2.0 * math.pi * (turn - phase - lag))
 

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -843,10 +843,24 @@ def gallop_keys(length):
         # stiff-necked rocking-horse; this is the motion that sells the effort.
         pose["spine"] = [6.0 * math.sin(2.0 * math.pi * turn), 0, 0]
         pose["croup"] = [-9.0 * math.sin(2.0 * math.pi * turn), 0, 0]
-        pose["neck"] = [-15.0 * math.sin(2.0 * math.pi * turn + 0.6), 0, 0]
-        pose["head"] = [9.0 * math.sin(2.0 * math.pi * turn + 1.1), 0, 0]
-        pose["tail_a"] = [-20.0 - 8.0 * math.sin(2.0 * math.pi * turn), 0, 0]
-        pose["tail_b"] = [-13.0 - 6.0 * math.sin(2.0 * math.pi * turn + 0.5), 0, 0]
+        # A GALLOPING HORSE REACHES WITH ITS HEAD. It does not run in the
+        # collected, head-up carriage of a dressage horse — it stretches the
+        # neck out and low and drives from behind. These oscillated around the
+        # REST carriage, so the animal nodded politely while sprinting.
+        #
+        # Measured, not guessed: negative neck takes the muzzle from 2.08m down
+        # to 1.65m and pushes it forward, so the extension is a negative BIAS
+        # under the swing. The head takes a small positive bias back so the face
+        # stays level instead of pointing at the sand.
+        pose["neck"] = [-20.0 - 15.0 * math.sin(2.0 * math.pi * turn + 0.6), 0, 0]
+        pose["head"] = [8.0 + 9.0 * math.sin(2.0 * math.pi * turn + 1.1), 0, 0]
+        # And the tail STREAMS. Negative extends it back — rear reach goes 1.16m
+        # at rest to 1.46m by -40 — so at a gallop it flies out behind instead
+        # of hanging off the quarters like a rope. It is only ever the gallop
+        # clip: stop the animation and the horse returns to its rest pose with
+        # the tail down, which is what a standing horse does.
+        pose["tail_a"] = [-42.0 - 8.0 * math.sin(2.0 * math.pi * turn), 0, 0]
+        pose["tail_b"] = [-24.0 - 7.0 * math.sin(2.0 * math.pi * turn + 0.5), 0, 0]
         frames[frame] = {bone: [round(v, 2) for v in angles] for bone, angles in pose.items()}
     frames[length] = dict(frames[1])
     return {str(k): v for k, v in frames.items()}

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -719,10 +719,26 @@ JOINT_LAG = 0.05
 # A galloping horse reaches: the lead foreleg swings well ahead of the chest and
 # the hind legs drive out behind the quarters. Small amplitudes read as a horse
 # running on the spot, which is what these were.
-HIND_SWING = 42.0                 # hip, fore and aft
-HIND_FLEX = (62.0, 34.0)          # gaskin (hock), cannon — flexion only
-FORE_SWING = 44.0                 # shoulder, fore and aft
-FORE_FLEX = (68.0, 28.0)          # forearm (knee), cannon — flexion only
+HIND_SWING = 50.0                 # hip, fore and aft
+HIND_FLEX = (66.0, 36.0)          # gaskin (hock), cannon — flexion only
+FORE_SWING = 50.0                 # shoulder, fore and aft
+FORE_FLEX = (72.0, 30.0)          # forearm (knee), cannon — flexion only
+
+# HOW FAR THE ANIMATION ITSELF SAYS ONE STRIDE COVERS.
+#
+# This is not a taste value, it falls out of the geometry: a planted hoof has to
+# stay still, so the ground the body covers during stance must equal the sweep
+# of the leg over the same time. Sweep is 2 * (hip height) * sin(swing), and
+# stance is STANCE of the cycle:
+#
+#     stride = 2 * 1.10 * sin(50 deg) / 0.30 = 5.62 m
+#
+# The client divides by this to pick the playback rate, so the hooves hold the
+# ground at ANY speed instead of only at the one the clip happened to suit.
+# Change the swing or the stance and this changes with it — recompute, do not
+# guess, and keep the number in step with games/chariot/project (track_spec's
+# neighbours) via the constant in broadcast_view.gd.
+HIP_HEIGHT_M = 1.10
 
 
 # A GALLOPING HORSE IS AIRBORNE MOST OF THE TIME.
@@ -916,9 +932,10 @@ def main() -> int:
             loop=True,
             _timeout=600,
         )
+        stride = 2.0 * HIP_HEIGHT_M * math.sin(math.radians(HIND_SWING)) / STANCE
         print(
             f"gallop   : {clip['fcurves']} curves, {clip['keyframes']} keys, "
-            f"{clip['frames']} frames"
+            f"{clip['frames']} frames, stride {stride:.2f} m"
         )
 
         check = forge.call("check.asset", triangle_budget=6000, material_budget=6)

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -628,102 +628,66 @@ def horse_bones():
     return bones
 
 
-def gallop_keys(length):
-    """A transverse gallop: a four-beat asymmetric gait with a suspension phase.
+# A transverse gallop is FOUR separate beats, and the whole difference between
+# a gallop and a bound is that the four legs are out of PHASE with each other.
+# The hand-authored poses this replaces moved left and right together — thigh_l
+# and thigh_r both swinging forward, then both back — which is a bound, the
+# gait a rabbit or a kangaroo uses. It read exactly like that in game.
+#
+# Footfall order, left lead: off-hind, near-hind, off-fore, near-fore, then all
+# four leave the ground. These are fractions of one stride.
+LEG_PHASE = {
+    "hind_r": 0.00,
+    "hind_l": 0.13,
+    "fore_r": 0.47,
+    "fore_l": 0.60,
+}
+# Each joint down a limb lags the one above it and swings less: that delay is
+# what makes a leg look jointed rather than like a swinging stick.
+JOINT_LAG = 0.08
+HIND_SWING = (34.0, 30.0, 20.0)   # thigh, gaskin, cannon amplitudes
+FORE_SWING = (32.0, 30.0, 26.0)   # shoulder, forearm, cannon
 
-    Not a trot and not a sine wave. The sequence is
-    off-hind, near-hind, off-fore, near-fore, then all four feet leave the
-    ground. Diagonal pairs are deliberately OFFSET — a horse whose legs move in
-    symmetric pairs reads as a rocking-horse toy, which is exactly what the
-    previous model looked like.
+
+def _swing(turn, phase, amplitude, lag=0.0):
+    """One joint's angle at this point in the stride."""
+    return amplitude * math.sin(2.0 * math.pi * (turn - phase - lag))
+
+
+def gallop_keys(length):
+    """A four-beat transverse gallop, generated from per-leg phase offsets.
+
+    Driving every joint from one phase per leg makes it impossible for the two
+    hinds (or the two fores) to move together by accident, which is the failure
+    the hand-written version had.
     """
-    q = max(1, length // 4)
-    frames = {
-        # 1: gathered — hind legs reaching forward under the body, back rounded
-        1: {
-            "spine": [-4, 0, 0],
-            "croup": [7, 0, 0],
-            "neck": [10, 0, 0],
-            "head": [-8, 0, 0],
-            "thigh_l": [-38, 0, 0],
-            "gaskin_l": [56, 0, 0],
-            "hind_cannon_l": [-34, 0, 0],
-            "thigh_r": [-24, 0, 0],
-            "gaskin_r": [44, 0, 0],
-            "hind_cannon_r": [-26, 0, 0],
-            "shoulder_l": [30, 0, 0],
-            "forearm_l": [-46, 0, 0],
-            "fore_cannon_l": [40, 0, 0],
-            "shoulder_r": [40, 0, 0],
-            "forearm_r": [-58, 0, 0],
-            "fore_cannon_r": [48, 0, 0],
-            "tail_a": [-16, 0, 0],
-            "tail_b": [-10, 0, 0],
-        },
-        # 2: hind drive — hindquarters push off, forelegs begin to reach
-        q: {
-            "spine": [3, 0, 0],
-            "croup": [-6, 0, 0],
-            "neck": [-4, 0, 0],
-            "head": [4, 0, 0],
-            "thigh_l": [26, 0, 0],
-            "gaskin_l": [-14, 0, 0],
-            "hind_cannon_l": [8, 0, 0],
-            "thigh_r": [34, 0, 0],
-            "gaskin_r": [-6, 0, 0],
-            "hind_cannon_r": [4, 0, 0],
-            "shoulder_l": [-14, 0, 0],
-            "forearm_l": [-8, 0, 0],
-            "fore_cannon_l": [6, 0, 0],
-            "shoulder_r": [4, 0, 0],
-            "forearm_r": [-26, 0, 0],
-            "fore_cannon_r": [22, 0, 0],
-            "tail_a": [-26, 0, 0],
-            "tail_b": [-18, 0, 0],
-        },
-        # 3: extension — front legs stretched out, hind trailing behind
-        q * 2: {
-            "spine": [5, 0, 0],
-            "croup": [-9, 0, 0],
-            "neck": [-12, 0, 0],
-            "head": [8, 0, 0],
-            "thigh_l": [40, 0, 0],
-            "gaskin_l": [-26, 0, 0],
-            "hind_cannon_l": [14, 0, 0],
-            "thigh_r": [30, 0, 0],
-            "gaskin_r": [-18, 0, 0],
-            "hind_cannon_r": [10, 0, 0],
-            "shoulder_l": [-34, 0, 0],
-            "forearm_l": [10, 0, 0],
-            "fore_cannon_l": [-6, 0, 0],
-            "shoulder_r": [-22, 0, 0],
-            "forearm_r": [-2, 0, 0],
-            "fore_cannon_r": [2, 0, 0],
-            "tail_a": [-30, 0, 0],
-            "tail_b": [-22, 0, 0],
-        },
-        # 4: suspension — legs folding back under, body at its highest
-        q * 3: {
-            "spine": [-2, 0, 0],
-            "croup": [4, 0, 0],
-            "neck": [4, 0, 0],
-            "head": [-4, 0, 0],
-            "thigh_l": [-8, 0, 0],
-            "gaskin_l": [28, 0, 0],
-            "hind_cannon_l": [-18, 0, 0],
-            "thigh_r": [4, 0, 0],
-            "gaskin_r": [16, 0, 0],
-            "hind_cannon_r": [-12, 0, 0],
-            "shoulder_l": [10, 0, 0],
-            "forearm_l": [-38, 0, 0],
-            "fore_cannon_l": [34, 0, 0],
-            "shoulder_r": [22, 0, 0],
-            "forearm_r": [-48, 0, 0],
-            "fore_cannon_r": [42, 0, 0],
-            "tail_a": [-22, 0, 0],
-            "tail_b": [-14, 0, 0],
-        },
-    }
+    frames = {}
+    for frame in range(1, length + 1):
+        turn = float(frame - 1) / float(length)
+        pose = {}
+        for side, leg in (("l", "hind_l"), ("r", "hind_r")):
+            phase = LEG_PHASE[leg]
+            thigh, gaskin, cannon = HIND_SWING
+            pose[f"thigh_{side}"] = [_swing(turn, phase, thigh), 0, 0]
+            # The gaskin folds AGAINST the thigh — a leg that folds the same
+            # way it swings is a stilt.
+            pose[f"gaskin_{side}"] = [-_swing(turn, phase, gaskin, JOINT_LAG), 0, 0]
+            pose[f"hind_cannon_{side}"] = [_swing(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
+        for side, leg in (("l", "fore_l"), ("r", "fore_r")):
+            phase = LEG_PHASE[leg]
+            shoulder, forearm, cannon = FORE_SWING
+            pose[f"shoulder_{side}"] = [_swing(turn, phase, shoulder), 0, 0]
+            pose[f"forearm_{side}"] = [-_swing(turn, phase, forearm, JOINT_LAG), 0, 0]
+            pose[f"fore_cannon_{side}"] = [_swing(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
+        # The back rounds and extends once per stride; the neck and head work
+        # against it, which is the counterweight a galloping horse actually is.
+        pose["spine"] = [4.5 * math.sin(2.0 * math.pi * turn), 0, 0]
+        pose["croup"] = [-7.0 * math.sin(2.0 * math.pi * turn), 0, 0]
+        pose["neck"] = [-9.0 * math.sin(2.0 * math.pi * turn + 0.6), 0, 0]
+        pose["head"] = [6.0 * math.sin(2.0 * math.pi * turn + 1.1), 0, 0]
+        pose["tail_a"] = [-20.0 - 8.0 * math.sin(2.0 * math.pi * turn), 0, 0]
+        pose["tail_b"] = [-13.0 - 6.0 * math.sin(2.0 * math.pi * turn + 0.5), 0, 0]
+        frames[frame] = {bone: [round(v, 2) for v in angles] for bone, angles in pose.items()}
     frames[length] = dict(frames[1])
     return {str(k): v for k, v in frames.items()}
 

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -341,18 +341,29 @@ def build_horse(forge, quality):
     parts.append("jaw")
 
     # --- mane: a crest strip, swept along the neck -----------------------
+    # A MANE SITS ON THE CREST, NOT INSIDE THE NECK.
+    #
+    # This path used to follow the spine's own centreline, which is where the
+    # sweep for the NECK is generated from — so the whole mane was buried a
+    # quarter of a metre inside the animal and had never once been visible. It
+    # is the neck's TOP SURFACE that is wanted: the spine station plus that
+    # station's vertical half-scale.
+    # A mane runs from the WITHERS to the poll, not just the top third — and it
+    # sits a little proud of the crest so the hair stands off the neck.
     mane_path = [
-        (0.0, 0.72, 1.30),
-        (0.0, 0.84, 1.52),
-        (0.0, 0.96, 1.70),
-        (0.0, 1.04, 1.82),
-        (0.0, 1.10, 1.84),
+        (0.0, 0.54, 1.65),  # withers:    1.27 + 0.35, where the mane starts
+        (0.0, 0.70, 1.68),  # neck base:  1.34 + 0.30
+        (0.0, 0.84, 1.83),  # mid crest:  1.54 + 0.25
+        (0.0, 0.96, 1.92),  # upper:      1.68 + 0.21
+        (0.0, 1.06, 1.94),  # poll:       1.76 + 0.16
     ]
     forge.call(
         "build.sweep",
         name="mane",
         profile=[-0.018, -0.10, 0.018, -0.10, 0.030, 0.055, -0.030, 0.055],
-        profile_scales=[0.7, 0.55, 1.0, 1.0, 1.0, 0.95, 0.8, 0.6, 0.5, 0.3],
+        # Fuller along the crest so it reads at race distance instead of
+        # vanishing into the neck it sits on.
+        profile_scales=[1.05, 0.95, 1.30, 1.25, 1.35, 1.25, 1.15, 1.00, 0.80, 0.55],
         path=flat3(mane_path),
         path_shape="custom",
         closed_path=False,
@@ -395,17 +406,21 @@ def build_horse(forge, quality):
         "build.sweep",
         name="tail",
         profile=ellipse(8),
+        # A TAIL IS A MASS OF HAIR, NOT A CONE. Tapering steadily to 0.022 gave
+        # a rat's tail — a smooth horn coming off the quarters. A real one is
+        # thin only at the dock, swells immediately below it where the hair
+        # falls, and carries most of that volume nearly to the end.
         profile_scales=[
-            0.085,
-            0.095,
-            0.078,
-            0.090,
-            0.062,
             0.075,
-            0.042,
-            0.052,
-            0.022,
-            0.028,
+            0.085,   # dock: the bone, and the only thin part
+            0.105,
+            0.130,   # the hair takes over and it thickens at once
+            0.105,
+            0.140,
+            0.085,
+            0.125,
+            0.055,
+            0.085,   # still full at the tip, not a point
         ],
         path=flat3(tail_path),
         path_shape="custom",

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -768,8 +768,33 @@ HIP_HEIGHT_M = 1.10
 # and it is what a horse actually does.
 STANCE = 0.30
 
+# Where each limb pivots, in metres off the ground. thigh_* turns about its head
+# at 1.10 and shoulder_* about its head at 1.12, so a hind leg and a fore leg
+# sweep slightly different arcs for the same angle.
+HIND_PIVOT_M = 1.10
+FORE_PIVOT_M = 1.12
 
-def _flex(turn, phase, amplitude, lag=0.0):
+
+def limb_sweep(pivot_m, swing_deg):
+    """How far this limb's foot travels backward relative to the body."""
+    return 2.0 * pivot_m * math.sin(math.radians(swing_deg))
+
+
+def _stride_m():
+    """Ground one stride covers — the mean of what the four limbs sweep.
+
+    Every limb then takes `its own sweep / this` as its stance fraction, which
+    is what makes each planted foot hold still. Averaging over the four is what
+    keeps those fractions centred on STANCE rather than drifting off it.
+    """
+    from_limbs = []
+    for reach in (LEAD_REACH, OFF_REACH):
+        from_limbs.append(limb_sweep(HIND_PIVOT_M, HIND_SWING * reach))
+        from_limbs.append(limb_sweep(FORE_PIVOT_M, FORE_SWING * reach))
+    return sum(from_limbs) / len(from_limbs) / STANCE
+
+
+def _flex(turn, phase, amplitude, stance, lag=0.0):
     """One joint's flexion, in degrees, always <= 0.
 
     Dead straight through the whole stance, carrying the horse. All the folding
@@ -782,13 +807,13 @@ def _flex(turn, phase, amplitude, lag=0.0):
     paws at the ground instead of striding, and never covers any distance.
     """
     turned = (turn - phase - lag) % 1.0
-    if turned < STANCE:
+    if turned < stance:
         return 0.0
-    swing = (turned - STANCE) / (1.0 - STANCE)
+    swing = (turned - stance) / (1.0 - stance)
     return -amplitude * math.sin(math.pi * swing)
 
 
-def _swing(turn, phase, amplitude, lag=0.0):
+def _swing(turn, phase, amplitude, stance, lag=0.0):
     """Hip or shoulder angle: forward is positive.
 
     Two different motions, not one sine. While the hoof is PLANTED the horse
@@ -799,15 +824,20 @@ def _swing(turn, phase, amplitude, lag=0.0):
     join never snaps.
     """
     turned = (turn - phase - lag) % 1.0
-    if turned < STANCE:
-        return amplitude * (1.0 - 2.0 * (turned / STANCE))
-    airborne = (turned - STANCE) / (1.0 - STANCE)
+    if turned < stance:
+        return amplitude * (1.0 - 2.0 * (turned / stance))
+    airborne = (turned - stance) / (1.0 - stance)
     return -amplitude * math.cos(math.pi * airborne)
 
 
 def _sine_swing(turn, phase, amplitude, lag=0.0):
     """One joint's angle at this point in the stride."""
     return amplitude * math.sin(2.0 * math.pi * (turn - phase - lag))
+
+
+# Fixed at import, once every constant it depends on exists. The build prints
+# it and broadcast_view.gd holds the same number as GALLOP_STRIDE_M.
+STRIDE_M = _stride_m()
 
 
 def gallop_keys(length):
@@ -821,21 +851,37 @@ def gallop_keys(length):
     for frame in range(1, length + 1):
         turn = float(frame - 1) / float(length)
         pose = {}
+        # EACH LIMB IS ON THE GROUND FOR ITS OWN LENGTH OF TIME.
+        #
+        # Once the lead limb reaches further than its partner, one stance
+        # fraction cannot serve both: the horse's body covers the same ground
+        # per stride whatever the leg is doing, so a limb that sweeps 1.89m and
+        # a limb that sweeps 1.50m must be down for different lengths of time or
+        # one of them is dragging. A real gallop does exactly this — the four
+        # contact times are not equal — and it is the last of the slip.
+        #
+        # The rule falls out of the requirement itself: stance = sweep / stride.
         for side, leg in (("l", "hind_l"), ("r", "hind_r")):
             phase = LEG_PHASE[leg]
             gaskin, cannon = HIND_FLEX
             reach = LEAD_REACH if side == LEAD_SIDE else OFF_REACH
+            swing_deg = HIND_SWING * reach
+            stance = limb_sweep(HIND_PIVOT_M, swing_deg) / STRIDE_M
             # Positive is forward, measured off the rig rather than guessed.
-            pose[f"thigh_{side}"] = [_swing(turn, phase, HIND_SWING * reach), 0, 0]
-            pose[f"gaskin_{side}"] = [_flex(turn, phase, gaskin, JOINT_LAG), 0, 0]
-            pose[f"hind_cannon_{side}"] = [_flex(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
+            pose[f"thigh_{side}"] = [_swing(turn, phase, swing_deg, stance), 0, 0]
+            pose[f"gaskin_{side}"] = [_flex(turn, phase, gaskin, stance, JOINT_LAG), 0, 0]
+            pose[f"hind_cannon_{side}"] = [
+                _flex(turn, phase, cannon, stance, 2.0 * JOINT_LAG), 0, 0]
         for side, leg in (("l", "fore_l"), ("r", "fore_r")):
             phase = LEG_PHASE[leg]
             forearm, cannon = FORE_FLEX
             reach = LEAD_REACH if side == LEAD_SIDE else OFF_REACH
-            pose[f"shoulder_{side}"] = [_swing(turn, phase, FORE_SWING * reach), 0, 0]
-            pose[f"forearm_{side}"] = [_flex(turn, phase, forearm, JOINT_LAG), 0, 0]
-            pose[f"fore_cannon_{side}"] = [_flex(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
+            swing_deg = FORE_SWING * reach
+            stance = limb_sweep(FORE_PIVOT_M, swing_deg) / STRIDE_M
+            pose[f"shoulder_{side}"] = [_swing(turn, phase, swing_deg, stance), 0, 0]
+            pose[f"forearm_{side}"] = [_flex(turn, phase, forearm, stance, JOINT_LAG), 0, 0]
+            pose[f"fore_cannon_{side}"] = [
+                _flex(turn, phase, cannon, stance, 2.0 * JOINT_LAG), 0, 0]
         # The back rounds and extends once per stride; the neck and head work
         # against it, which is the counterweight a galloping horse actually is.
         # A galloping horse's head and neck are a COUNTERWEIGHT, swinging
@@ -964,17 +1010,7 @@ def main() -> int:
             loop=True,
             _timeout=600,
         )
-        # The lead limb reaches further than its partner, so no single limb's
-        # sweep is "the" stride — the horse's body travel is their mean, and
-        # that is the number the client has to divide by.
-        stride = (
-            HIP_HEIGHT_M
-            * (
-                math.sin(math.radians(HIND_SWING * LEAD_REACH))
-                + math.sin(math.radians(HIND_SWING * OFF_REACH))
-            )
-            / STANCE
-        )
+        stride = STRIDE_M
         print(
             f"gallop   : {clip['fcurves']} curves, {clip['keyframes']} keys, "
             f"{clip['frames']} frames, stride {stride:.2f} m"

--- a/games/chariot/art_source/build_racing_horse.py
+++ b/games/chariot/art_source/build_racing_horse.py
@@ -701,6 +701,22 @@ LEG_PHASE = {
     "fore_r": 0.47,
     "fore_l": 0.60,
 }
+
+# A GALLOP IS NOT SYMMETRIC. It has a LEAD.
+#
+# The footfall order above — off-hind, near-hind, off-fore, near-fore — is a
+# LEFT lead: the near fore lands last and reaches furthest, and it is the limb
+# the horse balances the whole stride around. Giving both sides the same
+# amplitude produces a gait that is technically four-beat and still reads
+# mechanical, because a real horse is visibly lopsided and every photograph of
+# one shows it.
+#
+# Left is also the correct lead to bake for this track. The oval turns one way,
+# horses lead with the INSIDE leg, and a single clip can only carry one lead —
+# so it should be the one the corners actually ask for.
+LEAD_SIDE = "l"
+LEAD_REACH = 1.18     # the leading limb swings this much further
+OFF_REACH = 0.86      # and its partner correspondingly less
 # Each joint down a limb lags the one above it and swings less: that delay is
 # what makes a leg look jointed rather than like a swinging stick.
 # A LEG JOINT ONLY BENDS ONE WAY.
@@ -808,14 +824,16 @@ def gallop_keys(length):
         for side, leg in (("l", "hind_l"), ("r", "hind_r")):
             phase = LEG_PHASE[leg]
             gaskin, cannon = HIND_FLEX
+            reach = LEAD_REACH if side == LEAD_SIDE else OFF_REACH
             # Positive is forward, measured off the rig rather than guessed.
-            pose[f"thigh_{side}"] = [_swing(turn, phase, HIND_SWING), 0, 0]
+            pose[f"thigh_{side}"] = [_swing(turn, phase, HIND_SWING * reach), 0, 0]
             pose[f"gaskin_{side}"] = [_flex(turn, phase, gaskin, JOINT_LAG), 0, 0]
             pose[f"hind_cannon_{side}"] = [_flex(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
         for side, leg in (("l", "fore_l"), ("r", "fore_r")):
             phase = LEG_PHASE[leg]
             forearm, cannon = FORE_FLEX
-            pose[f"shoulder_{side}"] = [_swing(turn, phase, FORE_SWING), 0, 0]
+            reach = LEAD_REACH if side == LEAD_SIDE else OFF_REACH
+            pose[f"shoulder_{side}"] = [_swing(turn, phase, FORE_SWING * reach), 0, 0]
             pose[f"forearm_{side}"] = [_flex(turn, phase, forearm, JOINT_LAG), 0, 0]
             pose[f"fore_cannon_{side}"] = [_flex(turn, phase, cannon, 2.0 * JOINT_LAG), 0, 0]
         # The back rounds and extends once per stride; the neck and head work
@@ -932,7 +950,17 @@ def main() -> int:
             loop=True,
             _timeout=600,
         )
-        stride = 2.0 * HIP_HEIGHT_M * math.sin(math.radians(HIND_SWING)) / STANCE
+        # The lead limb reaches further than its partner, so no single limb's
+        # sweep is "the" stride — the horse's body travel is their mean, and
+        # that is the number the client has to divide by.
+        stride = (
+            HIP_HEIGHT_M
+            * (
+                math.sin(math.radians(HIND_SWING * LEAD_REACH))
+                + math.sin(math.radians(HIND_SWING * OFF_REACH))
+            )
+            / STANCE
+        )
         print(
             f"gallop   : {clip['fcurves']} curves, {clip['keyframes']} keys, "
             f"{clip['frames']} frames, stride {stride:.2f} m"

--- a/games/chariot/project/assets/track_spec.json
+++ b/games/chariot/project/assets/track_spec.json
@@ -1,10 +1,10 @@
 {
   "comment": "Single source of truth for the hippodrome. art_source/build_hippodrome.py builds the meshes from this file, src/core/track_geometry.gd positions horses, and src/presentation/crowd_director.gd seats the crowd. Loop length = 2*straight_m + 2*PI*turn_radius_m at the lane-1 centerline.",
-  "straight_m": 380.0,
-  "turn_radius_m": 110.0,
+  "straight_m": 68.0,
+  "turn_radius_m": 30.0,
   "lane_width_m": 2.5,
   "lanes": 10,
-  "finish_s_m": 342.0,
+  "finish_s_m": 61.0,
   "rail_inner_offset_lanes": -0.6,
   "rail_outer_offset_lanes": 10.6,
   "post_every_m": 12.0,

--- a/games/chariot/project/assets/track_spec.json
+++ b/games/chariot/project/assets/track_spec.json
@@ -1,10 +1,10 @@
 {
   "comment": "Single source of truth for the hippodrome. art_source/build_hippodrome.py builds the meshes from this file, src/core/track_geometry.gd positions horses, and src/presentation/crowd_director.gd seats the crowd. Loop length = 2*straight_m + 2*PI*turn_radius_m at the lane-1 centerline.",
-  "straight_m": 68.0,
-  "turn_radius_m": 30.0,
+  "straight_m": 95.0,
+  "turn_radius_m": 42.0,
   "lane_width_m": 2.5,
   "lanes": 10,
-  "finish_s_m": 61.0,
+  "finish_s_m": 85.0,
   "rail_inner_offset_lanes": -0.6,
   "rail_outer_offset_lanes": 10.6,
   "post_every_m": 12.0,

--- a/tools/bforge/catalog.json
+++ b/tools/bforge/catalog.json
@@ -1685,6 +1685,40 @@
               0.0,
               0.0
             ]
+          },
+          "keep_transform": {
+            "type": "boolean",
+            "description": "Keep the prop exactly where it already is, ignoring offset/rotation",
+            "default": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "char.bake_pose",
+      "summary": "Freeze a posed rig into the mesh vertices and drop the skin. Turns a char.rig + char.pose result into a plain static mesh that keeps the pose through export \u2014 for background figures, props and NPCs that never animate.",
+      "tags": [
+        "char",
+        "rig"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "mesh": {
+            "type": "string",
+            "description": "Skinned mesh object to freeze"
+          },
+          "rig": {
+            "type": "string",
+            "description": "Armature to delete afterwards (default: the one deforming this mesh; pass \"\" to keep it)"
+          },
+          "keep_groups": {
+            "type": "boolean",
+            "description": "Keep the vertex groups after baking",
+            "default": false
           }
         },
         "additionalProperties": false
@@ -2937,7 +2971,7 @@
     },
     {
       "name": "gameready.collision",
-      "summary": "Generate a physics collision proxy. Convex hulls are what you want for anything a character walks into; box is cheapest; simplified trimesh is for concave shapes like arenas and rooms. Named <object>-convcol / <object>-col per the studio import convention.",
+      "summary": "Generate a physics collision proxy. Convex hulls are what you want for anything a character walks into; box is cheapest; simplified trimesh is for concave shapes like arenas and rooms. Named <object>-convcol / <object>-col per the studio import convention. SKIP for hulls that ride inside a moving body: Godot imports the proxy as a StaticBody3D child, and a static collider inside a CharacterBody3D blocks its own vehicle.",
       "tags": [
         "gameready",
         "physics"
@@ -3726,7 +3760,7 @@
           },
           "band_min": {
             "type": "number",
-            "description": "top_band/bottom_band: lower bound as a fraction of height",
+            "description": "top_band/bottom_band: lower bound as a fraction of height. Bands select by face CENTER, so a thin band needs real face rows at that height - one tall quad (e.g. a column shaft) has its centre near the middle and a thin band elsewhere matches nothing",
             "default": 0.0
           },
           "band_max": {
@@ -3738,6 +3772,16 @@
             "type": "string",
             "description": "Override colour",
             "default": ""
+          },
+          "roughness": {
+            "type": "number",
+            "description": "Override roughness 0..1; -1 keeps the preset value",
+            "default": -1.0
+          },
+          "metallic": {
+            "type": "number",
+            "description": "Override metallic 0..1; -1 keeps the preset value. Metals read black without something bright to reflect - painted trim (metallic ~0.15) survives dark environments",
+            "default": -1.0
           }
         },
         "additionalProperties": false

--- a/tools/bforge/runtime/ops/char.py
+++ b/tools/bforge/runtime/ops/char.py
@@ -687,10 +687,11 @@ def char_pose(ctx, rig, preset, bones):
         "bone": ("str", "hand_r", "Bone to attach to"),
         "offset": ("vec3", [0.0, 0.0, 0.0], "Local offset in metres"),
         "rotation": ("vec3", [0.0, 0.0, 0.0], "Local rotation in degrees"),
+        "keep_transform": ("bool", False, "Keep the prop exactly where it already is, ignoring offset/rotation"),
     },
     tags=["char", "rig"],
 )
-def char_attach(ctx, prop, rig, bone, offset, rotation):
+def char_attach(ctx, prop, rig, bone, offset, rotation, keep_transform):
     item = _get(prop)
     armature = _get(rig)
     if armature.type != "ARMATURE":
@@ -700,12 +701,30 @@ def char_attach(ctx, prop, rig, bone, offset, rotation):
         raise OpError(
             f"no bone '{bone}' on '{rig}'. Bones: {sorted(b.name for b in armature.data.bones)}"
         )
+    # KEEP_TRANSFORM IS FOR KIT THAT IS ALREADY IN THE RIGHT PLACE.
+    #
+    # Bone parenting anchors at the bone TAIL, so attaching normally THROWS AWAY
+    # wherever the prop was authored and snaps it to the joint. That is right
+    # for a sword you are placing into a fist, and exactly wrong for a shield, a
+    # greave or an arm-guard band that was already modelled against the body —
+    # re-deriving each of those as a bone-relative offset is a dozen blind
+    # tuning cycles for no gain.
+    #
+    # With keep_transform the prop does not move at all; it simply starts
+    # following the bone from where it stands.
+    world = item.matrix_world.copy()
     item.parent = armature
     item.parent_type = "BONE"
     item.parent_bone = bone
-    item.matrix_parent_inverse = Matrix.Identity(4)
-    item.location = Vector(offset)
-    item.rotation_euler = [math.radians(a) for a in rotation]
+    if keep_transform:
+        # Assigning matrix_world after parenting makes Blender solve for the
+        # local basis, bone parent and all.
+        scene_lib.sync()
+        item.matrix_world = world
+    else:
+        item.matrix_parent_inverse = Matrix.Identity(4)
+        item.location = Vector(offset)
+        item.rotation_euler = [math.radians(a) for a in rotation]
     return {
         "prop": item.name,
         "rig": armature.name,

--- a/tools/bforge/runtime/ops/char.py
+++ b/tools/bforge/runtime/ops/char.py
@@ -267,7 +267,11 @@ def char_rig(ctx, name, height, build, falloff, armature_name):
         bpy.ops.object.mode_set(mode="OBJECT")
     view_layer.objects.active = previous_active
 
-    weights = _skin(obj, joints, falloff)
+    # The bones were just written in ARMATURE-LOCAL space and the armature sits
+    # at the mesh's location, so the depsgraph has to catch up before _skin can
+    # read matrix_world off it.
+    scene_lib.sync()
+    weights = _skin(obj, joints, falloff, rig)
 
     modifier = obj.modifiers.new("armature", "ARMATURE")
     modifier.object = rig
@@ -288,7 +292,42 @@ def char_rig(ctx, name, height, build, falloff, armature_name):
     }
 
 
-def _skin(obj, joints, falloff):
+# Bone pairs that may share a vertex: a bone and its direct parent. Built from
+# PARENTS so it stays correct if the skeleton ever gains bones.
+_RELATED = frozenset(
+    pair
+    for child, parent in PARENTS.items()
+    for pair in ((child, parent), (parent, child))
+)
+
+
+def _distance_to_segment(point, head, tail):
+    axis = tail - head
+    length_sq = axis.length_squared
+    if length_sq < 1e-9:
+        return (point - head).length
+    t = max(0.0, min(1.0, (point - head).dot(axis) / length_sq))
+    return (point - (head + axis * t)).length
+
+
+def _components(mesh):
+    """Vertex -> shell id, by union-find over the edges."""
+    parent = list(range(len(mesh.vertices)))
+
+    def find(a):
+        while parent[a] != a:
+            parent[a] = parent[parent[a]]
+            a = parent[a]
+        return a
+
+    for edge in mesh.edges:
+        a, b = (find(v) for v in edge.vertices)
+        if a != b:
+            parent[a] = b
+    return [find(i) for i in range(len(mesh.vertices))]
+
+
+def _skin(obj, joints, falloff, rig=None):
     """Distance-to-bone-segment weighting, normalised over the best 2 bones.
 
     Blender's automatic weights are a bone-heat solve that needs an operator
@@ -296,36 +335,83 @@ def _skin(obj, joints, falloff):
     predictable and never fails with "Bone Heat Weighting: failed to find
     solution", which is the error every automated rigging attempt eventually
     hits.
+
+    Distance alone is not enough, though. A humanoid rests with its arms at its
+    sides, which runs the arm bones about 3cm from the flank of the torso while
+    the spine is 19cm away — so by distance the arm owns the waist, and the
+    first time the character reaches forward it drags a bat-wing of torso with
+    it. The mesh knows better than the distances do: the arm is a separate
+    shell from the body, so a bone is confined to the shell it lives in.
     """
     for group in list(obj.vertex_groups):
         obj.vertex_groups.remove(group)
     groups = {n: obj.vertex_groups.new(name=n) for n in joints}
     matrix = obj.matrix_world
-    segments = {n: (Vector(a), Vector(b)) for n, (a, b) in joints.items()}
-    weighted = 0
+    # BOTH SIDES OF THIS COMPARISON MUST BE IN THE SAME SPACE.
+    #
+    # `joints` is in armature-local space, but the armature is placed at the
+    # mesh's location, and the vertices below are taken to world space. Compare
+    # the two directly and every bone is displaced by exactly the character's
+    # offset from the origin — so a figure built at [0, -0.92, 0.55] gets its
+    # torso weighted to its head bone and its pelvis to its shins, and the
+    # first pose you apply tears the mesh into flat sheets. Characters authored
+    # at the origin were unaffected, which is why this survived so long.
+    rig_matrix = rig.matrix_world if rig is not None else Matrix.Identity(4)
+    segments = {
+        n: (rig_matrix @ Vector(a), rig_matrix @ Vector(b)) for n, (a, b) in joints.items()
+    }
 
-    for vertex in obj.data.vertices:
-        world = matrix @ vertex.co
-        distances = []
+    mesh = obj.data
+    world = [matrix @ v.co for v in mesh.vertices]
+    shell = _components(mesh)
+
+    # Which shell does each bone live in? Take the vertices that bone is nearest
+    # to and let them vote on their shell.
+    #
+    # Not "the single closest vertex" — a resting arm interpenetrates the torso,
+    # so the one vertex nearest the arm bone is quite often a torso vertex, and
+    # picking it hands the entire torso to the arm. The arm cylinder outvotes
+    # that handful every time.
+    claims = {}
+    for index, point in enumerate(world):
+        nearest, owner = 1e9, None
         for bone_name, (head, tail) in segments.items():
-            axis = tail - head
-            length_sq = axis.length_squared
-            if length_sq < 1e-9:
-                t = 0.0
-            else:
-                t = max(0.0, min(1.0, (world - head).dot(axis) / length_sq))
-            closest = head + axis * t
-            distances.append((( world - closest).length, bone_name))
-        distances.sort()
+            distance = _distance_to_segment(point, head, tail)
+            if distance < nearest:
+                nearest, owner = distance, bone_name
+        if owner is not None:
+            claims.setdefault(owner, []).append(shell[index])
+    bone_shell = {}
+    for bone_name in segments:
+        votes = claims.get(bone_name, [])
+        bone_shell[bone_name] = (
+            max(set(votes), key=votes.count) if votes else None
+        )
+
+    weighted = 0
+    for index, point in enumerate(world):
+        here = shell[index]
+        candidates = [n for n in segments if bone_shell[n] == here]
+        if not candidates:
+            # A decorative shell no bone claims — fall back to every bone so it
+            # is carried by something rather than left behind at the origin.
+            candidates = list(segments)
+        distances = sorted(
+            (_distance_to_segment(point, *segments[n]), n) for n in candidates
+        )
         best = distances[:2]
-        influences = []
-        for distance, bone_name in best:
-            influences.append((bone_name, 1.0 / (distance + 1e-4) ** falloff))
+        # Within a shell a vertex may still be shared only by a bone and its
+        # direct parent — that is what makes an elbow bend smoothly. Anything
+        # else takes the nearest bone outright, so the two thighs cannot stretch
+        # a web across the crotch.
+        if len(best) == 2 and (best[0][1], best[1][1]) not in _RELATED:
+            best = best[:1]
+        influences = [(n, 1.0 / (d + 1e-4) ** falloff) for d, n in best]
         total = sum(w for _n, w in influences)
         if total <= 0.0:
             continue
         for bone_name, weight in influences:
-            groups[bone_name].add([vertex.index], weight / total, "REPLACE")
+            groups[bone_name].add([index], weight / total, "REPLACE")
         weighted += 1
     return weighted
 
@@ -631,6 +717,91 @@ def char_attach(ctx, prop, rig, bone, offset, rotation):
             "negative Y offset; render.contact_sheet is the fastest way to check it."
         ),
     }
+
+
+@op(
+    "char.bake_pose",
+    summary=(
+        "Freeze a posed rig into the mesh vertices and drop the skin. Turns a "
+        "char.rig + char.pose result into a plain static mesh that keeps the pose "
+        "through export — for background figures, props and NPCs that never animate."
+    ),
+    params={
+        "mesh": ("str", None, "Skinned mesh object to freeze"),
+        "rig": ("str", None, "Armature to delete afterwards (default: the one deforming this mesh; pass \"\" to keep it)"),
+        "keep_groups": ("bool", False, "Keep the vertex groups after baking"),
+    },
+    tags=["char", "rig"],
+)
+def char_bake_pose(ctx, mesh, rig, keep_groups):
+    """Bake the armature deformation down into the mesh.
+
+    `char.pose` only moves POSE BONES. The mesh follows in the viewport because
+    of its armature modifier, but the vertices themselves never move — so a mesh
+    exported without its armature comes out in the rest pose, standing to
+    attention, and a mesh exported WITH its armature drags a Skeleton3D into the
+    scene for a figure that was never going to animate.
+
+    This is the third option: evaluate the deformation, write it into the
+    vertices, delete the rig. What you posed is what ships.
+    """
+    obj = _get(mesh)
+    if obj.type != "MESH":
+        raise OpError(f"'{mesh}' is a {obj.type}, not a mesh")
+    modifier = next((m for m in obj.modifiers if m.type == "ARMATURE"), None)
+    if modifier is None:
+        raise OpError(
+            f"'{mesh}' has no armature modifier, so there is no pose to bake. "
+            "Call char.rig on it first, then char.pose the rig."
+        )
+
+    armature = modifier.object
+    if rig is None:
+        target = armature
+    elif rig == "":
+        target = None
+    else:
+        target = _get(rig)
+
+    # The pose is written straight to the data API, so the depsgraph has not
+    # necessarily seen it yet. Without this the bake silently freezes the REST
+    # pose and everything looks fine until you open the export.
+    scene_lib.sync()
+    before = _bounds(obj)
+    scene_lib.apply_modifiers(obj)
+    after = _bounds(obj)
+
+    if not keep_groups:
+        obj.vertex_groups.clear()
+    removed = None
+    if target is not None:
+        removed = target.name
+        scene_lib.delete(target)
+
+    moved = max(abs(a - b) for a, b in zip(before, after))
+    return {
+        "mesh": obj.name,
+        "rig_removed": removed,
+        "vertex_groups_kept": bool(keep_groups),
+        "bounds_before": [round(v, 4) for v in before],
+        "bounds_after": [round(v, 4) for v in after],
+        "moved": round(moved, 4),
+        "note": (
+            "moved is the largest change in the bounding box, in metres. If it is "
+            "0 the rig was still in its rest pose when you baked — char.pose it first."
+        ),
+    }
+
+
+def _bounds(obj):
+    """Local-space min/max of the mesh itself, not the evaluated object."""
+    verts = obj.data.vertices
+    if not verts:
+        return (0.0,) * 6
+    xs = [v.co.x for v in verts]
+    ys = [v.co.y for v in verts]
+    zs = [v.co.z for v in verts]
+    return (min(xs), min(ys), min(zs), max(xs), max(ys), max(zs))
 
 
 def _get(name):

--- a/tools/bforge/tests/skinning.py
+++ b/tools/bforge/tests/skinning.py
@@ -1,0 +1,101 @@
+"""Skinning regression test: a character must rig the same wherever it stands.
+
+These three failures all shipped silently, because a character authored at the
+origin looks fine and nobody rigs a blockout anywhere else until they are
+assembling a scene — at which point the figure tears itself apart and it reads
+as a modelling mistake rather than a tooling one.
+
+    python tools/bforge/tests/skinning.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge import Forge  # noqa: E402
+
+HEIGHT = 1.72
+# One arm swung forward — the pose that exposes every one of these bugs.
+POSE = {"upper_arm_l": [64.0, 0.0, 0.0], "upper_arm_r": [64.0, 0.0, 0.0]}
+
+
+def posed_size(forge, location, pose=POSE):
+    """Build, rig, pose and bake a figure at `location`; return size, bake, area."""
+    forge.call("session.reset")
+    forge.call(
+        "char.humanoid", name="f", height=HEIGHT, build="heroic",
+        bulk=1.25, detail=8, location=location,
+    )
+    rig = forge.call("char.rig", name="f", height=HEIGHT, build="heroic")
+    if pose:
+        forge.call("char.pose", rig=rig.get("armature"), preset="custom", bones=pose)
+    baked = forge.call("char.bake_pose", mesh="f", rig=rig.get("armature"))
+    info = forge.call("object.inspect", name="f")
+    return info["bounds"]["size"], baked, info["uv"]["world_area_m2"]
+
+
+def main():
+    failures = []
+    with Forge() as forge:
+        at_origin, baked_origin, _area = posed_size(forge, [0.0, 0.0, 0.0])
+        offset, _baked_offset, posed_area = posed_size(forge, [0.0, -0.92, 0.55])
+        _rest, _baked_rest, rest_area = posed_size(forge, [0.0, -0.92, 0.55], pose=None)
+
+        # 1. char.bake_pose must actually write the pose into the vertices.
+        # Exported without its armature, an unbaked figure ships in the rest
+        # pose — standing to attention, arms at its sides.
+        if float(baked_origin.get("moved", 0.0)) < 0.05:
+            failures.append(
+                f"char.bake_pose reported no movement: {baked_origin!r} — the pose did not bake"
+            )
+
+        # 2. THE SAME CHARACTER MUST RIG THE SAME WHEREVER IT STANDS.
+        # The skinner used to compare world-space vertices against
+        # armature-local bone positions, so every bone was displaced by exactly
+        # the character's offset from the origin. A figure built on a vehicle
+        # floor got its pelvis weighted to its shins.
+        drift = max(abs(a - b) for a, b in zip(at_origin, offset))
+        if drift > 0.01:
+            failures.append(
+                f"rigging depends on where the character stands: at origin {at_origin} "
+                f"vs offset {offset} (drift {drift:.3f}m) — skinning is solving in mixed spaces"
+            )
+
+        # 3. An arm must not bring the torso with it.
+        # Arms rest at the sides, which runs the arm bones ~3cm from the flank
+        # while the spine is ~19cm away, so by distance alone the arm owns the
+        # waist and swings a bat-wing of torso forward with it. Depth is the
+        # tell: a figure reaching forward is about one arm deep, not two.
+        limit = 0.62 * HEIGHT
+        if offset[1] > limit:
+            failures.append(
+                f"posed figure is {offset[1]:.3f}m deep, over the {limit:.3f}m an arm can "
+                "reach — the torso is being dragged along with the arm"
+            )
+
+        # 4. Posing must not manufacture surface area.
+        # Rotating a limb moves geometry; it does not create it. When a bone
+        # captures vertices from a neighbouring shell — the arm bone taking the
+        # torso's flank — the skin stretches a web between the two, and that web
+        # is new area. It leaves the bounding box alone, so nothing above sees
+        # it; the figure just quietly grows a bat-wing.
+        growth = posed_area / rest_area if rest_area else 0.0
+        if growth > 1.10:
+            failures.append(
+                f"posing grew the surface by {growth:.2f}x ({rest_area:.3f} -> "
+                f"{posed_area:.3f} m2) — bones are dragging geometry across mesh shells"
+            )
+
+    for line in failures:
+        print("FAIL:", line)
+    if failures:
+        return 1
+    print(f"skinning OK — origin {at_origin}, offset {offset}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Replaces #40, which cannot merge.** Same work, same 20 commits, same authorship
— replayed onto current `main`. Please close #40 in favour of this.

## Why #40 is stuck

Its merge base is `459faa0` (2026-07-22). Eleven of its 31 commits are the bforge
foundation / Forward+ / budget-gate work that **already reached `main` via #13–#38
under different hashes**. Git therefore saw 18 files as add/add — the same files
created independently on both sides — and a merge produced ~89 conflict hunks
across the rigger, the horse builder and the bforge runtime. That is why it shows
108 files and +28,500.

Merging was the wrong tool. Taking `main` (authoritative and reviewed) and
replaying only the genuinely-new 2026-07-26/27 commits gives:

**9 files, +1601 −223.** Two conflicts, both in `build_hippodrome.py`, both
resolved against the author's own stated intent:

- `b52a57d` reshapes the vomitoria; `main` had since rebuilt them via
  `build.sweep`+path, a different implementation with no `heading` at all. Took
  `main`'s side — because
- `a789989` **deletes the vomitoria entirely** ("a divider that hides the crowd it
  divides is worth less than no divider at all"). Took that side, removing
  `main`'s implementation. Net state matches the branch: no stair wedges.

## The bug this surfaced

`test_forge.py` failed: `'char.bake_pose' : catalog.json is stale`. The op is
implemented and dispatched but was never added to the catalog — and **55943b7,
the tip of the original branch, is missing it too.** #40 has been red on its own
test since the op landed. Fixed by `just bforge-catalog` (108 → 109 ops, OPS.md
regenerated).

## Verified

```
test_forge.py    62 tests  OK   (Blender-backed)
test_schema.py   14 tests  OK
test_mcp.py                OK   (5 tools, 109 ops)
skinning.py      skinning OK — origin [0.66103, 0.75232, 1.68494],
                              offset [0.66103, 0.75232, 1.68494]
```

That last line is the oracle for the headline fix: a character built at the
origin and one built off it now produce **identical bounds**. `_skin` used to
compare world-space vertices against armature-local bone positions, so every bone
was displaced by exactly the character's offset from the origin — a figure
standing on a vehicle floor got its pelvis weighted to its shins. Characters
authored at the origin were unaffected, which is why it survived.

Two more skinning fixes ride along, both pinned by the same test: weights may no
longer blend across unconnected bones, and a bone may no longer capture geometry
from another mesh shell (a resting arm runs ~3cm from the flank while the spine is
~19cm away, so by distance alone the arm owned the waist — that one grew the skin
**1.29× in surface area with the bounding box unchanged**, which is exactly why
nothing caught it, and why the test measures area).

## Not verified here

The art itself is not render-checked in this PR — no GPU on this box. The
resolutions are argued from the commits' own stated intent, and every automated
oracle the branch ships is green. A visual pass on the hippodrome before merge
would be worth it, since that is where both conflicts were.