### PR TITLE
ssao: backport upstream's r8 storage declaration, and land the stranded rejection attribution

### DIFF
--- a/docs/architecture/webgpu-runtime-status.md
+++ b/docs/architecture/webgpu-runtime-status.md
@@ -231,6 +231,36 @@ That distinction points the investigation at **command validity** — not at
 culling, camera placement, lighting, attachment formats, or whether geometry was
 submitted, all of which are now ruled out.
 
+**And command validity is now measured, with the rejections attributed.**
+`binding-trace.mjs` carries the shader families each encoder recorded through
+`finish()` and `submit()`, because the aggregate counts alone cannot say *which*
+submissions died:
+
+```
+commandEncoder.finish : 11570 calls,  888 invalid
+queue.submit          : 11570 calls,  888 rejected
+
+submissions, by the shader families the submitted buffers recorded:
+   accepted   2639   rejected      0   (none)
+   accepted    889   rejected      0   SkyShaderRD
+   accepted   4490   rejected    888   SceneForwardClusteredShaderRD
+   accepted    888   rejected      0   TonemapShaderRD
+   accepted    888   rejected      0   CanvasShaderRD
+   accepted    888   rejected      0   BlitShaderRD
+```
+
+**Every rejected submission carried clustered scene work, and no other family had
+a single rejection.** That distinguishes the two mechanisms that both explain a
+black scene: the invalid bind group poisons the command buffer *containing the
+scene draws*, rather than a separate compute submission whose missing output a
+later valid pass consumes. WebGPU rejects a submission as a whole if any command
+buffer in it is invalid, so those draws never reach the queue timeline.
+
+Scene work also appears in 4490 *accepted* submissions, so it is a subset of
+scene submissions that dies — consistent with depth and shadow passes surviving
+while the pass that produces visible colour does not. Which subset is not yet
+established.
+
 `tests/browser/binding-trace.mjs` settles which resource fails first. It wraps
 each `createBindGroup` in its own `pushErrorScope('validation')`, so a failure is
 attributed to that exact call rather than correlated by timestamp, and it records

--- a/docs/architecture/webgpu-runtime-status.md
+++ b/docs/architecture/webgpu-runtime-status.md
@@ -256,10 +256,18 @@ scene draws*, rather than a separate compute submission whose missing output a
 later valid pass consumes. WebGPU rejects a submission as a whole if any command
 buffer in it is invalid, so those draws never reach the queue timeline.
 
-Scene work also appears in 4490 *accepted* submissions, so it is a subset of
-scene submissions that dies — consistent with depth and shadow passes surviving
-while the pass that produces visible colour does not. Which subset is not yet
+Scene work also appears in accepted submissions, so it is a subset of scene
+submissions that dies — consistent with depth and shadow passes surviving while
+the pass that produces visible colour does not. Which subset is not yet
 established.
+
+**On the strength of that claim.** Unioning shader families across a submit list
+would only prove *submission-level* co-membership. The trace also records batch
+sizes, and every submission on this host carries exactly one command buffer
+(`{"1": 6734}`), so co-membership in a submission is co-membership in a command
+buffer: the invalid bind group and the scene draws are in the same buffer. On a
+runtime that batched several buffers per submit, only the weaker claim would
+hold.
 
 `tests/browser/binding-trace.mjs` settles which resource fails first. It wraps
 each `createBindGroup` in its own `pushErrorScope('validation')`, so a failure is
@@ -390,12 +398,30 @@ It has never been reachable before. Forward Mobile returns `false` from
 `_render_buffers_can_be_storage()`, so SSAO does not run at all under it — this
 code path executes for the first time under Forward+.
 
-Fixing it therefore means choosing how to reconcile an upstream mismatch, not
-correcting a driver defect, and the options differ in what they cost:
-rewrite the WGSL storage format to match the bound texture; allocate the AO
-buffer as RGBA8; or decline tier-1 preservation for storage textures whose
-shaders declare a wider format. That choice is deliberately left open rather than
-guessed at.
+**Resolved by patch 0032: backport upstream's own correction.** Current Godot
+master reads `layout(r8, ...)` on that line, changed by commit `d9ea5c261eb6`,
+*"Add error checks for texture type and storage format mismatches"* (2026-05-06)
+— upstream fixed this shader while adding checks for exactly this class of bug.
+
+That also corrects how the old state should be described. Not "Vulkan tolerates
+it": Vulkan requires the storage-image format declared in SPIR-V to match the
+view, and Godot's Vulkan path simply had not been rejecting it in the tested
+configurations.
+
+Three alternatives were rejected as worse answers to the same question:
+rewriting the generated WGSL (leaves GLSL/SPIR-V and WGSL disagreeing, and adds
+another brittle text mutation of the kind 0024 removed); allocating the AO target
+as RGBA8 (four times the memory and bandwidth for a scalar, to fit an erroneous
+declaration); and declining tier-1 preservation (penalises every valid R8/RG8
+storage resource globally for one stale shader line).
+
+  R8Unorm-vs-RGBA8Unorm bind-group failures   1 -> 0
+  distinct bind-group failure classes         2 -> 1
+
+Still black. The remaining class is a comparison sampler bound to a
+non-comparison slot, first in command order at `bgl:VolumetricFogProcessShaderRD`
+`entries[10]`, binding 22, whose layout entry carries `ShaderStage::None`
+visibility.
 
 **Portability, not just this P40.** 0027 requests `depth32float-stencil8` only
 when `adapter.features` exposes it, and 0028 makes the driver answer D32 support

--- a/engine/engine-lock.toml
+++ b/engine/engine-lock.toml
@@ -89,6 +89,7 @@ series = [
   { file = "patches/0029-webgpu-unused-color-targets-are-absent.patch", sha256 = "6da7b9fecb477ac6ac288270e38e500159827b9e931a132a4908b57bbb2aab50" },
   { file = "patches/0030-webgpu-view-format-follows-the-texture.patch", sha256 = "c63417574fd85a672ca884b535f2d1ca7c29ac997959de94afe29809ed3df809" },
   { file = "patches/0031-webgpu-shared-view-physical-format-invariant.patch", sha256 = "faab98a67f18d0e74c6389af485e8c59e197224ec377ffc34f209b65045a35f0" },
+  { file = "patches/0032-godot-ssao-interleave-r8-backport.patch", sha256 = "0c662817a350eb423e14baee160bc0777c838591c797f49667574719a573e83a" },
 ]
 
 [artifacts.export_templates]

--- a/engine/patches/0032-godot-ssao-interleave-r8-backport.patch
+++ b/engine/patches/0032-godot-ssao-interleave-r8-backport.patch
@@ -1,0 +1,80 @@
+Subject: [PATCH] ssao: match the interleave storage image to the R8 AO target
+
+ssao_interleave.glsl declares its destination image as rgba8, while
+SSEffects::ssao_allocate_buffers() allocates RB_FINAL as R8_UNORM. WebGPU
+requires the storage-texture format in a bind-group layout to equal the bound
+texture's format exactly, so the disagreement invalidates the bind group:
+
+  createBindGroup #305   layout bgl:SsaoInterleaveShaderRD:1:set0
+    binding 0
+      supplied  textureView  r8unorm / r8unorm
+      expected  storageTexture format=rgba8unorm
+
+Two obvious readings of that are both wrong, and the trace ruled them out before
+anything was changed.
+
+It is NOT a missed promotion. The adapter reports texture-formats-tier1 enabled,
+and _promote_storage_format deliberately preserves r8unorm when tier 1 is
+available, because the format is then natively valid for storage and widening it
+would discard its blendable/filterable properties. The texture is correct.
+
+It is NOT the placeholder-format defect of 0021 and 0029. The captured runtime
+WGSL declares texture_storage_2d<rgba8unorm, write>, so the layout faithfully
+reflects the shader. Nothing was invented.
+
+The declaration itself is stale, and current upstream Godot has already corrected
+it. On master the same line reads layout(r8, ...), changed by commit
+d9ea5c261eb6 "Add error checks for texture type and storage format mismatches"
+(2026-05-06) -- upstream fixed this shader while adding checks for exactly this
+class of bug, which is also why "Vulkan tolerates it" is the wrong way to
+describe the old state. Vulkan requires the storage-image format declared in
+SPIR-V to match the view; Godot's Vulkan path simply had not been rejecting it in
+the configurations that were tested.
+
+The interleave shader computes one scalar AO value and stores vec4(ao). Writing a
+four-component vector to a single-channel storage texture is the defined
+interface -- the red channel is stored and the rest discarded -- so the
+calculation and both imageStore() calls are unchanged, exactly as upstream left
+them.
+
+Backported unconditionally rather than behind a WebGPU define, because the
+declaration was wrong on every backend, not only under WebGPU. This patch becomes
+removable the moment the engine pin moves to a Godot containing d9ea5c261eb6.
+
+Rejected because they are worse answers to the same question:
+  * rewriting the generated WGSL to r8unorm -- leaves GLSL and SPIR-V saying one
+    thing and WGSL another, and adds another brittle text mutation of the kind
+    0024 was written to remove
+  * allocating the AO target as RGBA8 -- four times the memory and bandwidth for
+    a scalar, to fit an erroneous declaration
+  * declining tier-1 preservation -- penalises every valid R8/RG8 storage
+    resource globally to accommodate one stale shader line
+
+Measured on a Tesla P40 through headed Chrome/WebGPU, Chariot on Forward+:
+
+  R8Unorm-vs-RGBA8Unorm bind-group failures   1 -> 0
+  distinct bind-group failure classes         2 -> 1
+
+Still black. The remaining class is a comparison sampler bound to a
+non-comparison slot, first in command order at bgl:VolumetricFogProcessShaderRD
+entries[10], binding 22, whose layout entry carries ShaderStage::None visibility.
+Scene-bearing submissions are still rejected, so this was not the last poison:
+
+  commandEncoder.finish   6708 calls, 514 invalid
+  queue.submit            6708 calls, 514 rejected
+  submit batch sizes      {"1": 6734}   -- every submission holds one buffer
+  rejected submissions carrying SceneForwardClusteredShaderRD   514
+  rejected submissions carrying Sky / Tonemap / Canvas / Blit     0
+
+diff --git a/servers/rendering/renderer_rd/shaders/effects/ssao_interleave.glsl b/servers/rendering/renderer_rd/shaders/effects/ssao_interleave.glsl
+--- a/servers/rendering/renderer_rd/shaders/effects/ssao_interleave.glsl
++++ b/servers/rendering/renderer_rd/shaders/effects/ssao_interleave.glsl
+@@ -24,7 +24,7 @@
+ 
+ layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+ 
+-layout(rgba8, set = 0, binding = 0) uniform restrict writeonly image2D dest_image;
++layout(r8, set = 0, binding = 0) uniform restrict writeonly image2D dest_image;
+ layout(set = 1, binding = 0) uniform sampler2DArray source_texture;
+ 
+ layout(push_constant, std430) uniform Params {

--- a/tests/browser/binding-trace.mjs
+++ b/tests/browser/binding-trace.mjs
@@ -240,6 +240,13 @@ await page.addInitScript(() => {
         const families = new Set();
         for (const cb of list ?? []) for (const f of cb?.__studioFamilies ?? []) families.add(f);
         const key = [...families].sort().join(",") || "(none)";
+        // Record the batch size too. Unioning families across a list proves
+        // SUBMISSION-level co-membership; it only proves the invalid bind group
+        // and the scene draws shared one COMMAND BUFFER when the batch holds
+        // exactly one. Without this the stronger claim would be unsupported.
+        const b0 = globalThis.__bind;
+        const sizes = (b0.submit_batch_sizes ??= {});
+        sizes[(list ?? []).length] = (sizes[(list ?? []).length] ?? 0) + 1;
         if (dev) dev.pushErrorScope("validation");
         const r = orig.call(this, list);
         if (dev) {
@@ -324,6 +331,7 @@ const result = await page.evaluate(() => ({
     submit_failed: globalThis.__bind?.submit_failed ?? 0,
     submit_messages: globalThis.__bind?.submit_messages ?? [],
     by_shader_families: globalThis.__bind?.submits ?? {},
+    batch_sizes: globalThis.__bind?.submit_batch_sizes ?? {},
   },
 }));
 await browser.close();
@@ -338,6 +346,7 @@ if (AS_JSON) {
   const cb = result.command_buffers;
   console.log(`commandEncoder.finish : ${cb.finish_total} calls, ${cb.finish_failed} invalid`);
   console.log(`queue.submit          : ${cb.submit_total} calls, ${cb.submit_failed} rejected`);
+  console.log(`submit batch sizes    : ${JSON.stringify(cb.batch_sizes ?? {})}`);
   console.log("submissions, by the shader families the submitted buffers recorded:");
   for (const [fams, n] of Object.entries(cb.by_shader_families ?? {}))
     console.log(`   accepted ${String(n.accepted).padStart(6)}   rejected ${String(n.rejected).padStart(6)}   ${fams}`);

--- a/tests/browser/binding-trace.mjs
+++ b/tests/browser/binding-trace.mjs
@@ -50,7 +50,7 @@ const browser = await chromium.launch({
 const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
 
 await page.addInitScript(() => {
-  globalThis.__bind = { failures: [], seq: 0, counts: {} };
+  globalThis.__bind = { failures: [], seq: 0, counts: {}, encoderSeq: 0, submits: {} };
 
   const samplers = new WeakMap(); // GPUSampler -> descriptor
   const textures = new WeakMap(); // GPUTexture -> descriptor
@@ -159,6 +159,109 @@ await page.addInitScript(() => {
       return l;
     });
 
+  // --- encoder -> command buffer -> submit identity ------------------------
+  //
+  // An invalid bind group does not fail locally. It invalidates the encoder that
+  // binds it, finish() then returns an invalid command buffer, and submit()
+  // rejects the whole submission before anything reaches the GPU. Counting those
+  // rejections is what separates "a resource was invalid" from "the frame was
+  // actually thrown away".
+  //
+  // Carrying the recorded shader families along that chain answers the question
+  // the aggregate counts cannot: whether the rejected submissions were the ones
+  // containing the scene draws, or a separate compute submission whose missing
+  // output a later valid pass then consumed.
+  once(D, "createCommandEncoder", (orig) =>
+    function (d) {
+      const e = orig.call(this, d);
+      try {
+        e.__studioDevice = this;
+        e.__studioFamilies = new Set();
+        if (this.queue && !this.queue.__studioDevice) this.queue.__studioDevice = this;
+      } catch (err) {}
+      return e;
+    });
+
+  // A pass encoder cannot reach its parent, so it shares the family set by
+  // reference when the pass is begun.
+  for (const name of ["beginRenderPass", "beginComputePass"]) {
+    once(GPUCommandEncoder.prototype, name, (orig) =>
+      function (d) {
+        const pass = orig.call(this, d);
+        try {
+          pass.__studioFamilies = this.__studioFamilies;
+        } catch (e) {}
+        return pass;
+      });
+  }
+
+  for (const proto of [globalThis.GPURenderPassEncoder, globalThis.GPUComputePassEncoder]) {
+    if (!proto) continue;
+    once(proto.prototype, "setPipeline", (orig) =>
+      function (pl) {
+        try {
+          const fam = /:([A-Za-z]+ShaderRD)/.exec(pl?.label ?? "")?.[1];
+          if (fam && this.__studioFamilies) this.__studioFamilies.add(fam);
+        } catch (e) {}
+        return orig.call(this, pl);
+      });
+  }
+
+  once(GPUCommandEncoder.prototype, "finish", (orig) =>
+    function (d) {
+      const dev = this.__studioDevice ?? null;
+      const families = [...(this.__studioFamilies ?? [])];
+      if (dev) dev.pushErrorScope("validation");
+      const cb = orig.call(this, d);
+      try {
+        cb.__studioFamilies = families;
+      } catch (e) {}
+      if (dev) {
+        dev.popErrorScope()
+          .then((err) => {
+            const b = globalThis.__bind;
+            b.finish_total = (b.finish_total ?? 0) + 1;
+            if (err) {
+              b.finish_failed = (b.finish_failed ?? 0) + 1;
+              if ((b.finish_messages ??= []).length < 3) b.finish_messages.push(err.message);
+            }
+          })
+          .catch(() => {});
+      }
+      return cb;
+    });
+
+  if (globalThis.GPUQueue) {
+    once(GPUQueue.prototype, "submit", (orig) =>
+      function (list) {
+        const dev = this.__studioDevice ?? null;
+        // A submit is rejected as a whole if ANY buffer in it is invalid, so the
+        // families across the entire list are what a rejection took down.
+        const families = new Set();
+        for (const cb of list ?? []) for (const f of cb?.__studioFamilies ?? []) families.add(f);
+        const key = [...families].sort().join(",") || "(none)";
+        if (dev) dev.pushErrorScope("validation");
+        const r = orig.call(this, list);
+        if (dev) {
+          dev.popErrorScope()
+            .then((err) => {
+              const b = globalThis.__bind;
+              b.submit_total = (b.submit_total ?? 0) + 1;
+              const bucket = (b.submits[key] ??= { accepted: 0, rejected: 0 });
+              if (err) {
+                b.submit_failed = (b.submit_failed ?? 0) + 1;
+                bucket.rejected += 1;
+                if ((b.submit_messages ??= []).length < 3) b.submit_messages.push(err.message);
+              } else {
+                bucket.accepted += 1;
+              }
+            })
+            .catch(() => {});
+        }
+        return r;
+      });
+  }
+
   // The heart of it: attribute a validation error to the exact createBindGroup
   // that produced it, rather than to whatever happened to be nearby in time.
   once(D, "createBindGroup", (orig) =>
@@ -213,6 +316,15 @@ const result = await page.evaluate(() => ({
   failures: globalThis.__bind?.failures ?? [],
   counts: globalThis.__bind?.counts ?? {},
   total: globalThis.__bind?.seq ?? 0,
+  command_buffers: {
+    finish_total: globalThis.__bind?.finish_total ?? 0,
+    finish_failed: globalThis.__bind?.finish_failed ?? 0,
+    finish_messages: globalThis.__bind?.finish_messages ?? [],
+    submit_total: globalThis.__bind?.submit_total ?? 0,
+    submit_failed: globalThis.__bind?.submit_failed ?? 0,
+    submit_messages: globalThis.__bind?.submit_messages ?? [],
+    by_shader_families: globalThis.__bind?.submits ?? {},
+  },
 }));
 await browser.close();
 
@@ -223,6 +335,12 @@ if (AS_JSON) {
   console.log(JSON.stringify({ ...result, failures }, null, 2));
 } else {
   console.log(`createBindGroup calls: ${result.total}`);
+  const cb = result.command_buffers;
+  console.log(`commandEncoder.finish : ${cb.finish_total} calls, ${cb.finish_failed} invalid`);
+  console.log(`queue.submit          : ${cb.submit_total} calls, ${cb.submit_failed} rejected`);
+  console.log("submissions, by the shader families the submitted buffers recorded:");
+  for (const [fams, n] of Object.entries(cb.by_shader_families ?? {}))
+    console.log(`   accepted ${String(n.accepted).padStart(6)}   rejected ${String(n.rejected).padStart(6)}   ${fams}`);
   console.log(`distinct failure messages: ${Object.keys(result.counts).length}`);
   for (const [msg, n] of Object.entries(result.counts)) console.log(`  x${n}  ${msg}`);
   console.log();


### PR DESCRIPTION
Two commits. The first recovers instrumentation that #46 merged too early to include; the second is a one-line backport of a fix Godot upstream has already made.

## 1. Stranded from #46 — rejection attribution

`binding-trace.mjs` on `main` still stops at bind-group creation. The encoder → `finish()` → `submit()` hooks and shader-family attribution were pushed after #46's merge commit, so they didn't land. Same pattern as #44 and #45.

This is what turns the cascade from hypothesis into measurement:

```
commandEncoder.finish : 6708 calls,  514 invalid
queue.submit          : 6708 calls,  514 rejected
submit batch sizes    : {"1": 6734}

submissions, by the shader families the submitted buffers recorded:
   accepted   1490   rejected      0   (none)
   accepted    515   rejected      0   SkyShaderRD
   accepted   2647   rejected    514   SceneForwardClusteredShaderRD
   accepted    514   rejected      0   TonemapShaderRD / CanvasShaderRD / BlitShaderRD
```

**Every rejected submission carried clustered scene work; no other family had one.** And because the trace records batch sizes — every submission here holds exactly **one** command buffer — this proves same-*command-buffer* membership, not merely same-submission. On a runtime batching several buffers per submit, only the weaker claim would hold.

## 2. Patch 0032 — backport upstream's `layout(r8)`

`ssao_interleave.glsl` declares `rgba8` while Godot allocates `RB_FINAL` as `R8_UNORM`. WebGPU requires the storage format in a bind-group layout to equal the bound texture's exactly.

**Two obvious readings were both wrong**, and the trace ruled them out before anything changed:

| Reading | Verdict |
|---|---|
| Missed promotion — the texture should be wider | **No.** `texture-formats-tier1` is *enabled*; `_promote_storage_format` deliberately preserves `r8unorm` then. The texture is correct. |
| Placeholder-format defect, like 0021/0029 | **No.** The captured WGSL declares `texture_storage_2d<rgba8unorm, write>`. The layout is faithful. |

The declaration is stale, and **upstream already fixed it**: Godot master reads `layout(r8, ...)`, changed by `d9ea5c261eb6` — *"Add error checks for texture type and storage format mismatches"* (2026-05-06). Upstream corrected this shader **while adding checks for exactly this class of bug**.

That also corrects the earlier wording in the status doc. Not "Vulkan tolerates it" — Vulkan requires the declared storage-image format to match the view; Godot's Vulkan path simply hadn't been rejecting it in the configurations tested.

Backported unconditionally, not behind a WebGPU define, because the line was wrong on every backend. Removable the moment the engine pin moves to a Godot containing that commit.

**Rejected alternatives**, all worse answers to the same question:
- *Rewrite the generated WGSL* — leaves GLSL/SPIR-V and WGSL disagreeing, and adds another brittle text mutation of the kind 0024 removed.
- *Allocate the AO target as RGBA8* — 4× the memory and bandwidth for a scalar, to fit an erroneous declaration.
- *Decline tier-1 preservation* — penalises every valid R8/RG8 storage resource globally for one stale line.

```
R8Unorm-vs-RGBA8Unorm failures   1 -> 0
distinct bind-group classes      2 -> 1
```

## Still black, and this wasn't the last poison

Scene-bearing submissions are still rejected. The remaining class is a comparison sampler in a non-comparison slot, first in command order at `bgl:VolumetricFogProcessShaderRD` `entries[10]`, binding 22 — whose layout entry carries `ShaderStage::None` visibility, which is itself worth a look.

## Verification

32 patches: checksums + clean-tree `git apply` both green.