### PR TITLE
bforge: quality gate, character and creature forge, paint/morph/impostor — 127 ops

### DIFF
--- a/.claude/skills/bforge/SKILL.md
+++ b/.claude/skills/bforge/SKILL.md
@@ -5,7 +5,7 @@ description: Build game-ready 3D assets with Blender — props, modular kits, te
 
 # bforge — headless Blender asset forge
 
-`bforge` drives a persistent background Blender session through ~89 typed
+`bforge` drives a persistent background Blender session through 127 typed
 operations. It never needs the Blender GUI, it is deterministic (same params +
 same seed → same mesh, forever), and every generated asset comes out chamfered,
 UV'd, materialled, pivoted and validated against the studio's ADR 0006 rules.

--- a/docs/bforge/OPS.md
+++ b/docs/bforge/OPS.md
@@ -1,6 +1,6 @@
 # bforge op reference
 
-109 operations.
+127 operations.
 
 ## `arch.*`
 
@@ -349,7 +349,7 @@ Author a keyframed animation clip on a rig: idle, walk, run, attack, jump, death
 | parameter | type | default | description |
 | --- | --- | --- | --- |
 | `rig` | string | None | Armature object name (from char.rig) |
-| `clip` | idle \| walk \| run \| attack \| jump \| death \| wave | 'idle' | Which clip to author |
+| `clip` | idle \| walk \| run \| attack \| jump \| death \| wave \| trot \| gallop \| graze | 'idle' | Which clip to author |
 | `length` | integer | 24 | Clip length in frames (24 frames at 30 fps = 0.8 s) |
 | `amplitude` | number | 1.0 | Motion scale — 0.6 is subtle, 1.4 is exaggerated |
 | `loop` | boolean | True | Match the last frame to the first so the clip cycles |
@@ -378,6 +378,56 @@ Freeze a posed rig into the mesh vertices and drop the skin. Turns a char.rig + 
 | `rig` | string | None | Armature to delete afterwards (default: the one deforming this mesh; pass "" to keep it) |
 | `keep_groups` | boolean | False | Keep the vertex groups after baking |
 
+### `char.creature`
+
+Proportioned quadruped body (canine/equine/feline/generic) or hexapod (insect: scarab class, three leg stations). Pair with char.creature_rig and char.animate — walk/trot/gallop/graze for quadrupeds, tripod-gait walk for hexapods. Deterministic, data-API only, metres.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | 'creature' | Object name |
+| `length` | number | 1.4 | Body length in metres (chest-to-hip; abdomen-tip to head for insect) |
+| `shoulder` | number | 0.9 | Shoulder height in metres (thorax height for insect) |
+| `plan` | canine \| equine \| feline \| generic \| insect | 'canine' | Body plan — quadruped proportions or the hexapod scarab class |
+| `bulk` | number | 1.0 | Extra girth multiplier |
+| `detail` | integer | 8 | Limb cross-section segments |
+| `location` | array | [0.0, 0.0, 0.0] | World position |
+| `skin` | string | '#7a6248' | Body colour |
+| `seed` | integer | 0 | Random seed |
+
+### `char.creature_rig`
+
+Build a quadruped armature (hips root, spine chain, neck/head, 2-segment tail, 3-bone legs at both stations) fitted to a char.creature body, and skin it with the same shell-constrained distance-falloff solve as char.rig.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Creature mesh object (from char.creature) |
+| `length` | number | 0.0 | Chest-to-hip length; 0 measures from the mesh bounds Y extent |
+| `shoulder` | number | 0.0 | Shoulder height; 0 measures from the mesh bounds Z extent |
+| `plan` | canine \| equine \| feline \| generic \| insect | 'canine' | Body plan the rig assumes — match char.creature |
+| `falloff` | number | 1.6 | Weight blend sharpness; higher is more rigid |
+| `armature_name` | string | '' | Armature object name (defaults to <mesh>_rig) |
+
+### `char.face`
+
+Give a char.humanoid head a readable face — brow ridge, nose wedge, chin — so a close-up review render reads as a person, not a box. Stylised readability, not realism. Geometry is welded into the body mesh and takes the head bone when skinned.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Body mesh (from char.humanoid) |
+| `height` | number | 0.0 | Character height; 0 measures the mesh bounds |
+| `build` | realistic \| heroic \| stylized \| chibi \| lithe | 'heroic' | Proportions — match the char.humanoid build |
+
+### `char.hands`
+
+Upgrade a char.humanoid's block hands with readable fingers: four two-segment fingers with a relaxed curl plus a thumb, so a weapon grip or open hand reads at review distance. Welded into the body mesh; the hand bones own them when skinned.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Body mesh (from char.humanoid) |
+| `height` | number | 0.0 | Character height; 0 measures the mesh bounds |
+| `build` | realistic \| heroic \| stylized \| chibi \| lithe | 'heroic' | Proportions — match the char.humanoid build |
+| `curl` | number | 0.35 | Finger curl in radians-ish (0 flat, 0.8 fist); a relaxed read is ~0.35 |
+
 ### `char.humanoid`
 
 Proportioned humanoid blockout using classic figure-drawing head ratios (7.5 realistic, 8 heroic, 4 chibi). ~1400 tris. Pair with char.rig and char.animate for a complete animated character.
@@ -392,6 +442,23 @@ Proportioned humanoid blockout using classic figure-drawing head ratios (7.5 rea
 | `location` | array | [0.0, 0.0, 0.0] | World position |
 | `skin` | string | '#c08a6a' | Body colour |
 | `seed` | integer | 0 | Random seed |
+
+### `char.outfit`
+
+Fit an armour or clothing piece to a char.humanoid body: cuirass, pteruges skirt, greaves, bracers, helmet or round shield. Fit is derived from the body's own proportions, materials are perceptually distinct by construction (this is the anti 'brown blob' op), and pieces bone-parent to the rig when one exists so they animate with the character.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Body mesh (from char.humanoid) |
+| `piece` | cuirass \| pteruges \| greaves \| bracers \| helmet \| shield | 'cuirass' | What to fit. greaves and bracers come in pairs |
+| `height` | number | 0.0 | Character height; 0 measures the mesh bounds |
+| `build` | realistic \| heroic \| stylized \| chibi \| lithe | 'heroic' | Proportions the fit assumes — match the char.humanoid build |
+| `material` | bronze \| iron \| leather \| cloth | '' | Material family (defaults per piece: bronze for cuirass/greaves/helmet/shield, leather for pteruges/bracers). The families are deliberately far apart in colour and response — keep them that way |
+| `color` | any | '' | Override colour; stay clear of the other pieces' colours or check.materials will fail the set |
+| `crest` | none \| longitudinal \| transverse | 'longitudinal' | helmet: crest ridge orientation |
+| `side` | l \| r | 'l' | shield: which forearm carries it |
+| `gap` | number | 0.012 | Clearance between body and armour in metres; raise for bulky bodies |
+| `seed` | integer | 0 | Random seed (reserved; current pieces are fully deterministic) |
 
 ### `char.pose`
 
@@ -428,6 +495,16 @@ Run the studio's ADR 0006 asset rules against the open scene: naming, units, app
 | `require_collision` | boolean | False | Fail when no -col/-convcol proxy exists |
 | `require_lods` | boolean | False | Fail when no _lod1 object exists |
 
+### `check.conformance`
+
+Score how well each object conforms to the set's (or a reference object's) style fingerprint. Names the exact axis that breaks coherence — palette drift, texel-density mismatch, density outlier, edge-treatment drift — with the op that fixes it. The art-director gate: run it over a whole pack before export.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `objects` | array | [] | Objects to score (empty = every mesh) |
+| `reference` | string | '' | Conform to THIS object's fingerprint instead of the set median |
+| `texture_size` | integer | 1024 | Texture resolution the texel-density figure assumes |
+
 ### `check.critique`
 
 Quality critique with specific, actionable findings: triangle-density hot spots, degenerate and n-gon faces, UV stretch, texel-density mismatch between objects, non-manifold edges, unused material slots. Pair it with render.contact_sheet — numbers plus eyes.
@@ -447,6 +524,15 @@ Measure an image instead of eyeballing it: luminance range, blown highlights, cr
 | `colors` | integer | 6 | How many dominant colours to report |
 | `background` | array | [0.05, 0.055, 0.065, 1.0] | Backdrop colour, excluded from subject stats |
 
+### `check.materials`
+
+Measure whether an asset's materials are actually distinguishable — the '8 materials, all the same brown' failure that produces mud-blob characters. Reports every material's colour in CIELAB and the pairwise perceptual distance (ΔE); fails when several materials are perceptually identical or share one roughness/metallic signature.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `objects` | array | [] | Objects whose materials to measure (empty = every mesh) |
+| `min_delta_e` | number | 12.0 | Perceptual-separation floor in ΔE76. Below ~6 the difference is invisible in game; 12 is a safe bar for metal vs leather vs cloth |
+
 ### `check.silhouette`
 
 Score how readable an object's silhouette is from the standard game camera angles. A prop that fails here will not read at gameplay distance no matter how good its texture is.
@@ -455,6 +541,16 @@ Score how readable an object's silhouette is from the standard game camera angle
 | --- | --- | --- | --- |
 | `name` | string | None | Object to test |
 | `samples` | integer | 64 | Rays per axis for the projected-area estimate |
+
+### `check.style`
+
+Compute the style fingerprint of every mesh: area-weighted palette (in CIELAB), texel density, triangle density, hard-edge ratio, material count, UV coverage. This is the raw material of art direction — 'do these 40 assets look like one game' is unanswerable without it.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `objects` | array | [] | Objects to fingerprint (empty = every mesh) |
+| `texture_size` | integer | 1024 | Texture resolution the texel-density figure assumes |
+| `palette_size` | integer | 4 | Dominant colours to keep per object, area-weighted |
 
 ## `env.*`
 
@@ -609,6 +705,8 @@ One call: save the .blend master, export the GLB, write the .meta.json sidecar a
 | `ai_prompt` | string | '' | What the asset was asked for — recorded in provenance |
 | `contact_sheet` | boolean | True | Also render a review contact sheet |
 | `strict` | boolean | True | Block export on problems that would corrupt the import |
+| `gate` | boolean | True | Run gameready.review before writing anything; a failed review blocks the hand-off. Set false only for deliberate blockouts |
+| `style` | stylized \| realistic | 'stylized' | Art direction passed to gameready.review when gate=true |
 
 ### `export.blend`
 
@@ -725,6 +823,17 @@ Fix pivots and transforms across many objects at once — the two things engines
 | `apply_transforms` | boolean | True | Bake rotation and scale into the mesh |
 | `snap_to_ground` | boolean | False | Move each object so its lowest point sits at Z=0 |
 | `to_origin` | boolean | False | Also move the object itself to (0,0,0). Required for a single-asset master file — the studio validator rejects a root object that is not at the world origin |
+
+### `gameready.review`
+
+The quality gate: aggregate check.critique and check.materials into one pass/fail verdict before export. Exists because quality steps that are optional get skipped — a scene that passes this cannot ship the mud-blob failure (perceptually identical materials), broken geometry, or missing UVs without knowing it.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `objects` | array | [] | Objects to review (empty = every mesh in the scene) |
+| `severity` | error \| warn | 'error' | Findings at this level or worse fail the gate. 'error' blocks only what corrupts or reads as broken; 'warn' also blocks advisories like texel-density spread |
+| `style` | stylized \| realistic | 'stylized' | 'realistic' additionally fails an asset whose materials are ALL flat untextured colour — bake material.bake_pbr or pick the stylized look deliberately |
+| `min_delta_e` | number | 12.0 | Material-separation floor in ΔE76, passed to check.materials |
 
 ### `gameready.socket`
 
@@ -980,6 +1089,52 @@ List every available operation with its parameters. Call this first if you are u
 
 The studio colour palette and material presets. Use these names instead of inventing colours — palette discipline is what makes a set of assets look like one game.
 
+## `morph.*`
+
+### `morph.add`
+
+Add a shape key that displaces vertices by a deterministic rule — dent a crate for a damage state, inflate a cartoon prop, taper a tree trunk, bulge a cartoon cheek. Exports to glTF as a morph target on top of Basis.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object to add the shape key to |
+| `key` | string | None | Shape key name — this becomes the glTF morph target name (extras.targetNames), so make it meaningful: 'dented', 'inflate', 'blink' |
+| `rule` | inflate \| dent \| flatten \| taper \| bulge | 'dent' | Displacement rule: inflate pushes verts out along their normals, dent pulls verts inside `radius` toward `center`, bulge pushes them away, flatten squashes toward the center plane along `axis`, taper scales the cross-section down along `axis` |
+| `amount` | number | 0.1 | Displacement in metres (flatten/taper: 0..1 fraction of the way) |
+| `axis` | x \| y \| z | 'z' | Axis for flatten and taper (z is up) |
+| `center` | array | None | Local-space point the rule acts around; omit to use the centre of the mesh's own bounds |
+| `radius` | number | 1.0 | Reach of the effect in metres — verts beyond this from `center` are untouched (taper: full axis half-extent) |
+| `falloff` | smooth \| linear | 'smooth' | How the effect fades toward `radius`; smooth eases out, linear is a straight ramp |
+
+### `morph.animate`
+
+Keyframe a shape key's weight over time so glTF exports a morph-target animation channel — a crate denting on impact, a chest lid swell, a pulsing crystal. Follows the same action idiom as char.animate.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object with the shape key |
+| `key` | string | None | Shape key name to animate |
+| `frames` | array | None | Frame numbers, e.g. [1, 12, 24]; must be the same length as `values` |
+| `values` | array | None | Weight at each frame (0..1), e.g. [0, 1, 0] pops the morph and settles back |
+
+### `morph.list`
+
+Report an object's shape keys: names, slider ranges and current values. Check this before morph.animate — the key name must match exactly.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object to inspect |
+
+### `morph.set`
+
+Set a shape key's slider value (0..1) for review renders — pose the dent at 60% before render.contact_sheet so the still shows the damaged state.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object with the shape key |
+| `key` | string | None | Shape key name (from morph.add or morph.list) |
+| `value` | number | 1.0 | Slider weight, clamped to 0..1: 0 is Basis, 1 is the full morph |
+
 ## `object.*`
 
 ### `object.delete`
@@ -1066,6 +1221,60 @@ Move, rotate or scale an object. Rotation is in degrees.
 | `rotation` | array | None | Euler XYZ rotation in degrees |
 | `scale` | array | None | Per-axis scale multiplier |
 | `apply` | boolean | False | Bake rotation+scale into mesh data (required before export) |
+
+## `paint.*`
+
+### `paint.cavity`
+
+Bake 'dirt in the crevices' or 'edge wear' without textures: a deterministic geometric curvature estimate per vertex. Concave spots (recesses, grooves, inside corners) take the colour in cavity mode; convex ridges take it in edge mode. Blends over the existing layer, so fill white first if the mesh is unpainted.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object to paint — needs real surface relief; a flat quad has no curvature to find |
+| `color` | any | None | Colour blended into the crevices/edges: palette name, #rrggbb, or linear [r,g,b]. Dark browns read as grime, light greys as worn edges |
+| `mode` | cavity \| edge | 'cavity' | cavity paints concave spots (dirt), edge paints convex ridges (wear) |
+| `strength` | number | 1.0 | Blend strength multiplier; the deepest cavity gets the full colour at 1.0 |
+| `invert` | boolean | False | Flip the result — paint everything EXCEPT the crevices/edges |
+| `layer` | string | 'color' | Colour attribute name; the glTF exporter ships the active one as COLOR_0 |
+
+### `paint.fill`
+
+Set every loop of a mesh to one vertex colour. The base coat for the other paint.* ops — fill white before paint.cavity so unpainted areas stay neutral, or fill a flat tint for a stylised asset.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object to paint |
+| `color` | any | None | Colour: palette name, #rrggbb, or linear [r,g,b]. White leaves the material unchanged when the engine multiplies COLOR_0 in |
+| `layer` | string | 'color' | Colour attribute name; the glTF exporter ships the active one as COLOR_0 |
+
+### `paint.height`
+
+Paint a two-colour gradient along an axis — dust at the base of a wall, a snow line on a peak, waterline grime on a hull. Cheaper than any texture and it can never stretch or seam.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object to paint |
+| `low` | any | None | Colour at the bottom of the range: palette name, #rrggbb, or linear [r,g,b] |
+| `high` | any | None | Colour at the top of the range |
+| `axis` | x \| y \| z | 'z' | Axis the gradient runs along (z is up). Measured in the mesh's LOCAL space, like material.face_assign |
+| `min` | number | None | Axis value for 100% `low`; omit to use the mesh's own lower bound. Set both min and max to share one gradient across several objects |
+| `max` | number | None | Axis value for 100% `high`; omit to use the mesh's upper bound |
+| `curve` | linear \| smooth | 'linear' | Gradient easing; smooth eases in and out, which hides the band edges |
+| `layer` | string | 'color' | Colour attribute name; the glTF exporter ships the active one as COLOR_0 |
+
+### `paint.noise`
+
+Blend two colours by deterministic fBm noise sampled at vertex positions — mottled wear, rust patches, moss, dirt variation. Breaks up flat fills so large surfaces stop looking computer-perfect.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object to paint |
+| `color_a` | any | None | Colour where the noise is low: palette name, #rrggbb, or linear [r,g,b] |
+| `color_b` | any | None | Colour where the noise is high |
+| `scale` | number | 2.0 | Noise frequency in 1/metres — higher gives smaller, busier patches |
+| `seed` | integer | 0 | Random seed; same seed gives the same pattern forever |
+| `octaves` | integer | 3 | Fractal detail levels; more octaves, finer grain |
+| `layer` | string | 'color' | Colour attribute name; the glTF exporter ships the active one as COLOR_0 |
 
 ## `prop.*`
 
@@ -1362,6 +1571,20 @@ THE review image. Renders hero/front/side/top plus a wireframe pass (shows topol
 | `engine` | auto \| cycles \| eevee | 'auto' | Render engine |
 | `panels` | array | ['hero', 'front', 'left', 'top', 'wireframe', 'checker'] | Which panels to include |
 | `columns` | integer | 3 | Tiles per row |
+
+### `render.impostor`
+
+Bake an object into a billboard impostor sprite sheet: N orthographic views orbiting it, packed left-to-right then top-to-bottom into ONE transparent PNG, plus a JSON sidecar (grid layout, yaw angles, bounds) with everything a game engine needs to billboard it. This is THE distant-LOD technique — swap the real mesh for a camera-facing quad with this sheet beyond a few hundred metres and a browser can show thousands of instances at full frame rate. Pass normals=True to also bake a world-space normal sheet so the billboard can react to scene lighting.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Object to bake; its children are baked with it. Use object.list if you are unsure of the exact name |
+| `out` | string | 'impostor.png' | Sprite-sheet PNG path. The JSON sidecar is written next to it as <stem>.json |
+| `views` | integer | 8 | Yaw angles around the object, evenly spaced over 360 degrees. 8 is the standard for props; 4 is enough for near-symmetric ones and halves the bake time |
+| `size` | integer | 128 | Pixel size of each frame (frames are square). Billboards are only ever seen at distance, so 64-256 is the useful range — bigger just costs render time |
+| `normals` | boolean | False | Also write <stem>_normal.png: world-space normals packed into 0..1 colour, so the billboard can be lit instead of looking pasted on. Doubles render cost |
+| `samples` | integer | 16 | Cycles samples per frame. 16 is plenty at these sizes; raise only if the sprites look grainy |
+| `elevation` | number | 0.0 | Camera height above the horizon in degrees, the same for every view. Ground props read best at 0-15; high values waste frame area on the top face |
 
 ### `render.turntable`
 

--- a/tools/bforge/README.md
+++ b/tools/bforge/README.md
@@ -130,7 +130,7 @@ tools/bforge/
     daemon.py          JSON-line RPC loop
     registry.py        @op decorator: types, coercion, schema generation
     lib/               mesh, uvs, materials, scene-graph, finishing pass
-    ops/               the ~89 operations, grouped by namespace
+    ops/               the 127 operations, grouped by namespace
   catalog.json       committed op snapshot (so tools/list needs no Blender)
   tests/             unit + live-integration + visual gallery
 ```
@@ -197,8 +197,11 @@ Generation alone is not the hard part. This is:
    shows triangles spent where they buy no silhouette. The checker shows UV
    stretch and texel-density mismatch. Neither is visible in a triangle count.
 4. `check.critique` — numeric findings, each naming the op that fixes it
-5. `gameready.collision`, `gameready.lod`, `gameready.budget`
-6. `export.asset` — `.blend` master + `.glb` + `.meta.json` + review sheet
+5. `gameready.review` — the quality gate: critique + material separation in
+   one pass/fail. `export.asset` runs it by default (`gate=false` overrides),
+   so a mud-blob of identical materials cannot ship by accident
+6. `gameready.collision`, `gameready.lod`, `gameready.budget`
+7. `export.asset` — `.blend` master + `.glb` + `.meta.json` + review sheet
 
 Both halves matter. `check.critique` catches non-manifold edges and texel
 mismatch that no render shows; the contact sheet catches "the proportions are
@@ -208,7 +211,7 @@ wrong" that no metric shows.
 
 ## What it can make
 
-89 ops across 13 namespaces. Full reference: [`docs/bforge/OPS.md`](../../docs/bforge/OPS.md).
+127 ops across 18 namespaces. Full reference: [`docs/bforge/OPS.md`](../../docs/bforge/OPS.md).
 
 - **`prop.*`** — crate, barrel, chest, sack, rock, crystal, tree, pillar, torch,
   fence, furniture, weapon, banner, debris
@@ -218,7 +221,15 @@ wrong" that no metric shows.
   water, roads draped onto terrain, surface scatter, complete arenas
 - **`char.*`** — humanoid blockouts at real figure-drawing proportions, fitted
   armatures with distance-falloff skinning, keyframed idle/walk/run/attack/
-  jump/death/wave clips, bone attachment for weapons
+  jump/death/wave clips, bone attachment for weapons — plus **`char.outfit`**
+  (fitted cuirass/pteruges/greaves/bracers/helmet/shield, bone-parented,
+  materials distinct by construction), **`char.face`** and **`char.hands`**, and
+  **`char.creature`** + **`char.creature_rig`** for quadrupeds (canine/equine/
+  feline/generic plans) with walk/trot/gallop/graze gait tables
+- **`paint.*`** — vertex-colour wear: fill, height gradients (dust/snow/waterline),
+  cavity/edge grime from geometry, deterministic noise. Exports as glTF COLOR_0
+- **`morph.*`** — shape keys (inflate/dent/flatten/taper/bulge) with keyframable
+  weights, exported as glTF morph targets and morph animations
 - **`build.*`** — parametric primitives, lathe, loft, greeble, extrude, bevel,
   array, mirror, deform, and **`build.sweep`**: a cross-section along a path
   (oval / circle / line / arc / custom), which is how racetracks, grandstands,
@@ -230,8 +241,10 @@ wrong" that no metric shows.
   pivots, attachment sockets
 - **`render.*` / `check.*` / `export.*`** — contact sheets, turntables,
   **`render.camera`** (explicit position/target/lens, because auto-framing is
-  useless on a 700 m stadium), studio validation, critique, silhouette scoring,
-  glTF/blend/meta export
+  useless on a 700 m stadium), **`render.impostor`** (billboard sprite sheets +
+  normal sheets + JSON sidecar — the distant-LOD technique), studio validation,
+  critique, **`check.materials`** (perceptual material separation, the mud-blob
+  detector), silhouette scoring, gated glTF/blend/meta export
 - **`session.import`** — pull in an existing GLB/glTF/OBJ/FBX/blend to inspect,
   critique, fix or extend assets a game already ships. This is how the Chariot
   audit above was done.
@@ -281,7 +294,7 @@ wrong" that no metric shows.
 
 ```bash
 just bforge-test        # schema + MCP protocol (fast, no Blender)
-just bforge-test-live   # 42 live Blender integration tests
+just bforge-test-live   # 100+ live Blender integration tests
 just bforge-gallery     # regenerate the visual review gallery
 ```
 

--- a/tools/bforge/catalog.json
+++ b/tools/bforge/catalog.json
@@ -1604,7 +1604,10 @@
               "attack",
               "jump",
               "death",
-              "wave"
+              "wave",
+              "trot",
+              "gallop",
+              "graze"
             ],
             "description": "Which clip to author",
             "default": "idle"
@@ -1725,6 +1728,211 @@
       }
     },
     {
+      "name": "char.creature",
+      "summary": "Proportioned quadruped body (canine/equine/feline/generic) or hexapod (insect: scarab class, three leg stations). Pair with char.creature_rig and char.animate \u2014 walk/trot/gallop/graze for quadrupeds, tripod-gait walk for hexapods. Deterministic, data-API only, metres.",
+      "tags": [
+        "char"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Object name",
+            "default": "creature"
+          },
+          "length": {
+            "type": "number",
+            "description": "Body length in metres (chest-to-hip; abdomen-tip to head for insect)",
+            "default": 1.4
+          },
+          "shoulder": {
+            "type": "number",
+            "description": "Shoulder height in metres (thorax height for insect)",
+            "default": 0.9
+          },
+          "plan": {
+            "type": "string",
+            "enum": [
+              "canine",
+              "equine",
+              "feline",
+              "generic",
+              "insect"
+            ],
+            "description": "Body plan \u2014 quadruped proportions or the hexapod scarab class",
+            "default": "canine"
+          },
+          "bulk": {
+            "type": "number",
+            "description": "Extra girth multiplier",
+            "default": 1.0
+          },
+          "detail": {
+            "type": "integer",
+            "description": "Limb cross-section segments",
+            "default": 8
+          },
+          "location": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "description": "World position",
+            "default": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "skin": {
+            "type": "string",
+            "description": "Body colour",
+            "default": "#7a6248"
+          },
+          "seed": {
+            "type": "integer",
+            "description": "Random seed",
+            "default": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "char.creature_rig",
+      "summary": "Build a quadruped armature (hips root, spine chain, neck/head, 2-segment tail, 3-bone legs at both stations) fitted to a char.creature body, and skin it with the same shell-constrained distance-falloff solve as char.rig.",
+      "tags": [
+        "char",
+        "rig"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Creature mesh object (from char.creature)"
+          },
+          "length": {
+            "type": "number",
+            "description": "Chest-to-hip length; 0 measures from the mesh bounds Y extent",
+            "default": 0.0
+          },
+          "shoulder": {
+            "type": "number",
+            "description": "Shoulder height; 0 measures from the mesh bounds Z extent",
+            "default": 0.0
+          },
+          "plan": {
+            "type": "string",
+            "enum": [
+              "canine",
+              "equine",
+              "feline",
+              "generic",
+              "insect"
+            ],
+            "description": "Body plan the rig assumes \u2014 match char.creature",
+            "default": "canine"
+          },
+          "falloff": {
+            "type": "number",
+            "description": "Weight blend sharpness; higher is more rigid",
+            "default": 1.6
+          },
+          "armature_name": {
+            "type": "string",
+            "description": "Armature object name (defaults to <mesh>_rig)",
+            "default": ""
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "char.face",
+      "summary": "Give a char.humanoid head a readable face \u2014 brow ridge, nose wedge, chin \u2014 so a close-up review render reads as a person, not a box. Stylised readability, not realism. Geometry is welded into the body mesh and takes the head bone when skinned.",
+      "tags": [
+        "char"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Body mesh (from char.humanoid)"
+          },
+          "height": {
+            "type": "number",
+            "description": "Character height; 0 measures the mesh bounds",
+            "default": 0.0
+          },
+          "build": {
+            "type": "string",
+            "enum": [
+              "realistic",
+              "heroic",
+              "stylized",
+              "chibi",
+              "lithe"
+            ],
+            "description": "Proportions \u2014 match the char.humanoid build",
+            "default": "heroic"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "char.hands",
+      "summary": "Upgrade a char.humanoid's block hands with readable fingers: four two-segment fingers with a relaxed curl plus a thumb, so a weapon grip or open hand reads at review distance. Welded into the body mesh; the hand bones own them when skinned.",
+      "tags": [
+        "char"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Body mesh (from char.humanoid)"
+          },
+          "height": {
+            "type": "number",
+            "description": "Character height; 0 measures the mesh bounds",
+            "default": 0.0
+          },
+          "build": {
+            "type": "string",
+            "enum": [
+              "realistic",
+              "heroic",
+              "stylized",
+              "chibi",
+              "lithe"
+            ],
+            "description": "Proportions \u2014 match the char.humanoid build",
+            "default": "heroic"
+          },
+          "curl": {
+            "type": "number",
+            "description": "Finger curl in radians-ish (0 flat, 0.8 fist); a relaxed read is ~0.35",
+            "default": 0.35
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "char.humanoid",
       "summary": "Proportioned humanoid blockout using classic figure-drawing head ratios (7.5 realistic, 8 heroic, 4 chibi). ~1400 tris. Pair with char.rig and char.animate for a complete animated character.",
       "tags": [
@@ -1789,6 +1997,112 @@
           "seed": {
             "type": "integer",
             "description": "Random seed",
+            "default": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "char.outfit",
+      "summary": "Fit an armour or clothing piece to a char.humanoid body: cuirass, pteruges skirt, greaves, bracers, helmet or round shield. Fit is derived from the body's own proportions, materials are perceptually distinct by construction (this is the anti 'brown blob' op), and pieces bone-parent to the rig when one exists so they animate with the character.",
+      "tags": [
+        "char"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Body mesh (from char.humanoid)"
+          },
+          "piece": {
+            "type": "string",
+            "enum": [
+              "cuirass",
+              "pteruges",
+              "greaves",
+              "bracers",
+              "helmet",
+              "shield"
+            ],
+            "description": "What to fit. greaves and bracers come in pairs",
+            "default": "cuirass"
+          },
+          "height": {
+            "type": "number",
+            "description": "Character height; 0 measures the mesh bounds",
+            "default": 0.0
+          },
+          "build": {
+            "type": "string",
+            "enum": [
+              "realistic",
+              "heroic",
+              "stylized",
+              "chibi",
+              "lithe"
+            ],
+            "description": "Proportions the fit assumes \u2014 match the char.humanoid build",
+            "default": "heroic"
+          },
+          "material": {
+            "type": "string",
+            "enum": [
+              "bronze",
+              "iron",
+              "leather",
+              "cloth"
+            ],
+            "description": "Material family (defaults per piece: bronze for cuirass/greaves/helmet/shield, leather for pteruges/bracers). The families are deliberately far apart in colour and response \u2014 keep them that way",
+            "default": ""
+          },
+          "color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Override colour; stay clear of the other pieces' colours or check.materials will fail the set",
+            "default": ""
+          },
+          "crest": {
+            "type": "string",
+            "enum": [
+              "none",
+              "longitudinal",
+              "transverse"
+            ],
+            "description": "helmet: crest ridge orientation",
+            "default": "longitudinal"
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "l",
+              "r"
+            ],
+            "description": "shield: which forearm carries it",
+            "default": "l"
+          },
+          "gap": {
+            "type": "number",
+            "description": "Clearance between body and armour in metres; raise for bulky bodies",
+            "default": 0.012
+          },
+          "seed": {
+            "type": "integer",
+            "description": "Random seed (reserved; current pieces are fully deterministic)",
             "default": 0
           }
         },
@@ -1916,6 +2230,41 @@
       }
     },
     {
+      "name": "check.conformance",
+      "summary": "Score how well each object conforms to the set's (or a reference object's) style fingerprint. Names the exact axis that breaks coherence \u2014 palette drift, texel-density mismatch, density outlier, edge-treatment drift \u2014 with the op that fixes it. The art-director gate: run it over a whole pack before export.",
+      "tags": [
+        "check",
+        "inspect",
+        "material"
+      ],
+      "mutates": false,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "objects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Objects to score (empty = every mesh)",
+            "default": []
+          },
+          "reference": {
+            "type": "string",
+            "description": "Conform to THIS object's fingerprint instead of the set median",
+            "default": ""
+          },
+          "texture_size": {
+            "type": "integer",
+            "description": "Texture resolution the texel-density figure assumes",
+            "default": 1024
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "check.critique",
       "summary": "Quality critique with specific, actionable findings: triangle-density hot spots, degenerate and n-gon faces, UV stretch, texel-density mismatch between objects, non-manifold edges, unused material slots. Pair it with render.contact_sheet \u2014 numbers plus eyes.",
       "tags": [
@@ -1985,6 +2334,36 @@
       }
     },
     {
+      "name": "check.materials",
+      "summary": "Measure whether an asset's materials are actually distinguishable \u2014 the '8 materials, all the same brown' failure that produces mud-blob characters. Reports every material's colour in CIELAB and the pairwise perceptual distance (\u0394E); fails when several materials are perceptually identical or share one roughness/metallic signature.",
+      "tags": [
+        "check",
+        "inspect",
+        "material"
+      ],
+      "mutates": false,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "objects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Objects whose materials to measure (empty = every mesh)",
+            "default": []
+          },
+          "min_delta_e": {
+            "type": "number",
+            "description": "Perceptual-separation floor in \u0394E76. Below ~6 the difference is invisible in game; 12 is a safe bar for metal vs leather vs cloth",
+            "default": 12.0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "check.silhouette",
       "summary": "Score how readable an object's silhouette is from the standard game camera angles. A prop that fails here will not read at gameplay distance no matter how good its texture is.",
       "tags": [
@@ -2004,6 +2383,41 @@
             "type": "integer",
             "description": "Rays per axis for the projected-area estimate",
             "default": 64
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "check.style",
+      "summary": "Compute the style fingerprint of every mesh: area-weighted palette (in CIELAB), texel density, triangle density, hard-edge ratio, material count, UV coverage. This is the raw material of art direction \u2014 'do these 40 assets look like one game' is unanswerable without it.",
+      "tags": [
+        "check",
+        "inspect",
+        "material"
+      ],
+      "mutates": false,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "objects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Objects to fingerprint (empty = every mesh)",
+            "default": []
+          },
+          "texture_size": {
+            "type": "integer",
+            "description": "Texture resolution the texel-density figure assumes",
+            "default": 1024
+          },
+          "palette_size": {
+            "type": "integer",
+            "description": "Dominant colours to keep per object, area-weighted",
+            "default": 4
           }
         },
         "additionalProperties": false
@@ -2676,6 +3090,20 @@
             "type": "boolean",
             "description": "Block export on problems that would corrupt the import",
             "default": true
+          },
+          "gate": {
+            "type": "boolean",
+            "description": "Run gameready.review before writing anything; a failed review blocks the hand-off. Set false only for deliberate blockouts",
+            "default": true
+          },
+          "style": {
+            "type": "string",
+            "enum": [
+              "stylized",
+              "realistic"
+            ],
+            "description": "Art direction passed to gameready.review when gate=true",
+            "default": "stylized"
           }
         },
         "additionalProperties": false
@@ -3144,6 +3572,53 @@
             "type": "boolean",
             "description": "Also move the object itself to (0,0,0). Required for a single-asset master file \u2014 the studio validator rejects a root object that is not at the world origin",
             "default": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "gameready.review",
+      "summary": "The quality gate: aggregate check.critique and check.materials into one pass/fail verdict before export. Exists because quality steps that are optional get skipped \u2014 a scene that passes this cannot ship the mud-blob failure (perceptually identical materials), broken geometry, or missing UVs without knowing it.",
+      "tags": [
+        "gameready",
+        "check"
+      ],
+      "mutates": false,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "objects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Objects to review (empty = every mesh in the scene)",
+            "default": []
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "error",
+              "warn"
+            ],
+            "description": "Findings at this level or worse fail the gate. 'error' blocks only what corrupts or reads as broken; 'warn' also blocks advisories like texel-density spread",
+            "default": "error"
+          },
+          "style": {
+            "type": "string",
+            "enum": [
+              "stylized",
+              "realistic"
+            ],
+            "description": "'realistic' additionally fails an asset whose materials are ALL flat untextured colour \u2014 bake material.bake_pbr or pick the stylized look deliberately",
+            "default": "stylized"
+          },
+          "min_delta_e": {
+            "type": "number",
+            "description": "Material-separation floor in \u0394E76, passed to check.materials",
+            "default": 12.0
           }
         },
         "additionalProperties": false
@@ -4244,6 +4719,165 @@
       }
     },
     {
+      "name": "morph.add",
+      "summary": "Add a shape key that displaces vertices by a deterministic rule \u2014 dent a crate for a damage state, inflate a cartoon prop, taper a tree trunk, bulge a cartoon cheek. Exports to glTF as a morph target on top of Basis.",
+      "tags": [
+        "morph"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object to add the shape key to"
+          },
+          "key": {
+            "type": "string",
+            "description": "Shape key name \u2014 this becomes the glTF morph target name (extras.targetNames), so make it meaningful: 'dented', 'inflate', 'blink'"
+          },
+          "rule": {
+            "type": "string",
+            "enum": [
+              "inflate",
+              "dent",
+              "flatten",
+              "taper",
+              "bulge"
+            ],
+            "description": "Displacement rule: inflate pushes verts out along their normals, dent pulls verts inside `radius` toward `center`, bulge pushes them away, flatten squashes toward the center plane along `axis`, taper scales the cross-section down along `axis`",
+            "default": "dent"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Displacement in metres (flatten/taper: 0..1 fraction of the way)",
+            "default": 0.1
+          },
+          "axis": {
+            "type": "string",
+            "enum": [
+              "x",
+              "y",
+              "z"
+            ],
+            "description": "Axis for flatten and taper (z is up)",
+            "default": "z"
+          },
+          "center": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "description": "Local-space point the rule acts around; omit to use the centre of the mesh's own bounds"
+          },
+          "radius": {
+            "type": "number",
+            "description": "Reach of the effect in metres \u2014 verts beyond this from `center` are untouched (taper: full axis half-extent)",
+            "default": 1.0
+          },
+          "falloff": {
+            "type": "string",
+            "enum": [
+              "smooth",
+              "linear"
+            ],
+            "description": "How the effect fades toward `radius`; smooth eases out, linear is a straight ramp",
+            "default": "smooth"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "morph.animate",
+      "summary": "Keyframe a shape key's weight over time so glTF exports a morph-target animation channel \u2014 a crate denting on impact, a chest lid swell, a pulsing crystal. Follows the same action idiom as char.animate.",
+      "tags": [
+        "morph",
+        "anim"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object with the shape key"
+          },
+          "key": {
+            "type": "string",
+            "description": "Shape key name to animate"
+          },
+          "frames": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Frame numbers, e.g. [1, 12, 24]; must be the same length as `values`"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Weight at each frame (0..1), e.g. [0, 1, 0] pops the morph and settles back"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "morph.list",
+      "summary": "Report an object's shape keys: names, slider ranges and current values. Check this before morph.animate \u2014 the key name must match exactly.",
+      "tags": [
+        "morph",
+        "inspect"
+      ],
+      "mutates": false,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object to inspect"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "morph.set",
+      "summary": "Set a shape key's slider value (0..1) for review renders \u2014 pose the dent at 60% before render.contact_sheet so the still shows the damaged state.",
+      "tags": [
+        "morph"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object with the shape key"
+          },
+          "key": {
+            "type": "string",
+            "description": "Shape key name (from morph.add or morph.list)"
+          },
+          "value": {
+            "type": "number",
+            "description": "Slider weight, clamped to 0..1: 0 is Basis, 1 is the full morph",
+            "default": 1.0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "object.delete",
       "summary": "Remove objects from the scene.",
       "tags": [
@@ -4510,6 +5144,259 @@
             "type": "boolean",
             "description": "Bake rotation+scale into mesh data (required before export)",
             "default": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "paint.cavity",
+      "summary": "Bake 'dirt in the crevices' or 'edge wear' without textures: a deterministic geometric curvature estimate per vertex. Concave spots (recesses, grooves, inside corners) take the colour in cavity mode; convex ridges take it in edge mode. Blends over the existing layer, so fill white first if the mesh is unpainted.",
+      "tags": [
+        "paint"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object to paint \u2014 needs real surface relief; a flat quad has no curvature to find"
+          },
+          "color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Colour blended into the crevices/edges: palette name, #rrggbb, or linear [r,g,b]. Dark browns read as grime, light greys as worn edges"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "cavity",
+              "edge"
+            ],
+            "description": "cavity paints concave spots (dirt), edge paints convex ridges (wear)",
+            "default": "cavity"
+          },
+          "strength": {
+            "type": "number",
+            "description": "Blend strength multiplier; the deepest cavity gets the full colour at 1.0",
+            "default": 1.0
+          },
+          "invert": {
+            "type": "boolean",
+            "description": "Flip the result \u2014 paint everything EXCEPT the crevices/edges",
+            "default": false
+          },
+          "layer": {
+            "type": "string",
+            "description": "Colour attribute name; the glTF exporter ships the active one as COLOR_0",
+            "default": "color"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "paint.fill",
+      "summary": "Set every loop of a mesh to one vertex colour. The base coat for the other paint.* ops \u2014 fill white before paint.cavity so unpainted areas stay neutral, or fill a flat tint for a stylised asset.",
+      "tags": [
+        "paint"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object to paint"
+          },
+          "color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Colour: palette name, #rrggbb, or linear [r,g,b]. White leaves the material unchanged when the engine multiplies COLOR_0 in"
+          },
+          "layer": {
+            "type": "string",
+            "description": "Colour attribute name; the glTF exporter ships the active one as COLOR_0",
+            "default": "color"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "paint.height",
+      "summary": "Paint a two-colour gradient along an axis \u2014 dust at the base of a wall, a snow line on a peak, waterline grime on a hull. Cheaper than any texture and it can never stretch or seam.",
+      "tags": [
+        "paint"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object to paint"
+          },
+          "low": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Colour at the bottom of the range: palette name, #rrggbb, or linear [r,g,b]"
+          },
+          "high": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Colour at the top of the range"
+          },
+          "axis": {
+            "type": "string",
+            "enum": [
+              "x",
+              "y",
+              "z"
+            ],
+            "description": "Axis the gradient runs along (z is up). Measured in the mesh's LOCAL space, like material.face_assign",
+            "default": "z"
+          },
+          "min": {
+            "type": "number",
+            "description": "Axis value for 100% `low`; omit to use the mesh's own lower bound. Set both min and max to share one gradient across several objects"
+          },
+          "max": {
+            "type": "number",
+            "description": "Axis value for 100% `high`; omit to use the mesh's upper bound"
+          },
+          "curve": {
+            "type": "string",
+            "enum": [
+              "linear",
+              "smooth"
+            ],
+            "description": "Gradient easing; smooth eases in and out, which hides the band edges",
+            "default": "linear"
+          },
+          "layer": {
+            "type": "string",
+            "description": "Colour attribute name; the glTF exporter ships the active one as COLOR_0",
+            "default": "color"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "paint.noise",
+      "summary": "Blend two colours by deterministic fBm noise sampled at vertex positions \u2014 mottled wear, rust patches, moss, dirt variation. Breaks up flat fills so large surfaces stop looking computer-perfect.",
+      "tags": [
+        "paint"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object to paint"
+          },
+          "color_a": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Colour where the noise is low: palette name, #rrggbb, or linear [r,g,b]"
+          },
+          "color_b": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Colour where the noise is high"
+          },
+          "scale": {
+            "type": "number",
+            "description": "Noise frequency in 1/metres \u2014 higher gives smaller, busier patches",
+            "default": 2.0
+          },
+          "seed": {
+            "type": "integer",
+            "description": "Random seed; same seed gives the same pattern forever",
+            "default": 0
+          },
+          "octaves": {
+            "type": "integer",
+            "description": "Fractal detail levels; more octaves, finer grain",
+            "default": 3
+          },
+          "layer": {
+            "type": "string",
+            "description": "Colour attribute name; the glTF exporter ships the active one as COLOR_0",
+            "default": "color"
           }
         },
         "additionalProperties": false
@@ -5954,6 +6841,55 @@
             "type": "integer",
             "description": "Tiles per row",
             "default": 3
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "render.impostor",
+      "summary": "Bake an object into a billboard impostor sprite sheet: N orthographic views orbiting it, packed left-to-right then top-to-bottom into ONE transparent PNG, plus a JSON sidecar (grid layout, yaw angles, bounds) with everything a game engine needs to billboard it. This is THE distant-LOD technique \u2014 swap the real mesh for a camera-facing quad with this sheet beyond a few hundred metres and a browser can show thousands of instances at full frame rate. Pass normals=True to also bake a world-space normal sheet so the billboard can react to scene lighting.",
+      "tags": [
+        "render"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Object to bake; its children are baked with it. Use object.list if you are unsure of the exact name"
+          },
+          "out": {
+            "type": "string",
+            "description": "Sprite-sheet PNG path. The JSON sidecar is written next to it as <stem>.json",
+            "default": "impostor.png"
+          },
+          "views": {
+            "type": "integer",
+            "description": "Yaw angles around the object, evenly spaced over 360 degrees. 8 is the standard for props; 4 is enough for near-symmetric ones and halves the bake time",
+            "default": 8
+          },
+          "size": {
+            "type": "integer",
+            "description": "Pixel size of each frame (frames are square). Billboards are only ever seen at distance, so 64-256 is the useful range \u2014 bigger just costs render time",
+            "default": 128
+          },
+          "normals": {
+            "type": "boolean",
+            "description": "Also write <stem>_normal.png: world-space normals packed into 0..1 colour, so the billboard can be lit instead of looking pasted on. Doubles render cost",
+            "default": false
+          },
+          "samples": {
+            "type": "integer",
+            "description": "Cycles samples per frame. 16 is plenty at these sizes; raise only if the sprites look grainy",
+            "default": 16
+          },
+          "elevation": {
+            "type": "number",
+            "description": "Camera height above the horizon in degrees, the same for every view. Ground props read best at 0-15; high values waste frame area on the top face",
+            "default": 0.0
           }
         },
         "additionalProperties": false

--- a/tools/bforge/examples/characters.py
+++ b/tools/bforge/examples/characters.py
@@ -1,0 +1,127 @@
+"""Build a four-character cast through the full bforge quality loop.
+
+Every character: proportioned humanoid -> face + hands -> era-appropriate
+outfit -> vertex-colour wear -> rig + idle/walk clips -> quality gate ->
+gated export (.blend + .glb + .meta.json + contact sheet).
+
+Usage (from the repo root):
+
+    uv run --project tools python tools/bforge/examples/characters.py [out_dir]
+
+The point of the example is the LOOP, not the cast: generate, measure
+(check.materials, gameready.review), then export only what passes. Characters
+are where the 'brown blob' failure hurts most, and every guard against it is
+exercised here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge import Forge  # noqa: E402
+
+CAST = [
+    {
+        "id": "settler",
+        "brief": "First Fire settler — hide wrap, work-worn hands, no metal anywhere",
+        "height": 1.68, "build": "stylized", "skin": "#a8795a",
+        "outfit": [("pteruges", "cloth"), ("bracers", "leather")],
+        "wear_on": [],
+        "seed": 11,
+    },
+    {
+        "id": "scout",
+        "brief": "Hunter-scout — lean, leather bracers, cloth wrap, moves first",
+        "height": 1.74, "build": "lithe", "skin": "#8a6248",
+        "outfit": [("pteruges", "cloth"), ("bracers", "leather")],
+        "wear_on": [],
+        "seed": 23,
+    },
+    {
+        "id": "warden",
+        "brief": "Fortification-era bronze guard — cuirass, crested helmet, aspis on the forearm",
+        "height": 1.82, "build": "heroic", "skin": "#b08a68",
+        "outfit": [("cuirass", "bronze"), ("pteruges", "leather"), ("greaves", "bronze"),
+                   ("bracers", "leather"), ("helmet", "bronze"), ("shield", "bronze")],
+        "wear_on": ["cuirass", "helmet", "shield"],
+        "seed": 3,
+    },
+    {
+        "id": "raider",
+        "brief": "Frontier raider — heavy, dark leather and scavenged iron, shield right",
+        "height": 1.86, "build": "realistic", "skin": "#96684e",
+        "outfit": [("cuirass", "iron"), ("pteruges", "leather"), ("bracers", "leather"),
+                   ("helmet", "iron"), ("shield", "iron")],
+        "wear_on": ["cuirass", "helmet", "shield"],
+        "seed": 41,
+    },
+]
+
+
+def build_character(forge: Forge, spec: dict, out_dir: Path) -> dict:
+    forge.call("session.reset")
+    name = spec["id"]
+    height = spec["height"]
+
+    forge.call("char.humanoid", name=name, height=height, build=spec["build"],
+               skin=spec["skin"], seed=spec["seed"])
+    forge.call("char.face", name=name, height=height, build=spec["build"])
+    forge.call("char.hands", name=name, height=height, build=spec["build"])
+
+    pieces = []
+    for piece, material in spec["outfit"]:
+        result = forge.call(
+            "char.outfit", name=name, piece=piece, height=height,
+            build=spec["build"], material=material,
+            side="r" if spec["id"] == "raider" and piece == "shield" else "l",
+        )
+        pieces.append((result["object"], material))
+
+    # Wear: grime in the cavities, dust at the hem — on METAL, where it reads.
+    for obj, material in pieces:
+        if obj.rsplit("_", 1)[-1] in spec["wear_on"]:
+            forge.call("paint.fill", name=obj, color="#ffffff")
+            forge.call("paint.cavity", name=obj, color="#3a2c1c",
+                       mode="cavity", strength=0.55)
+            forge.call("paint.height", name=obj, low="#5a4a34", high="#ffffff",
+                       curve="smooth")
+
+    rig = forge.call("char.rig", name=name, height=height, build=spec["build"])
+    for clip in ("idle", "walk"):
+        forge.call("char.animate", rig=rig["armature"], clip=clip, length=24)
+
+    objects = [name, rig["armature"]] + [obj for obj, _m in pieces]
+    review = forge.call("gameready.review", objects=objects)
+    if not review["passed"]:
+        raise SystemExit(f"{name} failed the quality gate: {review['findings']}")
+
+    result = forge.call(
+        "export.asset", asset_id=name, out_dir=str(out_dir), objects=objects,
+        engine="threejs", category="character", ai_prompt=spec["brief"],
+    )
+    separation = forge.call("check.materials", objects=objects)["max_delta_e"]
+    return {
+        "id": name, "triangles": result["triangles"], "bytes": result["bytes"],
+        "max_delta_e": separation, "pieces": len(pieces),
+    }
+
+
+def main() -> None:
+    out_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "characters")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with Forge() as forge:
+        for spec in CAST:
+            report = build_character(forge, spec, out_dir)
+            print(
+                f"{report['id']:8s}  {report['triangles']:5d} tris  "
+                f"{report['pieces']} pieces  ΔE {report['max_delta_e']:5.1f}  "
+                f"{report['bytes'] / 1024:.0f} KiB"
+            )
+    print(f"\npack -> {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bforge/examples/first_fire.py
+++ b/tools/bforge/examples/first_fire.py
@@ -1,0 +1,199 @@
+"""The First Fire settlement pack — Ashenward's Age-1 homestead, in one scene.
+
+Eight camp assets on a 4 m grid, all built from stock bforge recipes and
+compositions, then gated TWICE: per-asset gameready.review inside the gated
+export.asset, and check.conformance across the whole set — because a camp of
+individually-fine props that don't look like one game is the failure this
+example exists to prevent.
+
+    uv run --project tools python tools/bforge/examples/first_fire.py [out_dir]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge import Forge  # noqa: E402
+
+GRID = 4.0  # metres between asset anchors
+
+
+def campfire(f: Forge, at):
+    names = []
+    for i in range(8):
+        angle = i * 45.0
+        x = at[0] + 0.45 * __import__("math").cos(__import__("math").radians(angle))
+        y = at[1] + 0.45 * __import__("math").sin(__import__("math").radians(angle))
+        names.append(f.call("prop.rock", name=f"campfire_stone_{i}",
+                            location=[x, y, at[2]], size=[0.24, 0.22, 0.2],
+                            detail=1, seed=60 + i)["name"])
+    for i in range(3):
+        names.append(f.call(
+            "build.cylinder", name=f"campfire_log_{i}", radius=0.045, depth=0.7,
+            segments=8, material="wood", color="#5d4426",
+            location=[at[0], at[1], at[2] + 0.28])["name"])
+        f.call("object.transform", name=f"campfire_log_{i}",
+               rotation=[62.0, 0.0, i * 120.0])
+    coals = f.call("build.cylinder", name="campfire_coals", radius=0.26,
+                   radius_top=0.2, depth=0.1, segments=12, material="stone",
+                   location=[at[0], at[1], at[2] + 0.05])["name"]
+    f.call("material.set", object=coals, preset="stone", name="m_embers",
+           color="#ff5a14", emission=4.5)
+    return names + [coals]
+
+
+def hide_tent(f: Forge, at):
+    names = []
+    # Ridge pole along X at the peak, one support pole at each end.
+    names.append(f.call(
+        "build.cylinder", name="tent_ridge", radius=0.035, depth=2.4,
+        segments=8, material="wood", color="#6a4e2c",
+        location=[at[0], at[1], at[2] + 1.55])["name"])
+    f.call("object.transform", name="tent_ridge", rotation=[0.0, 90.0, 0.0])
+    for side in (-1, 1):
+        names.append(f.call(
+            "build.cylinder", name=f"tent_pole_{side}", radius=0.035, depth=1.6,
+            segments=8, material="wood", color="#6a4e2c",
+            location=[at[0] + side * 1.1, at[1], at[2] + 0.8])["name"])
+    # Two sloped hide panels leaning on the ridge — the A in A-frame.
+    for side, rot, yoff in (("a", 58.0, -0.72), ("b", -58.0, 0.72)):
+        panel = f.call("build.box", name=f"tent_hide_{side}", size=[2.3, 0.05, 1.9],
+                       material="cloth", color="#7a5a38",
+                       location=[at[0], at[1] + yoff, at[2] + 0.82])["name"]
+        f.call("object.transform", name=panel, rotation=[rot, 0.0, 0.0])
+        f.call("paint.fill", name=panel, color="#c9b898")
+        f.call("paint.cavity", name=panel, color="#4a3620", mode="cavity", strength=0.5)
+        names.append(panel)
+    return names
+
+
+def palisade(f: Forge, at):
+    names = []
+    for i in range(7):
+        depth = 2.4 if i % 2 == 0 else 2.55
+        names.append(f.call(
+            "build.cylinder", name=f"palisade_log_{i}", radius=0.09, radius_top=0.0,
+            depth=depth, segments=10, material="wood", color="#6a4e2c",
+            location=[at[0] + (i - 3) * 0.19, at[1], at[2] + depth / 2.0])["name"])
+    return names
+
+
+def storage_rack(f: Forge, at):
+    rack = f.call("prop.furniture", name="rack", kind="shelf",
+                  size=[1.4, 0.5, 1.2], location=list(at), seed=21)["name"]
+    sack_a = f.call("prop.sack", name="rack_sack_a",
+                    location=[at[0] - 0.3, at[1], at[2] + 0.75], seed=31)["name"]
+    sack_b = f.call("prop.sack", name="rack_sack_b",
+                    location=[at[0] + 0.32, at[1] - 0.05, at[2]], seed=47)["name"]
+    return [rack, sack_a, sack_b]
+
+
+def well(f: Forge, at):
+    import math
+    names = []
+    for row in range(2):
+        for i in range(9):
+            angle = i * 40.0 + row * 20.0
+            names.append(f.call(
+                "prop.rock", name=f"well_stone_{row}_{i}",
+                location=[at[0] + 0.62 * math.cos(math.radians(angle)),
+                          at[1] + 0.62 * math.sin(math.radians(angle)),
+                          at[2] + 0.14 + row * 0.24],
+                size=[0.3, 0.28, 0.24], detail=1, seed=100 + row * 10 + i)["name"])
+    for side in (-1, 1):
+        names.append(f.call(
+            "build.cylinder", name=f"well_post_{side}", radius=0.05, depth=1.3,
+            segments=8, material="wood", color="#6a4e2c",
+            location=[at[0] + side * 0.62, at[1], at[2] + 0.65])["name"])
+    names.append(f.call(
+        "build.cylinder", name="well_bar", radius=0.045, depth=1.34, segments=8,
+        material="wood", color="#5d4426",
+        location=[at[0], at[1], at[2] + 1.28])["name"])
+    f.call("object.transform", name="well_bar", rotation=[0.0, 90.0, 0.0])
+    return names
+
+
+def workbench(f: Forge, at):
+    bench = f.call("prop.furniture", name="workbench", kind="table",
+                   size=[1.4, 0.7, 0.8], location=list(at), seed=9)["name"]
+    axe = f.call("prop.weapon", name="bench_axe", kind="axe",
+                 location=[at[0] + 0.2, at[1], at[2] + 0.82], seed=5)["name"]
+    f.call("object.transform", name="bench_axe", rotation=[0.0, 0.0, 78.0])
+    debris = f.call("prop.debris", name="bench_shavings",
+                    location=[at[0] - 0.4, at[1] + 0.3, at[2]], seed=12)["name"]
+    return [bench, axe, debris]
+
+
+def firewood(f: Forge, at):
+    names = []
+    rows = ((3, 0.07), (2, 0.21), (1, 0.35))
+    for row, (count, z) in enumerate(rows):
+        for i in range(count):
+            names.append(f.call(
+                "build.cylinder", name=f"firewood_{row}_{i}", radius=0.07,
+                depth=0.8, segments=10, material="wood", color="#6a4e2c",
+                location=[at[0] + (i - (count - 1) / 2.0) * 0.16, at[1], at[2] + z])["name"])
+            f.call("object.transform", name=f"firewood_{row}_{i}",
+                   rotation=[0.0, 90.0, 0.0])
+    return names
+
+
+def supply_stack(f: Forge, at):
+    crate = f.call("prop.crate", name="supply_crate", location=list(at), seed=3)["name"]
+    barrel = f.call("prop.barrel", name="supply_barrel", height=0.9, bands=3,
+                    location=[at[0] + 0.85, at[1] + 0.2, at[2]], seed=7)["name"]
+    sack = f.call("prop.sack", name="supply_sack",
+                  location=[at[0] + 0.35, at[1] - 0.55, at[2]], seed=53)["name"]
+    f.call("object.transform", name="supply_crate", rotation=[0.0, 0.0, 12.0])
+    return [crate, barrel, sack]
+
+
+ASSETS = [
+    ("campfire", campfire, "The First Fire itself — stone ring, log teepee, live embers"),
+    ("hide_tent", hide_tent, "A-frame hide shelter, weathered leather"),
+    ("palisade", palisade, "Sharpened-log stockade section"),
+    ("storage_rack", storage_rack, "Drying/storage rack with sacks"),
+    ("well", well, "Stone well with wooden windlass frame"),
+    ("workbench", workbench, "Crafter's bench with axe and shavings"),
+    ("firewood_pile", firewood, "Stacked firewood pyramid"),
+    ("supply_stack", supply_stack, "Crate, barrel and sack supply cluster"),
+]
+
+
+def main() -> None:
+    out_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "first_fire")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with Forge() as forge:
+        forge.call("session.reset")
+        every_object = []
+        per_asset = {}
+        for index, (asset_id, builder, _brief) in enumerate(ASSETS):
+            at = [(index % 4) * GRID, (index // 4) * GRID, 0.0]
+            names = builder(forge, at)
+            per_asset[asset_id] = names
+            every_object.extend(names)
+
+        conformance = forge.call("check.conformance", objects=every_object)
+        print(f"set conformance: {conformance['coherent']}/{len(conformance['objects'])} "
+              f"coherent, outliers: {conformance['outliers'] or 'none'}")
+
+        for asset_id, _builder, brief in ASSETS:
+            names = per_asset[asset_id]
+            review = forge.call("gameready.review", objects=names)
+            if not review["passed"]:
+                raise SystemExit(f"{asset_id} failed the gate: {review['findings']}")
+            result = forge.call(
+                "export.asset", asset_id=asset_id, out_dir=str(out_dir),
+                objects=names, engine="threejs", category="environment",
+                ai_prompt=brief, contact_sheet=True,
+            )
+            print(f"{asset_id:14s} {result['triangles']:5d} tris  "
+                  f"{result['bytes'] / 1024:4.0f} KiB")
+    print(f"\npack -> {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bforge/runtime/ops/__init__.py
+++ b/tools/bforge/runtime/ops/__init__.py
@@ -6,10 +6,12 @@ Layering, low to high:
     build     parametric primitives and mesh editing
     material  PBR + procedural materials, baking
     uv        unwrapping and UV measurement
+    paint     vertex colours, exported as glTF COLOR_0
     prop      finished props (crate, barrel, chest, rock, ...)
     kit       modular building kits on a snap grid
     env       terrain, trees, scatter
     char      humanoid blockouts, armatures, animation
+    morph     shape keys, exported as glTF morph targets
     gameready LODs, collision, budgets, atlases
     render    contact sheets and turntables — the agent's eyes
     export    glTF/GLB with per-engine presets
@@ -21,11 +23,13 @@ from . import build  # noqa: F401
 from . import arch  # noqa: F401
 from . import material  # noqa: F401
 from . import uv  # noqa: F401
+from . import paint  # noqa: F401
 from . import prop  # noqa: F401
 from . import kit  # noqa: F401
 from . import env  # noqa: F401
 from . import char  # noqa: F401
 from . import rig  # noqa: F401
+from . import morph  # noqa: F401
 from . import gameready  # noqa: F401
 from . import render  # noqa: F401
 from . import export  # noqa: F401

--- a/tools/bforge/runtime/ops/char.py
+++ b/tools/bforge/runtime/ops/char.py
@@ -420,7 +420,11 @@ def _skin(obj, joints, falloff, rig=None):
 # animation
 # ---------------------------------------------------------------------------
 
-CLIPS = ["idle", "walk", "run", "attack", "jump", "death", "wave"]
+CLIPS = ["idle", "walk", "run", "attack", "jump", "death", "wave",
+         "trot", "gallop", "graze"]
+
+_HUMANOID_ONLY = {"run", "attack", "jump", "death", "wave"}
+_QUADRUPED_ONLY = {"trot", "gallop", "graze"}
 
 
 def action_fcurves(action):
@@ -581,7 +585,29 @@ def char_animate(ctx, rig, clip, length, amplitude, loop, action_name):
         bone.rotation_euler = (0.0, 0.0, 0.0)
         bone.location = (0.0, 0.0, 0.0)
 
-    keys = _clip_keys(clip, length, amplitude)
+    keys_source = _clip_keys
+    hexapod = "mid_upper_l" in obj.data.bones
+    quadruped = not hexapod and "front_upper_l" in obj.data.bones
+    if hexapod:
+        if clip not in ("walk", "idle"):
+            raise OpError(
+                f"'{clip}' has no hexapod table — hexapod clips are walk (tripod "
+                "gait) and idle. The full gait vocabulary is a quadruped feature."
+            )
+        keys_source = _hexapod_clip_keys
+    elif quadruped and clip in _HUMANOID_ONLY:
+        raise OpError(
+            f"'{clip}' is a humanoid clip but '{rig}' is a quadruped rig. "
+            "Quadruped gaits: walk, trot, gallop, graze, idle."
+        )
+    if not quadruped and clip in _QUADRUPED_ONLY:
+        raise OpError(
+            f"'{clip}' is a quadruped gait but '{rig}' is a humanoid rig. "
+            "Humanoid clips: idle, walk, run, attack, jump, death, wave."
+        )
+    if quadruped:
+        keys_source = _quadruped_clip_keys
+    keys = keys_source(clip, length, amplitude)
     hip_lift = 0.0
     if isinstance(keys, tuple):
         keys, hip_lift = keys
@@ -823,8 +849,963 @@ def _bounds(obj):
     return (min(xs), min(ys), min(zs), max(xs), max(ys), max(zs))
 
 
+# ---------------------------------------------------------------------------
+# outfit: fitted armour and clothing for humanoids
+# ---------------------------------------------------------------------------
+#
+# The "brown blob" lesson: a bare char.humanoid with a shield slab reads as a
+# mud-coloured lump no matter how good the prompt was. Two rules are built
+# into everything below, so the failure is not available to make:
+#
+#   1. Fit is DERIVED from the same _skeleton() proportions the body was built
+#      with — never absolute metre constants — so any build/height gets
+#      fitting pieces.
+#   2. Materials are perceptually distinct by construction (bright metallic
+#      bronze vs dark matte leather vs oxblood cloth). check.materials
+#      measures pairwise ΔE; these defaults pass it by a wide margin.
+
+OUTFIT_MATERIALS = {
+    # name: (hex colour, metallic, roughness) — separated in both colour AND
+    # light response, because separation in only one channel still reads as mud.
+    "bronze":  ("#b08850", 1.0, 0.35),
+    "iron":    ("#878d93", 1.0, 0.45),
+    "leather": ("#6d4a2c", 0.0, 0.78),
+    "cloth":   ("#7c2222", 0.0, 0.92),
+}
+
+_PIECE_BONE = {
+    "cuirass": "chest", "pteruges": "hips", "helmet": "head",
+    "greave_l": "shin_l", "greave_r": "shin_r",
+    "bracer_l": "forearm_l", "bracer_r": "forearm_r",
+    "shield": "forearm_l",
+}
+
+
+def _fit(name, height, build):
+    """Body measurements for fitting, derived from the skeleton proportions."""
+    obj = _get(name)
+    if obj.type != "MESH":
+        raise OpError(f"'{name}' is a {obj.type}, not a mesh — outfit the body mesh")
+    if height <= 0:
+        height = mesh_lib.bounds(obj)["size"][2] or 1.8
+    joints, spec, head_unit = _skeleton(height, build)
+    girth = spec["bulk"]
+    torso_r = height * 0.078 * girth
+    upper_r = height * 0.030 * girth
+    thigh_r = height * 0.043 * girth
+    return obj, joints, head_unit, torso_r, upper_r, thigh_r, height
+
+
+def _shell_profile(points):
+    """Close a lathe profile into a shell: outer up, then straight back down
+    inside, so the piece has wall thickness and no open boundaries."""
+    outer = points
+    inner = [(max(1e-4, r - 0.008), h) for r, h in reversed(points)]
+    return outer + inner
+
+
+def _canonicalize_faces(bm):
+    """Return a new bmesh with faces in a stable geometric order.
+
+    bmesh.ops.spin's seam merge (and remove_doubles on some topologies) can
+    leave faces in a different order run to run even when every vertex is
+    bit-identical — the export then differs only in the index buffer, which is
+    still a determinism break. Vertices here are already welded and unique, so
+    rebuilding with faces sorted by centroid (then vertex count) makes the
+    index buffer a pure function of the geometry.
+    """
+    if not bm.faces:
+        return bm
+    ordered = sorted(
+        bm.faces,
+        key=lambda f: (
+            round(f.calc_center_median().x, 5),
+            round(f.calc_center_median().y, 5),
+            round(f.calc_center_median().z, 5),
+            len(f.verts),
+        ),
+    )
+    rings = [[v.index for v in f.verts] for f in ordered]
+    fresh = mesh_lib.new_bmesh()
+    verts = [fresh.verts.new(v.co[:]) for v in bm.verts]
+    for ring in rings:
+        fresh.faces.new([verts[i] for i in ring])
+    bm.free()
+    return fresh
+
+
+def _attach_or_parent(ctx, piece_obj, body, bone):
+    """Follow the rig when there is one, in place (keep_transform), else the body."""
+    rig = next(
+        (m.object for m in body.modifiers if m.type == "ARMATURE" and m.object), None
+    )
+    if rig is not None and bone in rig.data.bones:
+        char_attach(ctx, piece_obj.name, rig.name, bone, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], True)
+        return f"{rig.name}:{bone}"
+    piece_obj.parent = body
+    piece_obj.matrix_parent_inverse = body.matrix_world.inverted()
+    return f"{body.name} (no rig — parented to body)"
+
+
+@op(
+    "char.outfit",
+    summary="Fit an armour or clothing piece to a char.humanoid body: cuirass, pteruges skirt, greaves, bracers, helmet or round shield. Fit is derived from the body's own proportions, materials are perceptually distinct by construction (this is the anti 'brown blob' op), and pieces bone-parent to the rig when one exists so they animate with the character.",
+    params={
+        "name": ("str", None, "Body mesh (from char.humanoid)"),
+        "piece": ("enum:cuirass|pteruges|greaves|bracers|helmet|shield", "cuirass", "What to fit. greaves and bracers come in pairs"),
+        "height": ("num", 0.0, "Character height; 0 measures the mesh bounds"),
+        "build": ("enum:realistic|heroic|stylized|chibi|lithe", "heroic", "Proportions the fit assumes — match the char.humanoid build"),
+        "material": ("enum:bronze|iron|leather|cloth", "", "Material family (defaults per piece: bronze for cuirass/greaves/helmet/shield, leather for pteruges/bracers). The families are deliberately far apart in colour and response — keep them that way"),
+        "color": ("colorref", "", "Override colour; stay clear of the other pieces' colours or check.materials will fail the set"),
+        "crest": ("enum:none|longitudinal|transverse", "longitudinal", "helmet: crest ridge orientation"),
+        "side": ("enum:l|r", "l", "shield: which forearm carries it"),
+        "gap": ("num", 0.012, "Clearance between body and armour in metres; raise for bulky bodies"),
+        "seed": ("int", 0, "Random seed (reserved; current pieces are fully deterministic)"),
+    },
+    tags=["char"],
+)
+def char_outfit(ctx, name, piece, height, build, material, color, crest, side, gap, seed):
+    body, joints, head_unit, torso_r, upper_r, thigh_r, total_height = _fit(name, height, build)
+    shoulder_z = total_height - head_unit * 1.42
+    hip_z = total_height * 0.50
+
+    default_material = "leather" if piece in ("pteruges", "bracers") else "bronze"
+    family = material or default_material
+    hex_color, metallic, roughness = OUTFIT_MATERIALS[family]
+    mat = mat_lib.principled(
+        f"m_{body.name}_{piece}", color=color or hex_color,
+        roughness=roughness, metallic=metallic,
+    )
+
+    bm = mesh_lib.new_bmesh()
+    bone = _PIECE_BONE.get(piece, "chest")
+
+    if piece == "cuirass":
+        z0, z1 = hip_z + total_height * 0.02, shoulder_z + head_unit * 0.02
+        outer = [
+            (torso_r * 0.98 + gap, z0),
+            (torso_r * 1.22 + gap, z0 + (z1 - z0) * 0.55),
+            (torso_r * 1.10 + gap, z1),
+            (torso_r * 0.48, z1 + 0.004),
+        ]
+        mesh_lib.lathe(bm, _shell_profile(outer), segments=16, cap=False)
+
+    elif piece == "pteruges":
+        straps = max(10, int(2.0 * math.pi * torso_r / (total_height * 0.02 * 1.3)))
+        length = total_height * 0.14
+        radius = torso_r * 0.98 + gap
+        for i in range(straps):
+            angle = 2.0 * math.pi * i / straps
+            tilt = math.radians(8.0 if i % 2 == 0 else 14.0)
+            cx, cy = radius * math.cos(angle), radius * math.sin(angle)
+            piece_bm = mesh_lib.new_bmesh()
+            mesh_lib.add_box(
+                piece_bm,
+                size=(total_height * 0.02, 0.006, length),
+                center=(0.0, 0.0, -length * 0.5), bevel=0.003,
+            )
+            rot = (
+                Matrix.Rotation(angle, 4, "Z")
+                @ Matrix.Rotation(tilt, 4, "X")
+            )
+            bmesh_transform(piece_bm, Matrix.Translation(Vector((cx, cy, hip_z + 0.01))) @ rot)
+            _absorb(bm, piece_bm)
+
+    elif piece in ("greaves", "bracers"):
+        pair = (("l", 1.0), ("r", -1.0))
+        for s, sign in pair:
+            if piece == "greaves":
+                head, tail = joints[f"shin_{s}"]
+                r0, r1 = thigh_r * 0.85 + gap, thigh_r * 0.55 + gap
+                bone_name = f"shin_{s}"
+            else:
+                head, tail = joints[f"forearm_{s}"]
+                r0, r1 = upper_r * 0.80 + gap, upper_r * 0.62 + gap
+                bone_name = f"forearm_{s}"
+            axis = (Vector(tail) - Vector(head))
+            length = axis.length
+            piece_bm = mesh_lib.new_bmesh()
+            mesh_lib.lathe(
+                piece_bm,
+                _shell_profile([(r0, 0.0), (r1, length * 0.96)]),
+                segments=12, axis=axis.normalized(), center=head, cap=False,
+            )
+            _absorb(bm, piece_bm)
+        bone = f"{'shin' if piece == 'greaves' else 'forearm'}_l"
+
+    elif piece == "helmet":
+        head_center = Vector(joints["head"][0]).lerp(Vector(joints["head"][1]), 0.5)
+        dome_r = head_unit * 0.50 + gap
+        brow_z = head_center.z + head_unit * 0.06
+        mesh_lib.lathe(
+            bm,
+            _shell_profile([
+                (dome_r, 0.0),
+                (dome_r * 1.01, dome_r * 0.55),
+                (dome_r * 0.55, dome_r * 0.95),
+                (0.012, dome_r * 1.02),
+            ]),
+            segments=16, center=(0.0, 0.0, brow_z), cap=False,
+        )
+        # Cheek guards and nose guard — the shapes that say 'helmet', not 'bowl'.
+        for sign in (1.0, -1.0):
+            piece_bm = mesh_lib.new_bmesh()
+            mesh_lib.add_wedge(
+                piece_bm,
+                size=(dome_r * 0.34, dome_r * 0.42, head_unit * 0.34),
+                center=(sign * dome_r * 0.72, -dome_r * 0.30, brow_z - head_unit * 0.16),
+            )
+            bmesh_transform(piece_bm, Matrix.Rotation(math.radians(sign * 8.0), 4, "Z"))
+            _absorb(bm, piece_bm)
+        piece_bm = mesh_lib.new_bmesh()
+        mesh_lib.add_box(
+            piece_bm,
+            size=(dome_r * 0.12, dome_r * 0.10, head_unit * 0.30),
+            center=(0.0, -dome_r * 0.90, brow_z - head_unit * 0.10),
+        )
+        _absorb(bm, piece_bm)
+        if crest != "none":
+            ridge = mesh_lib.new_bmesh()
+            along_y = crest == "longitudinal"
+            mesh_lib.add_box(
+                ridge,
+                size=(
+                    dome_r * (0.16 if along_y else 1.5),
+                    dome_r * (1.5 if along_y else 0.16),
+                    dome_r * 0.42,
+                ),
+                center=(0.0, 0.0, brow_z + dome_r * 1.05), bevel=0.004,
+            )
+            _absorb(bm, ridge)
+
+    elif piece == "shield":
+        fore_head, fore_tail = joints[f"forearm_{side}"]
+        sign = 1.0 if side == "l" else -1.0
+        radius = total_height * 0.24
+        depth = 0.025
+        center = Vector(fore_head).lerp(Vector(fore_tail), 0.5)
+        center.x += sign * (upper_r + radius * 0.35)
+        center.y -= 0.01
+        disc = mesh_lib.new_bmesh()
+        mesh_lib.add_cylinder(disc, radius=radius, depth=depth, segments=20, bevel=0.004)
+        bmesh_transform(
+            disc, Matrix.Translation(center) @ Matrix.Rotation(math.radians(90.0), 4, "Y")
+        )
+        _absorb(bm, disc)
+        rim = mesh_lib.new_bmesh()
+        mesh_lib.add_torus(rim, major=radius * 0.97, minor=radius * 0.045,
+                           major_segments=20, minor_segments=6)
+        bmesh_transform(
+            rim, Matrix.Translation(center) @ Matrix.Rotation(math.radians(90.0), 4, "Y")
+        )
+        _absorb(bm, rim)
+        boss = mesh_lib.new_bmesh()
+        mesh_lib.add_icosphere(boss, radius=radius * 0.16, subdivisions=2)
+        bmesh_transform(
+            boss,
+            Matrix.Translation(center + Vector((sign * depth * 1.2, 0.0, 0.0)))
+            @ Matrix.Diagonal(Vector((0.5, 1.0, 1.0))).to_4x4(),
+        )
+        _absorb(bm, boss)
+        bone = f"forearm_{side}"
+
+    mesh_lib.cleanup(bm, merge_dist=total_height * 0.001)
+    bm = _canonicalize_faces(bm)
+    piece_obj = mesh_lib.to_object(bm, scene_lib.unique_name(f"{body.name}_{piece}"))
+    result = finish_lib.finish(
+        ctx, piece_obj, material=mat, uv="smart_packed", origin="world",
+        smooth=True, smooth_angle=45.0,
+    )
+    followed = _attach_or_parent(ctx, piece_obj, body, bone)
+    return {
+        "piece": piece,
+        "object": piece_obj.name,
+        "triangles": result["triangles"],
+        "material": mat.name,
+        "follows": followed,
+        "note": "fit another piece the same way; keep materials in different families "
+                "(bronze/leather/cloth) or check.materials will fail the set at review",
+    }
+
+
+@op(
+    "char.face",
+    summary="Give a char.humanoid head a readable face — brow ridge, nose wedge, chin — so a close-up review render reads as a person, not a box. Stylised readability, not realism. Geometry is welded into the body mesh and takes the head bone when skinned.",
+    params={
+        "name": ("str", None, "Body mesh (from char.humanoid)"),
+        "height": ("num", 0.0, "Character height; 0 measures the mesh bounds"),
+        "build": ("enum:realistic|heroic|stylized|chibi|lithe", "heroic", "Proportions — match the char.humanoid build"),
+    },
+    tags=["char"],
+)
+def char_face(ctx, name, height, build):
+    body, joints, head_unit, _torso_r, _upper_r, _thigh_r, _h = _fit(name, height, build)
+    head_center = Vector(joints["head"][0]).lerp(Vector(joints["head"][1]), 0.5)
+    head_r = head_unit * 0.46
+
+    bm = mesh_lib.obj_bmesh(body)
+    before = len(bm.faces)
+
+    brow = mesh_lib.new_bmesh()
+    mesh_lib.add_box(
+        brow,
+        size=(head_r * 1.15, head_r * 0.28, head_r * 0.16),
+        center=(0.0, -head_r * 0.80, head_center.z + head_unit * 0.14), bevel=0.004,
+    )
+    _absorb(bm, brow)
+
+    nose = mesh_lib.new_bmesh()
+    mesh_lib.add_wedge(
+        nose,
+        size=(head_r * 0.20, head_r * 0.26, head_r * 0.40),
+        center=(0.0, -head_r * 0.86, head_center.z - head_unit * 0.04),
+    )
+    _absorb(bm, nose)
+
+    chin = mesh_lib.new_bmesh()
+    mesh_lib.add_icosphere(chin, radius=head_r * 0.28, subdivisions=1)
+    bmesh_transform(
+        chin,
+        Matrix.Translation(Vector((0.0, -head_r * 0.62, head_center.z - head_r * 0.66)))
+        @ Matrix.Diagonal(Vector((1.0, 0.75, 0.9))).to_4x4(),
+    )
+    _absorb(bm, chin)
+
+    added = len(bm.faces) - before
+    mesh_lib.write_bmesh(bm, body)
+    mesh_lib.shade_auto_smooth(body, 50.0)
+    return {
+        "object": body.name,
+        "faces_added": added,
+        "note": "features share the body's skin material and weld to the head shell; "
+                "the head bone owns them when char.rig skins the mesh",
+    }
+
+
+@op(
+    "char.hands",
+    summary="Upgrade a char.humanoid's block hands with readable fingers: four two-segment fingers with a relaxed curl plus a thumb, so a weapon grip or open hand reads at review distance. Welded into the body mesh; the hand bones own them when skinned.",
+    params={
+        "name": ("str", None, "Body mesh (from char.humanoid)"),
+        "height": ("num", 0.0, "Character height; 0 measures the mesh bounds"),
+        "build": ("enum:realistic|heroic|stylized|chibi|lithe", "heroic", "Proportions — match the char.humanoid build"),
+        "curl": ("num", 0.35, "Finger curl in radians-ish (0 flat, 0.8 fist); a relaxed read is ~0.35"),
+    },
+    tags=["char"],
+)
+def char_hands(ctx, name, height, build, curl):
+    body, joints, _head_unit, _torso_r, upper_r, _thigh_r, _h = _fit(name, height, build)
+    curl = max(0.0, min(0.8, curl))
+
+    bm = mesh_lib.obj_bmesh(body)
+    before = len(bm.faces)
+
+    for side, sign in (("l", 1.0), ("r", -1.0)):
+        hand_center = Vector(joints[f"hand_{side}"][0]).lerp(
+            Vector(joints[f"hand_{side}"][1]), 0.6
+        )
+        finger_w = upper_r * 0.18
+        finger_len = upper_r * 1.15
+        for f in range(4):
+            x = hand_center.x + (f - 1.5) * (finger_w * 1.25)
+            for segment, (seg_len, bend) in enumerate(
+                ((finger_len * 0.55, curl * 0.5), (finger_len * 0.45, curl))
+            ):
+                piece_bm = mesh_lib.new_bmesh()
+                mesh_lib.add_box(
+                    piece_bm,
+                    size=(finger_w, finger_w * 0.9, seg_len),
+                    center=(0.0, 0.0, -seg_len * 0.5), bevel=finger_w * 0.2,
+                )
+                z_base = hand_center.z - upper_r * 0.45 - segment * finger_len * 0.5
+                rot = Matrix.Rotation(bend, 4, "X")
+                bmesh_transform(
+                    piece_bm,
+                    Matrix.Translation(Vector((x, hand_center.y, z_base))) @ rot,
+                )
+                _absorb(bm, piece_bm)
+        thumb = mesh_lib.new_bmesh()
+        mesh_lib.add_box(
+            thumb,
+            size=(finger_w, finger_w * 0.9, finger_len * 0.6),
+            center=(0.0, 0.0, -finger_len * 0.3), bevel=finger_w * 0.2,
+        )
+        bmesh_transform(
+            thumb,
+            Matrix.Translation(
+                Vector((hand_center.x - sign * upper_r * 0.55, hand_center.y - upper_r * 0.15,
+                        hand_center.z - upper_r * 0.2))
+            )
+            @ Matrix.Rotation(sign * math.radians(40.0), 4, "Y")
+            @ Matrix.Rotation(curl * 0.6, 4, "X"),
+        )
+        _absorb(bm, thumb)
+
+    added = len(bm.faces) - before
+    mesh_lib.write_bmesh(bm, body)
+    mesh_lib.shade_auto_smooth(body, 50.0)
+    return {
+        "object": body.name,
+        "faces_added": added,
+        "curl": curl,
+        "note": "fingers share the body's skin material; articulation needs finger "
+                "bones, which the base rig does not have — pose with morph.add instead",
+    }
+
+
 def _get(name):
     try:
         return scene_lib.get_object(name)
     except ValueError as exc:
         raise OpError(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# creatures: quadruped bodies, rigs and gaits
+# ---------------------------------------------------------------------------
+#
+# char.humanoid only covers the two-legged cast. Games need the other half —
+# hounds, horses, stalkers — and a quadruped is not a humanoid on all fours:
+# the torso is horizontal, the legs hang from a shoulder/hip at two stations,
+# and its gaits are four-beat patterns, not a two-beat stride. Body plan
+# ratios below follow the same figure-drawing discipline as BUILDS.
+
+CREATURE_PLANS = {
+    # leg = leg length as a fraction of shoulder height; neck rise in degrees;
+    # tail as a fraction of body length; girth multiplier.
+    "canine":   {"leg": 0.92, "neck_deg": 35.0, "tail": 0.42, "girth": 0.92},
+    "equine":   {"leg": 1.10, "neck_deg": 55.0, "tail": 0.55, "girth": 1.05},
+    "feline":   {"leg": 0.86, "neck_deg": 25.0, "tail": 0.60, "girth": 0.82},
+    "generic":  {"leg": 0.95, "neck_deg": 40.0, "tail": 0.45, "girth": 1.00},
+    # Hexapod (insect): a different skeleton, not a tuning of the quadruped —
+    # three leg stations and a tripod gait. leg ratio is measured against the
+    # thorax height; splay is how far the legs angle outward from the body.
+    "insect":   {"leg": 1.05, "neck_deg": 0.0, "tail": 0.0, "girth": 1.10, "splay": 1.35},
+}
+
+_HEXAPOD_PLANS = {"insect"}
+
+
+def _hexapod_skeleton(length, height, plan):
+    """Joint positions for a hexapod (scarab class), standing at the origin.
+
+    Faces -Y. Three leg stations (front/mid/rear) splay outward from the
+    thorax; abdomen is the root chain (hips -> chest), head at the front.
+    `length` is abdomen-tip to head; `height` is thorax height off the ground.
+    """
+    spec = CREATURE_PLANS[plan]
+    leg_len = height * spec["leg"]
+    splay = spec["splay"]
+    thorax_y = -length * 0.12
+    head_y = -length * 0.42
+    abdomen_y = length * 0.30
+    z = height
+
+    joints = {
+        "hips": ((0.0, abdomen_y, z), (0.0, abdomen_y + length * 0.16, z * 0.94)),
+        "chest": ((0.0, abdomen_y * 0.4, z), (0.0, thorax_y, z)),
+        "head": ((0.0, thorax_y, z), (0.0, head_y, z * 0.92)),
+    }
+    for side, sign in (("l", 1.0), ("r", -1.0)):
+        for station, y, back in (("front", thorax_y - length * 0.10, -0.35),
+                                 ("mid", thorax_y + length * 0.10, 0.0),
+                                 ("rear", abdomen_y * 0.7, 0.45)):
+            hip = (sign * length * 0.10, y, z * 0.9)
+            knee = (sign * length * 0.10 * (1.0 + splay * 0.55), y + back * length * 0.22,
+                    z * 0.9 + leg_len * 0.45)
+            ankle = (sign * length * 0.10 * (1.0 + splay), y + back * length * 0.5, z * 0.16)
+            foot = (sign * length * 0.10 * (1.0 + splay * 1.05), y + back * length * 0.62, 0.0)
+            joints[f"{station}_upper_{side}"] = (hip, knee)
+            joints[f"{station}_lower_{side}"] = (knee, ankle)
+            joints[f"{station}_paw_{side}"] = (ankle, foot)
+    return joints, spec
+
+
+HEXAPOD_PARENTS = {
+    "chest": "hips", "head": "chest",
+    "front_upper_l": "chest", "front_lower_l": "front_upper_l", "front_paw_l": "front_lower_l",
+    "front_upper_r": "chest", "front_lower_r": "front_upper_r", "front_paw_r": "front_lower_r",
+    "mid_upper_l": "chest", "mid_lower_l": "mid_upper_l", "mid_paw_l": "mid_lower_l",
+    "mid_upper_r": "chest", "mid_lower_r": "mid_upper_r", "mid_paw_r": "mid_lower_r",
+    "rear_upper_l": "hips", "rear_lower_l": "rear_upper_l", "rear_paw_l": "rear_lower_l",
+    "rear_upper_r": "hips", "rear_lower_r": "rear_upper_r", "rear_paw_r": "rear_lower_r",
+}
+
+_RELATED = _RELATED | frozenset(
+    pair
+    for child, parent in HEXAPOD_PARENTS.items()
+    for pair in ((child, parent), (parent, child))
+)
+
+
+def _hexapod_clip_keys(clip, length, amplitude):
+    """Tripod gait and idle for the hexapod skeleton.
+
+    Insects walk on alternating TRIPODS — front+rear of one side with the
+    middle of the other — which is what makes six legs read as six. Bobbing
+    all legs together reads as a toy car.
+    """
+    a = amplitude
+    half = max(1, length // 2)
+    swing, knee = 16 * a, 14 * a
+    tripod_a = (("front", "l"), ("mid", "r"), ("rear", "l"))
+    tripod_b = (("front", "r"), ("mid", "l"), ("rear", "r"))
+
+    if clip == "walk":
+        keys = {1: {}, half: {}, length: {}}
+        for frame, forward in ((1, tripod_a), (half, tripod_b), (length, tripod_a)):
+            for station, side in forward:
+                keys[frame][f"{station}_upper_{side}"] = (swing, 0, 0)
+                keys[frame][f"{station}_lower_{side}"] = (-knee * 0.6, 0, 0)
+            for station, side in (tripod_b if forward is tripod_a else tripod_a):
+                keys[frame][f"{station}_upper_{side}"] = (-swing, 0, 0)
+                keys[frame][f"{station}_lower_{side}"] = (-knee * 0.15, 0, 0)
+        return keys, 0.012 * a
+
+    # idle: antennae/head wobble and a slow abdomen breath.
+    return {
+        1:      {"head": (0, 0, 0), "hips": (0, 0, 0), "chest": (0, 0, 0)},
+        half:   {"head": (4 * a, 0, 6 * a), "hips": (1.5 * a, 0, 0), "chest": (0, 0, 0)},
+        length: {"head": (0, 0, 0), "hips": (0, 0, 0), "chest": (0, 0, 0)},
+    }
+
+
+
+def _quadruped_skeleton(length, shoulder, plan):
+    """Joint positions in metres for a quadruped standing at the origin.
+
+    Faces -Y (the studio forward), spine horizontal, legs at two stations.
+    `length` is chest-to-hip body length; `shoulder` is shoulder height.
+    """
+    spec = CREATURE_PLANS[plan]
+    leg_len = shoulder * spec["leg"]
+    body_z = leg_len
+    chest_y = -length * 0.5
+    hip_y = length * 0.5
+    leg_x = length * 0.11 * spec["girth"]
+    neck_len = shoulder * 0.42
+    neck_rad = math.radians(spec["neck_deg"])
+
+    joints = {
+        "hips": ((0.0, hip_y, body_z), (0.0, hip_y, body_z + length * 0.10)),
+        "spine": ((0.0, hip_y, body_z), (0.0, length * 0.08, body_z + length * 0.045)),
+        "chest": ((0.0, length * 0.08, body_z + length * 0.045), (0.0, chest_y, body_z + length * 0.03)),
+        "neck": (
+            (0.0, chest_y, body_z + length * 0.03),
+            (0.0, chest_y - math.cos(neck_rad) * neck_len, body_z + length * 0.03 + math.sin(neck_rad) * neck_len),
+        ),
+        "head": (
+            (0.0, chest_y - math.cos(neck_rad) * neck_len, body_z + length * 0.03 + math.sin(neck_rad) * neck_len),
+            (0.0, chest_y - math.cos(neck_rad) * neck_len - length * 0.16,
+             body_z + length * 0.03 + math.sin(neck_rad) * neck_len + length * 0.02),
+        ),
+        "tail_1": ((0.0, hip_y, body_z), (0.0, hip_y + length * spec["tail"] * 0.55, body_z + length * 0.04)),
+        "tail_2": (
+            (0.0, hip_y + length * spec["tail"] * 0.55, body_z + length * 0.04),
+            (0.0, hip_y + length * spec["tail"], body_z - length * 0.06),
+        ),
+    }
+    for side, sign in (("l", 1.0), ("r", -1.0)):
+        for station, y in (("front", chest_y), ("rear", hip_y)):
+            joints[f"{station}_upper_{side}"] = (
+                (sign * leg_x, y, body_z),
+                (sign * leg_x * 1.05, y, body_z - leg_len * 0.52),
+            )
+            joints[f"{station}_lower_{side}"] = (
+                (sign * leg_x * 1.05, y, body_z - leg_len * 0.52),
+                (sign * leg_x * 1.08, y, body_z - leg_len * 0.88),
+            )
+            joints[f"{station}_paw_{side}"] = (
+                (sign * leg_x * 1.08, y, body_z - leg_len * 0.88),
+                (sign * leg_x * 1.08, y - length * 0.045, max(0.0, body_z - leg_len)),
+            )
+    return joints, spec
+
+
+QUADRUPED_PARENTS = {
+    "spine": "hips", "chest": "spine", "neck": "chest", "head": "neck",
+    "tail_1": "hips", "tail_2": "tail_1",
+    "front_upper_l": "chest", "front_lower_l": "front_upper_l", "front_paw_l": "front_lower_l",
+    "front_upper_r": "chest", "front_lower_r": "front_upper_r", "front_paw_r": "front_lower_r",
+    "rear_upper_l": "hips", "rear_lower_l": "rear_upper_l", "rear_paw_l": "rear_lower_l",
+    "rear_upper_r": "hips", "rear_lower_r": "rear_upper_r", "rear_paw_r": "rear_lower_r",
+}
+
+# The two-bone elbow/knee blend in _skin applies to a bone and its direct
+# parent, on either body plan.
+_RELATED = _RELATED | frozenset(
+    pair
+    for child, parent in QUADRUPED_PARENTS.items()
+    for pair in ((child, parent), (parent, child))
+)
+
+
+def _creature_hexapod_body(ctx, name, length, height, plan, bulk, detail, location, skin, seed):
+    """Scarab-class body: segmented abdomen, thorax, dorsal shell, mandibles,
+    six splayed legs. Separate from the quadruped assembly on purpose."""
+    ctx.reseed(seed)
+    joints, spec = _hexapod_skeleton(length, height, plan)
+    sides = max(5, min(16, detail))
+    girth = spec["girth"] * bulk
+    body_r = length * 0.15 * girth
+    bm = mesh_lib.new_bmesh()
+
+    def limb(a, b, radius_a, radius_b):
+        start, end = Vector(a), Vector(b)
+        axis = end - start
+        if axis.length < 1e-5:
+            return
+        piece = mesh_lib.new_bmesh()
+        mesh_lib.add_cylinder(
+            piece, radius=radius_a, radius_top=radius_b, depth=axis.length,
+            segments=sides, center=(0.0, 0.0, axis.length * 0.5),
+        )
+        rotation = axis.normalized().to_track_quat("Z", "Y").to_matrix().to_4x4()
+        bmesh_transform(piece, Matrix.Translation(start) @ rotation)
+        _absorb(bm, piece)
+
+    def blob(center, radius, squash=(1.0, 1.0, 1.0)):
+        piece = mesh_lib.new_bmesh()
+        mesh_lib.add_icosphere(piece, radius=radius, subdivisions=2)
+        bmesh_transform(
+            piece, Matrix.Translation(Vector(center)) @ Matrix.Diagonal(Vector(squash)).to_4x4()
+        )
+        _absorb(bm, piece)
+
+    hips_a, hips_b = joints["hips"]
+    # Segmented abdomen: three overlapping blobs shrinking rearward.
+    for i, factor in enumerate((1.0, 0.82, 0.58)):
+        t = i / 2.0
+        center = Vector(hips_a).lerp(Vector(hips_b), t)
+        blob((center.x, center.y + i * length * 0.05, center.z - i * length * 0.015),
+             body_r * factor, (0.95, 1.1, 0.9))
+    blob(joints["chest"][1], body_r * 0.9, (1.0, 1.15, 0.95))
+    # Dorsal shell (elytra) — the scarab signature. One squashed dome over the back.
+    shell_center = Vector(hips_a).lerp(Vector(joints["chest"][1]), 0.4)
+    blob((shell_center.x, shell_center.y, shell_center.z + body_r * 0.28),
+         body_r * 1.12, (0.95, 1.45, 0.5))
+    head_center = Vector(joints["head"][0]).lerp(Vector(joints["head"][1]), 0.6)
+    blob(head_center, body_r * 0.5, (0.9, 1.0, 0.85))
+    for sign in (1.0, -1.0):
+        mandible = mesh_lib.new_bmesh()
+        mesh_lib.add_wedge(
+            mandible, size=(body_r * 0.16, body_r * 0.45, body_r * 0.12),
+            center=(sign * body_r * 0.2, head_center.y - body_r * 0.5, head_center.z - body_r * 0.1),
+        )
+        _absorb(bm, mandible)
+
+    leg_r = body_r * 0.16
+    for side in ("l", "r"):
+        for station in ("front", "mid", "rear"):
+            upper_a, upper_b = joints[f"{station}_upper_{side}"]
+            lower_a, lower_b = joints[f"{station}_lower_{side}"]
+            paw_a, paw_b = joints[f"{station}_paw_{side}"]
+            limb(upper_a, upper_b, leg_r * 1.2, leg_r * 0.9)
+            limb(lower_a, lower_b, leg_r * 0.9, leg_r * 0.65)
+            limb(paw_a, paw_b, leg_r * 0.65, leg_r * 0.4)
+
+    mesh_lib.cleanup(bm, merge_dist=length * 0.002)
+    obj = mesh_lib.to_object(bm, scene_lib.unique_name(name))
+    obj.location = location
+    skin_mat = mat_lib.principled(f"m_{obj.name}_skin", color=skin, roughness=0.55, metallic=0.15)
+    result = finish_lib.finish(
+        ctx, obj, material=skin_mat, uv="smart_packed", origin="bottom", smooth=True,
+        smooth_angle=50.0,
+    )
+    result["plan"] = plan
+    result["length_m"] = length
+    ctx.note(
+        f"'{obj.name}' is a hexapod body. char.creature_rig plan='{plan}' rigs it; "
+        "char.animate clip='walk' uses the tripod gait table."
+    )
+    return result
+
+
+@op(
+    "char.creature",
+    summary="Proportioned quadruped body (canine/equine/feline/generic) or hexapod (insect: scarab class, three leg stations). Pair with char.creature_rig and char.animate — walk/trot/gallop/graze for quadrupeds, tripod-gait walk for hexapods. Deterministic, data-API only, metres.",
+    params={
+        "name": ("str", "creature", "Object name"),
+        "length": ("num", 1.4, "Body length in metres (chest-to-hip; abdomen-tip to head for insect)"),
+        "shoulder": ("num", 0.9, "Shoulder height in metres (thorax height for insect)"),
+        "plan": ("enum:canine|equine|feline|generic|insect", "canine", "Body plan — quadruped proportions or the hexapod scarab class"),
+        "bulk": ("num", 1.0, "Extra girth multiplier"),
+        "detail": ("int", 8, "Limb cross-section segments"),
+        "location": ("vec3", [0.0, 0.0, 0.0], "World position"),
+        "skin": ("str", "#7a6248", "Body colour"),
+        "seed": ("int", 0, "Random seed"),
+    },
+    tags=["char"],
+)
+def char_creature(ctx, name, length, shoulder, plan, bulk, detail, location, skin, seed):
+    if plan in _HEXAPOD_PLANS:
+        return _creature_hexapod_body(ctx, name, length, shoulder, plan, bulk, detail,
+                                      location, skin, seed)
+    ctx.reseed(seed)
+    joints, spec = _quadruped_skeleton(length, shoulder, plan)
+    sides = max(5, min(16, detail))
+    girth = spec["girth"] * bulk
+    body_r = length * 0.115 * girth
+    bm = mesh_lib.new_bmesh()
+
+    def limb(a, b, radius_a, radius_b):
+        start, end = Vector(a), Vector(b)
+        axis = end - start
+        if axis.length < 1e-5:
+            return
+        piece = mesh_lib.new_bmesh()
+        mesh_lib.add_cylinder(
+            piece, radius=radius_a, radius_top=radius_b, depth=axis.length,
+            segments=sides, center=(0.0, 0.0, axis.length * 0.5),
+        )
+        rotation = axis.normalized().to_track_quat("Z", "Y").to_matrix().to_4x4()
+        bmesh_transform(piece, Matrix.Translation(start) @ rotation)
+        _absorb(bm, piece)
+
+    def blob(center, radius, squash=(1.0, 1.0, 1.0)):
+        piece = mesh_lib.new_bmesh()
+        mesh_lib.add_icosphere(piece, radius=radius, subdivisions=2)
+        bmesh_transform(
+            piece, Matrix.Translation(Vector(center)) @ Matrix.Diagonal(Vector(squash)).to_4x4()
+        )
+        _absorb(bm, piece)
+
+    # Torso: chest -> spine -> hips as two overlapping capsules so the belly
+    # sags slightly between the stations instead of reading as a pipe.
+    limb(joints["chest"][1], joints["spine"][0], body_r * 1.05, body_r * 0.92)
+    limb(joints["spine"][0], joints["hips"][0], body_r * 0.92, body_r * 0.82)
+    blob(joints["chest"][1], body_r * 1.08, (0.9, 1.05, 1.0))
+    blob(joints["hips"][0], body_r * 0.95, (0.85, 1.0, 0.95))
+
+    limb(joints["neck"][0], joints["neck"][1], body_r * 0.55, body_r * 0.42)
+    head_center = Vector(joints["head"][0]).lerp(Vector(joints["head"][1]), 0.55)
+    blob(head_center, body_r * 0.62, (0.85, 1.35, 0.95))
+    # Muzzle — the feature that stops a quadruped head reading as a ball.
+    muzzle = Vector(joints["head"][1])
+    blob((muzzle.x, muzzle.y - length * 0.015, muzzle.z - length * 0.01),
+         body_r * 0.34, (0.7, 1.5, 0.8))
+
+    limb(joints["tail_1"][0], joints["tail_1"][1], body_r * 0.30, body_r * 0.22)
+    limb(joints["tail_2"][0], joints["tail_2"][1], body_r * 0.22, body_r * 0.08)
+
+    leg_r = body_r * 0.30
+    for side in ("l", "r"):
+        for station in ("front", "rear"):
+            upper_a, upper_b = joints[f"{station}_upper_{side}"]
+            lower_a, lower_b = joints[f"{station}_lower_{side}"]
+            paw_a, paw_b = joints[f"{station}_paw_{side}"]
+            limb(upper_a, upper_b, leg_r * 1.15, leg_r * 0.85)
+            limb(lower_a, lower_b, leg_r * 0.85, leg_r * 0.60)
+            paw_center = Vector(paw_a).lerp(Vector(paw_b), 0.5)
+            blob(paw_center, leg_r * 0.75, (1.0, 1.4, 0.75))
+
+    mesh_lib.cleanup(bm, merge_dist=length * 0.002)
+    obj = mesh_lib.to_object(bm, scene_lib.unique_name(name))
+    obj.location = location
+    skin_mat = mat_lib.principled(f"m_{obj.name}_skin", color=skin, roughness=0.72)
+    result = finish_lib.finish(
+        ctx, obj, material=skin_mat, uv="smart_packed", origin="bottom", smooth=True,
+        smooth_angle=50.0,
+    )
+    result["plan"] = plan
+    result["length_m"] = length
+    ctx.note(
+        f"'{obj.name}' is a body. Run char.creature_rig name='{obj.name}' for the "
+        "armature, then char.animate clip='trot' (or walk/gallop/graze/idle)."
+    )
+    return result
+
+
+@op(
+    "char.creature_rig",
+    summary="Build a quadruped armature (hips root, spine chain, neck/head, 2-segment tail, 3-bone legs at both stations) fitted to a char.creature body, and skin it with the same shell-constrained distance-falloff solve as char.rig.",
+    params={
+        "name": ("str", None, "Creature mesh object (from char.creature)"),
+        "length": ("num", 0.0, "Chest-to-hip length; 0 measures from the mesh bounds Y extent"),
+        "shoulder": ("num", 0.0, "Shoulder height; 0 measures from the mesh bounds Z extent"),
+        "plan": ("enum:canine|equine|feline|generic|insect", "canine", "Body plan the rig assumes — match char.creature"),
+        "falloff": ("num", 1.6, "Weight blend sharpness; higher is more rigid"),
+        "armature_name": ("str", "", "Armature object name (defaults to <mesh>_rig)"),
+    },
+    tags=["char", "rig"],
+)
+def char_creature_rig(ctx, name, length, shoulder, plan, falloff, armature_name):
+    obj = _get(name)
+    if obj.type != "MESH":
+        raise OpError(f"'{name}' is a {obj.type}, not a mesh — rig the body mesh")
+    bounds = mesh_lib.bounds(obj)
+    hexapod = plan in _HEXAPOD_PLANS
+    if length <= 0:
+        length = (bounds["size"][1] * (0.8 if hexapod else 0.55)) or 1.4
+    if shoulder <= 0:
+        shoulder = (bounds["size"][2] * (0.5 if hexapod else 0.75)) or 0.9
+    if hexapod:
+        joints, _spec = _hexapod_skeleton(length, shoulder, plan)
+        parents = HEXAPOD_PARENTS
+    else:
+        joints, _spec = _quadruped_skeleton(length, shoulder, plan)
+        parents = QUADRUPED_PARENTS
+
+    rig_name = scene_lib.unique_name(armature_name or f"{obj.name}_rig")
+    armature_data = bpy.data.armatures.new(rig_name)
+    rig = bpy.data.objects.new(rig_name, armature_data)
+    bpy.context.scene.collection.objects.link(rig)
+    rig.location = obj.location
+
+    view_layer = bpy.context.view_layer
+    previous_active = view_layer.objects.active
+    view_layer.objects.active = rig
+    bpy.ops.object.mode_set(mode="EDIT")
+    try:
+        created = {}
+        for bone_name, (head, tail) in joints.items():
+            bone = armature_data.edit_bones.new(bone_name)
+            bone.head = Vector(head)
+            bone.tail = Vector(tail)
+            bone.use_deform = True
+            created[bone_name] = bone
+        for child, parent in parents.items():
+            if child in created and parent in created:
+                created[child].parent = created[parent]
+                created[child].use_connect = False
+    finally:
+        bpy.ops.object.mode_set(mode="OBJECT")
+    view_layer.objects.active = previous_active
+
+    scene_lib.sync()
+    weights = _skin(obj, joints, falloff, rig)
+
+    modifier = obj.modifiers.new("armature", "ARMATURE")
+    modifier.object = rig
+    modifier.use_vertex_groups = True
+    obj.parent = rig
+    obj.matrix_parent_inverse = rig.matrix_world.inverted()
+
+    return {
+        "armature": rig.name,
+        "mesh": obj.name,
+        "bones": sorted(b.name for b in armature_data.bones),
+        "bone_count": len(armature_data.bones),
+        "vertex_groups": len(obj.vertex_groups),
+        "weighted_vertices": weights,
+        "note": "gaits live in char.animate: clip='walk'|'trot'|'gallop'|'graze'|'idle' "
+                "— the quadruped tables are chosen automatically from these bones",
+    }
+
+
+def _quadruped_clip_keys(clip, length, amplitude):
+    """Gait pose tables for the quadruped skeleton.
+
+    Real quadruped gaits are footfall SEQUENCES, and the silhouette of each
+    beat is what reads: a walk is a four-beat lateral sequence (LH, LF, RH,
+    RF), a trot is two-beat diagonal pairs, a gallop is front-pair reach then
+    rear-pair drive with the spine flexing between. Sine waves on all four
+    legs at once is how you get a rocking horse, not an animal.
+    """
+    a = amplitude
+    quarter = max(1, length // 4)
+
+    if clip == "walk":
+        swing, knee = 15 * a, 12 * a
+        phases = {
+            1:            (("rear", "l", swing), ("front", "l", -swing * 0.4),
+                           ("rear", "r", -swing * 0.4), ("front", "r", swing * 0.6)),
+            quarter:      (("rear", "l", swing * 0.4), ("front", "l", swing),
+                           ("rear", "r", -swing), ("front", "r", -swing * 0.4)),
+            quarter * 2:  (("rear", "l", -swing * 0.4), ("front", "l", swing * 0.6),
+                           ("rear", "r", swing), ("front", "r", -swing * 0.4)),
+            quarter * 3:  (("rear", "l", -swing), ("front", "l", -swing * 0.4),
+                           ("rear", "r", swing * 0.4), ("front", "r", swing)),
+            length:       (("rear", "l", swing), ("front", "l", -swing * 0.4),
+                           ("rear", "r", -swing * 0.4), ("front", "r", swing * 0.6)),
+        }
+        keys = {}
+        for frame, beats in phases.items():
+            pose = {}
+            for station, side, angle in beats:
+                pose[f"{station}_upper_{side}"] = (angle, 0, 0)
+                pose[f"{station}_lower_{side}"] = (-knee * (0.4 if angle > 0 else 0.1), 0, 0)
+            keys[frame] = pose
+        return keys
+
+    if clip == "trot":
+        swing, knee = 20 * a, 18 * a
+        keys = {
+            1: {}, quarter: {}, quarter * 2: {}, quarter * 3: {}, length: {},
+        }
+        diagonal_a = (("front", "l"), ("rear", "r"))
+        diagonal_b = (("front", "r"), ("rear", "l"))
+        for frame, forward in ((1, diagonal_a), (quarter * 2, diagonal_b), (length, diagonal_a)):
+            for station, side in forward:
+                keys[frame][f"{station}_upper_{side}"] = (swing, 0, 0)
+                keys[frame][f"{station}_lower_{side}"] = (-knee * 0.5, 0, 0)
+            for station, side in (diagonal_b if forward is diagonal_a else diagonal_a):
+                keys[frame][f"{station}_upper_{side}"] = (-swing, 0, 0)
+                keys[frame][f"{station}_lower_{side}"] = (-knee * 0.15, 0, 0)
+        for frame in (quarter, quarter * 3):
+            for station in ("front", "rear"):
+                for side in ("l", "r"):
+                    keys[frame][f"{station}_upper_{side}"] = (0, 0, 0)
+                    keys[frame][f"{station}_lower_{side}"] = (-knee * 0.25, 0, 0)
+        return keys, 0.02 * a
+
+    if clip == "gallop":
+        reach, drive, flex = 30 * a, 34 * a, 10 * a
+        keys = {
+            1: {
+                "chest": (-flex * 0.5, 0, 0), "spine": (flex * 0.5, 0, 0),
+                "front_upper_l": (reach, 0, 0), "front_upper_r": (reach * 0.9, 0, 0),
+                "front_lower_l": (-reach * 0.7, 0, 0), "front_lower_r": (-reach * 0.6, 0, 0),
+                "rear_upper_l": (-drive, 0, 0), "rear_upper_r": (-drive * 0.9, 0, 0),
+                "rear_lower_l": (drive * 0.5, 0, 0), "rear_lower_r": (drive * 0.45, 0, 0),
+                "neck": (-6 * a, 0, 0),
+            },
+            quarter: {
+                "chest": (flex, 0, 0), "spine": (-flex, 0, 0),
+                "front_upper_l": (-reach * 0.4, 0, 0), "front_upper_r": (-reach * 0.35, 0, 0),
+                "front_lower_l": (-reach * 0.2, 0, 0), "front_lower_r": (-reach * 0.2, 0, 0),
+                "rear_upper_l": (drive * 0.6, 0, 0), "rear_upper_r": (drive * 0.55, 0, 0),
+                "rear_lower_l": (-drive * 0.6, 0, 0), "rear_lower_r": (-drive * 0.55, 0, 0),
+                "neck": (4 * a, 0, 0),
+            },
+            quarter * 2: {
+                "chest": (flex * 0.6, 0, 0), "spine": (-flex * 0.6, 0, 0),
+                "front_upper_l": (reach * 0.3, 0, 0), "front_upper_r": (reach * 0.35, 0, 0),
+                "front_lower_l": (-reach * 0.3, 0, 0), "front_lower_r": (-reach * 0.3, 0, 0),
+                "rear_upper_l": (drive * 0.2, 0, 0), "rear_upper_r": (drive * 0.25, 0, 0),
+                "rear_lower_l": (-drive * 0.3, 0, 0), "rear_lower_r": (-drive * 0.3, 0, 0),
+                "neck": (2 * a, 0, 0),
+            },
+            length: {
+                "chest": (-flex * 0.5, 0, 0), "spine": (flex * 0.5, 0, 0),
+                "front_upper_l": (reach, 0, 0), "front_upper_r": (reach * 0.9, 0, 0),
+                "front_lower_l": (-reach * 0.7, 0, 0), "front_lower_r": (-reach * 0.6, 0, 0),
+                "rear_upper_l": (-drive, 0, 0), "rear_upper_r": (-drive * 0.9, 0, 0),
+                "rear_lower_l": (drive * 0.5, 0, 0), "rear_lower_r": (drive * 0.45, 0, 0),
+                "neck": (-6 * a, 0, 0),
+            },
+        }
+        return keys, 0.04 * a
+
+    if clip == "graze":
+        drop = 38 * a
+        return {
+            1:            {"neck": (0, 0, 0), "head": (0, 0, 0)},
+            quarter:      {"neck": (drop, 0, 0), "head": (drop * 0.4, 0, 0)},
+            quarter * 2:  {"neck": (drop * 1.05, 0, 0), "head": (drop * 0.45, 0, 0),
+                           "tail_1": (0, 0, 8 * a)},
+            quarter * 3:  {"neck": (drop * 0.9, 0, 0), "head": (drop * 0.35, 0, 0)},
+            length:       {"neck": (0, 0, 0), "head": (0, 0, 0)},
+        }
+
+    # idle: weight shift, tail sway, ear-flick stand-in on the head.
+    return {
+        1:            {"chest": (0, 0, 0), "tail_1": (0, 0, 0), "head": (0, 0, 0)},
+        quarter:      {"chest": (1.5 * a, 0, 1.5 * a), "tail_1": (0, 0, 10 * a),
+                       "head": (3 * a, 0, 0)},
+        quarter * 2:  {"chest": (0, 0, 0), "tail_1": (0, 0, -4 * a), "head": (0, 0, 0)},
+        quarter * 3:  {"chest": (1.5 * a, 0, -1.5 * a), "tail_1": (0, 0, -10 * a),
+                       "head": (-2 * a, 0, 0)},
+        length:       {"chest": (0, 0, 0), "tail_1": (0, 0, 0), "head": (0, 0, 0)},
+    }
+

--- a/tools/bforge/runtime/ops/check.py
+++ b/tools/bforge/runtime/ops/check.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import re
 
 import bpy
+from lib import mat as mat_lib
 from lib import mesh as mesh_lib
 from lib import scene as scene_lib
 from lib import uvs as uv_lib
@@ -348,9 +349,348 @@ def check_critique(ctx, objects, texture_size):
 
 
 @op(
-    "check.image",
-    summary="Measure an image instead of eyeballing it: luminance range, blown highlights, crushed blacks, contrast, saturation, dominant colours and subject coverage. Reading a render is slow and cannot tell 'the asset is wrong' from 'the render is over-lit'. These numbers can, in a fraction of the time.",
+    "check.materials",
+    summary="Measure whether an asset's materials are actually distinguishable — the '8 materials, all the same brown' failure that produces mud-blob characters. Reports every material's colour in CIELAB and the pairwise perceptual distance (ΔE); fails when several materials are perceptually identical or share one roughness/metallic signature.",
     params={
+        "objects": ("str[]", [], "Objects whose materials to measure (empty = every mesh)"),
+        "min_delta_e": ("num", 12.0, "Perceptual-separation floor in ΔE76. Below ~6 the difference is invisible in game; 12 is a safe bar for metal vs leather vs cloth"),
+    },
+    tags=["check", "inspect", "material"],
+    mutates=False,
+)
+def check_materials(ctx, objects, min_delta_e):
+    targets = [_get(n) for n in objects] if objects else scene_lib.mesh_objects()
+    targets = [o for o in targets if o.type == "MESH"]
+    if not targets:
+        raise OpError("no mesh objects to measure materials on")
+
+    materials = []
+    seen = set()
+    for obj in targets:
+        for material in obj.data.materials:
+            if material is None or material.name in seen:
+                continue
+            seen.add(material.name)
+            materials.append(_material_appearance(material))
+
+    for entry in materials:
+        entry["lab"] = [round(c, 2) for c in _linear_rgb_to_lab(*entry["base_color"][:3])]
+
+    pairs = []
+    for i in range(len(materials)):
+        for j in range(i + 1, len(materials)):
+            a, b = materials[i]["lab"], materials[j]["lab"]
+            delta = sum((a[k] - b[k]) ** 2 for k in range(3)) ** 0.5
+            pairs.append({"a": materials[i]["name"], "b": materials[j]["name"], "delta_e": round(delta, 2)})
+
+    findings = []
+    max_pair = max(pairs, key=lambda p: p["delta_e"]) if pairs else None
+    if len(materials) >= 3 and max_pair and max_pair["delta_e"] < min_delta_e:
+        findings.append(
+            {
+                "object": f"{len(materials)} materials",
+                "severity": "error",
+                "issue": "perceptually identical materials",
+                "detail": f"the most distant pair ('{max_pair['a']}' vs '{max_pair['b']}') is only "
+                          f"ΔE {max_pair['delta_e']:.1f} — every material reads as the same "
+                          "substance, so the asset renders as one flat mass no matter how many "
+                          "slots it has. This is the single most common reason generated "
+                          "characters look like brown blobs",
+                "fix": "separate metal/leather/cloth/skin with material.set + material.pbr "
+                       "(distinct base colours AND roughness/metallic), then add wear with "
+                       "paint.cavity and paint.height",
+            }
+        )
+    if len(materials) >= 2:
+        rough = [m["roughness"] for m in materials]
+        metal = [m["metallic"] for m in materials]
+        if max(rough) - min(rough) < 0.05 and max(metal) - min(metal) < 0.05:
+            findings.append(
+                {
+                    "object": f"{len(materials)} materials",
+                    "severity": "warn",
+                    "issue": "no material language",
+                    "detail": f"all materials share roughness {rough[0]:.2f} and metallic "
+                              f"{metal[0]:.2f} — even distinct colours will read as one "
+                              "substance because light responds identically to all of them",
+                    "fix": "spread the response: metal metallic=1 roughness~0.3, leather "
+                           "metallic=0 roughness~0.7, cloth roughness~0.9 (material.set)",
+                }
+            )
+
+    return {
+        "materials": materials,
+        "pairs": pairs,
+        "max_delta_e": max_pair["delta_e"] if max_pair else None,
+        "findings": findings,
+        "separated": not findings,
+        "note": "colours are linear-space base colours; ΔE76 below ~6 is invisible at gameplay distance",
+    }
+
+
+def _material_appearance(material):
+    """Base colour / roughness / metallic for a material, nodes or not."""
+    if material.use_nodes:
+        described = mat_lib._describes(material)
+        if described is not None:
+            base, roughness, metallic = described[0], described[1], described[2]
+            return {
+                "name": material.name,
+                "base_color": [round(float(c), 4) for c in base[:3]],
+                "hex": "#" + "".join(
+                    f"{max(0, min(255, round(_linear_to_srgb(float(c)) * 255))):02x}"
+                    for c in base[:3]
+                ),
+                "roughness": round(float(roughness), 4),
+                "metallic": round(float(metallic), 4),
+            }
+    base = tuple(material.diffuse_color)
+    return {
+        "name": material.name,
+        "base_color": [round(float(c), 4) for c in base[:3]],
+        "hex": "#" + "".join(
+            f"{max(0, min(255, round(_linear_to_srgb(float(c)) * 255))):02x}" for c in base[:3]
+        ),
+        "roughness": round(float(getattr(material, "roughness", 0.5)), 4),
+        "metallic": round(float(getattr(material, "metallic", 0.0)), 4),
+    }
+
+
+def _linear_rgb_to_lab(r, g, b):
+    """Linear sRGB -> CIELAB (D65). Deterministic stdlib math; ΔE76 is the
+    Euclidean distance in this space."""
+    x = r * 0.4124 + g * 0.3576 + b * 0.1805
+    y = r * 0.2126 + g * 0.7152 + b * 0.0722
+    z = r * 0.0193 + g * 0.1192 + b * 0.9505
+
+    def f(t):
+        return t ** (1.0 / 3.0) if t > 0.008856 else 7.787 * t + 16.0 / 116.0
+
+    fx, fy, fz = f(x / 0.95047), f(y), f(z / 1.08883)
+    return (116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz))
+
+
+@op(
+    "check.style",
+    summary="Compute the style fingerprint of every mesh: area-weighted palette (in CIELAB), texel density, triangle density, hard-edge ratio, material count, UV coverage. This is the raw material of art direction — 'do these 40 assets look like one game' is unanswerable without it.",
+    params={
+        "objects": ("str[]", [], "Objects to fingerprint (empty = every mesh)"),
+        "texture_size": ("int", 1024, "Texture resolution the texel-density figure assumes"),
+        "palette_size": ("int", 4, "Dominant colours to keep per object, area-weighted"),
+    },
+    tags=["check", "inspect", "material"],
+    mutates=False,
+)
+def check_style(ctx, objects, texture_size, palette_size):
+    targets = [_get(n) for n in objects] if objects else scene_lib.mesh_objects()
+    targets = [o for o in targets if o.type == "MESH"]
+    if not targets:
+        raise OpError("no mesh objects to fingerprint")
+
+    fingerprints = [_fingerprint(o, texture_size, palette_size) for o in targets]
+    texels = [f["texel_density"] for f in fingerprints if f["texel_density"] > 0]
+    return {
+        "objects": fingerprints,
+        "set": {
+            "count": len(fingerprints),
+            "median_texel_density": _median(texels) if texels else 0.0,
+            "median_hard_edge_ratio": _median([f["hard_edge_ratio"] for f in fingerprints]),
+            "median_tris_per_m3": _median([f["tris_per_m3"] for f in fingerprints]),
+        },
+    }
+
+
+@op(
+    "check.conformance",
+    summary="Score how well each object conforms to the set's (or a reference object's) style fingerprint. Names the exact axis that breaks coherence — palette drift, texel-density mismatch, density outlier, edge-treatment drift — with the op that fixes it. The art-director gate: run it over a whole pack before export.",
+    params={
+        "objects": ("str[]", [], "Objects to score (empty = every mesh)"),
+        "reference": ("str", "", "Conform to THIS object's fingerprint instead of the set median"),
+        "texture_size": ("int", 1024, "Texture resolution the texel-density figure assumes"),
+    },
+    tags=["check", "inspect", "material"],
+    mutates=False,
+)
+def check_conformance(ctx, objects, reference, texture_size):
+    targets = [_get(n) for n in objects] if objects else scene_lib.mesh_objects()
+    targets = [o for o in targets if o.type == "MESH"]
+    if len(targets) < 2:
+        raise OpError("conformance needs at least two objects — a set, or an object plus its reference")
+
+    prints = {o.name: _fingerprint(o, texture_size, 4) for o in targets}
+    if reference:
+        if reference not in prints:
+            raise OpError(f"reference '{reference}' is not among the objects")
+        anchor = prints[reference]
+    else:
+        anchor = {
+            "palette": _set_palette(list(prints.values())),
+            "texel_density": _median([f["texel_density"] for f in prints.values()
+                                      if f["texel_density"] > 0] or [0.0]),
+            "hard_edge_ratio": _median([f["hard_edge_ratio"] for f in prints.values()]),
+            "tris_per_m3": _median([f["tris_per_m3"] for f in prints.values()]),
+            "materials": _median([f["materials"] for f in prints.values()]),
+        }
+
+    results = []
+    for name, fp in prints.items():
+        axes = {
+            "palette": _palette_distance(fp["palette"], anchor["palette"]),
+            "texel_density": _ratio_off(fp["texel_density"], anchor["texel_density"]),
+            "hard_edge": abs(fp["hard_edge_ratio"] - anchor["hard_edge_ratio"]),
+            "tris_density": _ratio_off(fp["tris_per_m3"], anchor["tris_per_m3"]),
+            "materials": abs(fp["materials"] - anchor["materials"]),
+        }
+        # Penalty weights tuned so each axis fires at its known coherence-break
+        # point: texel >2.5x (ADR-level finding), palette ΔE ~12 (the blob
+        # floor), hard-edge drift ~0.35, density ~4x, material count ±2.
+        penalty = min(100.0,
+                      axes["palette"] / 12.0 * 25.0
+                      + max(0.0, axes["texel_density"] - 1.0) * 20.0
+                      + axes["hard_edge"] / 0.35 * 15.0
+                      + max(0.0, axes["tris_density"] - 2.0) * 10.0
+                      + axes["materials"] / 2.0 * 10.0)
+        score = round(max(0.0, 100.0 - penalty), 1)
+        worst = max(axes, key=lambda a: (
+            axes["palette"] / 12.0 * 25.0 if a == "palette" else
+            max(0.0, axes["texel_density"] - 1.0) * 20.0 if a == "texel_density" else
+            axes["hard_edge"] / 0.35 * 15.0 if a == "hard_edge" else
+            max(0.0, axes["tris_density"] - 2.0) * 10.0 if a == "tris_density" else
+            axes["materials"] / 2.0 * 10.0))
+        verdict = ("coherent" if score >= 75 else
+                   "drifting" if score >= 45 else "outlier")
+        results.append({
+            "object": name,
+            "score": score,
+            "verdict": verdict,
+            "axes": {k: round(v, 3) for k, v in axes.items()},
+            "worst_axis": worst,
+            "fix": _conformance_fix(name, worst, axes),
+        })
+
+    results.sort(key=lambda r: r["score"])
+    return {
+        "reference": reference or "(set median)",
+        "objects": results,
+        "coherent": sum(1 for r in results if r["verdict"] == "coherent"),
+        "outliers": [r["object"] for r in results if r["verdict"] == "outlier"],
+    }
+
+
+def _fingerprint(obj, texture_size, palette_size):
+    import bmesh
+
+    mesh = obj.data
+    tris = mesh_lib.tri_count(obj)
+    bounds = mesh_lib.bounds(obj)
+    volume = max(1e-6, bounds["size"][0] * bounds["size"][1] * bounds["size"][2])
+
+    # Area-weighted palette from the materials actually facing outward.
+    areas = {}
+    for poly in mesh.polygons:
+        if poly.material_index < len(mesh.materials) and mesh.materials[poly.material_index]:
+            key = mesh.materials[poly.material_index].name
+            areas[key] = areas.get(key, 0.0) + poly.area
+    palette = []
+    total_area = sum(areas.values()) or 1.0
+    for mat_name, area in sorted(areas.items(), key=lambda kv: -kv[1])[:palette_size]:
+        appearance = _material_appearance(bpy.data.materials[mat_name])
+        palette.append({
+            "material": mat_name,
+            "hex": appearance["hex"],
+            "lab": [round(c, 2) for c in _linear_rgb_to_lab(*appearance["base_color"])],
+            "share": round(area / total_area, 3),
+        })
+
+    bm = bmesh.new()
+    bm.from_mesh(mesh)
+    hard = 0
+    for edge in bm.edges:
+        if len(edge.link_faces) == 2:
+            angle = edge.link_faces[0].normal.angle(edge.link_faces[1].normal)
+            if angle > 0.61:  # ~35 degrees, matching the studio shade threshold
+                hard += 1
+    boundary = sum(1 for e in bm.edges if len(e.link_faces) == 1)
+    bm.free()
+    solid = max(1, len(mesh.edges) - boundary)
+
+    uv_stats = uv_lib.stats(obj, texture_size=texture_size)
+    return {
+        "name": obj.name,
+        "triangles": tris,
+        "tris_per_m3": round(tris / volume, 1),
+        "materials": len(areas),
+        "palette": palette,
+        "texel_density": uv_stats.get("texel_density_px_per_m", 0.0),
+        "uv_coverage": uv_stats.get("coverage", 0.0),
+        "hard_edge_ratio": round(hard / solid, 3),
+    }
+
+
+def _median(values):
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def _set_palette(fps):
+    merged = {}
+    for fp in fps:
+        for entry in fp["palette"]:
+            key = entry["hex"]
+            if key not in merged or entry["share"] > merged[key]["share"]:
+                merged[key] = entry
+    return sorted(merged.values(), key=lambda e: -e["share"])[:6]
+
+
+def _palette_distance(palette, anchor_palette):
+    """Mean ΔE from each of the object's colours to the nearest anchor colour."""
+    if not palette or not anchor_palette:
+        return 0.0
+    total = 0.0
+    weight = 0.0
+    for entry in palette:
+        best = min(
+            sum((entry["lab"][k] - anchor["lab"][k]) ** 2 for k in range(3)) ** 0.5
+            for anchor in anchor_palette
+        )
+        total += best * entry["share"]
+        weight += entry["share"]
+    return total / max(weight, 1e-6)
+
+
+def _ratio_off(value, anchor):
+    """log2-style fold distance from the anchor: 0 = identical, 1 = 2x off."""
+    if value <= 0 or anchor <= 0:
+        return 0.0
+    import math as _math
+    return abs(_math.log2(value / anchor))
+
+
+def _conformance_fix(name, worst, axes):
+    if worst == "palette":
+        return (f"'{name}' palette drifts ΔE {axes['palette']:.1f} from the set — "
+                "re-colour with material.set using the set's hex values (check.style "
+                "prints them), then re-run check.conformance")
+    if worst == "texel_density":
+        return (f"'{name}' texel density is {axes['texel_density']:.1f} doublings off the "
+                "set — re-unwrap with uv.unwrap using the SAME uv_scale as the rest of "
+                "the pack")
+    if worst == "hard_edge":
+        return (f"'{name}' edge treatment differs — object.shade angle=35 to match the "
+                "studio threshold, or add the missing chamfer with build.bevel")
+    if worst == "tris_density":
+        return (f"'{name}' spends triangles {axes['tris_density']:.1f} doublings off the "
+                "set's density — gameready.optimize or raise the generator detail to match")
+    return (f"'{name}' uses {axes['materials']:.0f} more/fewer materials than the set — "
+            "gameready.atlas or material.consolidate")
+
+
+@op(
+    "check.image",
+    summary="Measure an image instead of eyeballing it: luminance range, blown highlights, crushed blacks, contrast, saturation, dominant colours and subject coverage. Reading a render is slow and cannot tell 'the asset is wrong' from 'the render is over-lit'. These numbers can, in a fraction of the time.",    params={
         "path": ("path", None, "PNG to analyse — a render, a contact sheet, or a baked texture"),
         "colors": ("int", 6, "How many dominant colours to report"),
         "background": ("color", [0.05, 0.055, 0.065, 1.0], "Backdrop colour, excluded from subject stats"),

--- a/tools/bforge/runtime/ops/export.py
+++ b/tools/bforge/runtime/ops/export.py
@@ -104,6 +104,10 @@ def export_gltf(ctx, out, objects, engine, format, animations, draco, strict, re
             export_image_format="AUTO",
             export_skins=True,
             export_morph=True,
+            # The default 'MATERIAL' only ships COLOR_0 when a material node
+            # consumes it; paint.* writes the active colour attribute and expects
+            # it in the export. Meshes without a colour attribute are unaffected.
+            export_vertex_color="ACTIVE",
             **settings,
         )
     except (RuntimeError, TypeError) as exc:
@@ -309,15 +313,31 @@ def export_meta(ctx, out, asset_id, category, license, creator, source, ai_tool,
         "ai_prompt": ("str", "", "What the asset was asked for — recorded in provenance"),
         "contact_sheet": ("bool", True, "Also render a review contact sheet"),
         "strict": ("bool", True, "Block export on problems that would corrupt the import"),
+        "gate": ("bool", True, "Run gameready.review before writing anything; a failed review blocks the hand-off. Set false only for deliberate blockouts"),
+        "style": ("enum:stylized|realistic", "stylized", "Art direction passed to gameready.review when gate=true"),
     },
     tags=["export", "io"],
 )
 def export_asset(ctx, asset_id, out_dir, objects, engine, category, ai_prompt, contact_sheet,
-                 strict):
+                 strict, gate, style):
+    from . import gameready as gameready_ops
     from . import render as render_ops
 
     identifier = scene_lib.sanitize(asset_id)
     prefix = f"{out_dir.rstrip('/')}/{identifier}" if out_dir else identifier
+
+    if gate:
+        review = gameready_ops.gameready_review(ctx, objects, "error", style, 12.0)
+        if not review["passed"]:
+            lines = "\n  - ".join(
+                f"[{f['severity']}] {f['issue']} on {f['object']}: {f['fix']}"
+                for f in review["findings"]
+                if f["severity"] == "error"
+            )
+            raise OpError(
+                f"export '{identifier}' blocked by gameready.review:\n  - {lines}\n"
+                "Fix these, or re-run with gate=false to export anyway."
+            )
 
     blend = export_blend(ctx, f"{prefix}.blend", True, True)
     glb = export_gltf(ctx, f"{prefix}.glb", objects, engine, "glb", True, False, strict, None)

--- a/tools/bforge/runtime/ops/gameready.py
+++ b/tools/bforge/runtime/ops/gameready.py
@@ -498,6 +498,64 @@ def gameready_socket(ctx, name, parent, location, rotation, size):
     }
 
 
+@op(
+    "gameready.review",
+    summary="The quality gate: aggregate check.critique and check.materials into one pass/fail verdict before export. Exists because quality steps that are optional get skipped — a scene that passes this cannot ship the mud-blob failure (perceptually identical materials), broken geometry, or missing UVs without knowing it.",
+    params={
+        "objects": ("str[]", [], "Objects to review (empty = every mesh in the scene)"),
+        "severity": ("enum:error|warn", "error", "Findings at this level or worse fail the gate. 'error' blocks only what corrupts or reads as broken; 'warn' also blocks advisories like texel-density spread"),
+        "style": ("enum:stylized|realistic", "stylized", "'realistic' additionally fails an asset whose materials are ALL flat untextured colour — bake material.bake_pbr or pick the stylized look deliberately"),
+        "min_delta_e": ("num", 12.0, "Material-separation floor in ΔE76, passed to check.materials"),
+    },
+    tags=["gameready", "check"],
+    mutates=False,
+)
+def gameready_review(ctx, objects, severity, style, min_delta_e):
+    from . import check as check_ops
+
+    critique = check_ops.check_critique(ctx, objects, 1024)
+    materials = check_ops.check_materials(ctx, objects, min_delta_e)
+
+    findings = list(critique["findings"]) + list(materials["findings"])
+    if style == "realistic":
+        textured = any(
+            material.use_nodes
+            and any(n.type == "TEX_IMAGE" for n in material.node_tree.nodes)
+            for material in bpy.data.materials
+        )
+        if not textured and materials["materials"]:
+            findings.append(
+                {
+                    "object": f"{len(materials['materials'])} materials",
+                    "severity": "error",
+                    "issue": "flat colours only under a realistic brief",
+                    "detail": "not one material carries a texture — at realistic art direction "
+                              "that reads as untextured blockout, not as a finished surface",
+                    "fix": "run material.bake_pbr (and material.bake_detail if a high-detail "
+                           "source exists), or review again with style='stylized'",
+                }
+            )
+
+    ranks = {"error": 0, "warn": 1, "info": 2}
+    floor = ranks[severity]
+    blocking = [f for f in findings if ranks.get(f["severity"], 3) <= floor]
+    findings.sort(key=lambda f: ranks.get(f["severity"], 3))
+    return {
+        "passed": not blocking,
+        "blocking": len(blocking),
+        "findings": findings,
+        "summary": {
+            "objects": len(critique["objects"]),
+            "critique_errors": critique["errors"],
+            "critique_warnings": critique["warnings"],
+            "max_delta_e": materials["max_delta_e"],
+            "style": style,
+            "severity_floor": severity,
+        },
+        "note": "every finding names the op that fixes it; export.asset runs this gate by default (gate=false overrides deliberately)",
+    }
+
+
 def _get(name):
     try:
         return scene_lib.get_object(name)

--- a/tools/bforge/runtime/ops/morph.py
+++ b/tools/bforge/runtime/ops/morph.py
@@ -1,0 +1,259 @@
+"""Shape keys — glTF morph targets for damage states and expressions.
+
+A shape key stores a per-vertex offset from the Basis shape; glTF exports it as
+a morph target, and engines blend it at runtime with a 0..1 weight. That is how
+a crate gets a "dented" damage state, a cartoon prop gets an inflate, or a face
+gets an expression, without a second mesh or a skeleton.
+
+All displacement here is deterministic geometry maths — no randomness — and the
+keyframing idiom mirrors char.py: actions are authored directly on the shape-key
+datablock, which the glTF exporter picks up as a morph-weights animation
+channel.
+"""
+
+from __future__ import annotations
+
+import bpy
+from lib import mesh as mesh_lib
+from lib import scene as scene_lib
+from mathutils import Vector
+from registry import OpError, op
+
+
+@op(
+    "morph.add",
+    summary="Add a shape key that displaces vertices by a deterministic rule — dent a crate for a damage state, inflate a cartoon prop, taper a tree trunk, bulge a cartoon cheek. Exports to glTF as a morph target on top of Basis.",
+    params={
+        "name": ("str", None, "Mesh object to add the shape key to"),
+        "key": ("str", None, "Shape key name — this becomes the glTF morph target name (extras.targetNames), so make it meaningful: 'dented', 'inflate', 'blink'"),
+        "rule": ("enum:inflate|dent|flatten|taper|bulge", "dent", "Displacement rule: inflate pushes verts out along their normals, dent pulls verts inside `radius` toward `center`, bulge pushes them away, flatten squashes toward the center plane along `axis`, taper scales the cross-section down along `axis`"),
+        "amount": ("num", 0.1, "Displacement in metres (flatten/taper: 0..1 fraction of the way)"),
+        "axis": ("enum:x|y|z", "z", "Axis for flatten and taper (z is up)"),
+        "center": ("vec3", None, "Local-space point the rule acts around; omit to use the centre of the mesh's own bounds"),
+        "radius": ("num", 1.0, "Reach of the effect in metres — verts beyond this from `center` are untouched (taper: full axis half-extent)"),
+        "falloff": ("enum:smooth|linear", "smooth", "How the effect fades toward `radius`; smooth eases out, linear is a straight ramp"),
+    },
+    tags=["morph"],
+)
+def morph_add(ctx, name, key, rule, amount, axis, center, radius, falloff):
+    obj = _get_mesh(name)
+    mesh = obj.data
+    if not mesh.vertices:
+        raise OpError(f"'{name}' has no vertices to deform")
+
+    keys = mesh.shape_keys
+    if keys is not None and key in keys.key_blocks:
+        raise OpError(
+            f"shape key '{key}' already exists on '{name}' — pick another name, or "
+            "use morph.set / morph.animate to drive the existing one."
+        )
+    if keys is None:
+        obj.shape_key_add(name="Basis", from_mix=False)
+
+    bounds_min, bounds_max = _local_bounds(mesh)
+    if center is None:
+        center = [(bounds_min[i] + bounds_max[i]) * 0.5 for i in range(3)]
+    center = Vector(center)
+    radius = max(1e-6, radius)
+
+    # Normals are needed by inflate; read them through bmesh (data API only —
+    # bmesh is read here, never written back).
+    normals = None
+    if rule == "inflate":
+        bm = mesh_lib.obj_bmesh(obj)
+        bm.verts.ensure_lookup_table()
+        bm.normal_update()
+        normals = [v.normal.copy() for v in bm.verts]
+        bm.free()
+
+    axis_index = {"x": 0, "y": 1, "z": 2}[axis]
+    moved = 0
+    block = obj.shape_key_add(name=key, from_mix=False)
+    for index, vert in enumerate(mesh.vertices):
+        co = vert.co
+        offset = co - center
+        distance = offset.length
+        delta = Vector((0.0, 0.0, 0.0))
+
+        if rule == "taper":
+            # Cross-section shrinks from 100% at center-axis to (1-amount) at
+            # center+radius along the axis; radius doubles as the half-extent.
+            t01 = _clamp01(0.5 + 0.5 * (co[axis_index] - center[axis_index]) / radius)
+            scale = max(0.0, 1.0 - amount * t01)
+            for k in range(3):
+                if k != axis_index:
+                    delta[k] = (center[k] + (co[k] - center[k]) * scale) - co[k]
+        elif rule == "flatten":
+            weight = _falloff(distance / radius, falloff)
+            if weight > 0.0:
+                fraction = _clamp01(amount) * weight
+                delta[axis_index] = (center[axis_index] - co[axis_index]) * fraction
+        else:
+            weight = _falloff(distance / radius, falloff)
+            if weight > 0.0:
+                if rule == "inflate":
+                    delta = normals[index] * (amount * weight)
+                elif distance > 1e-9:
+                    direction = offset / distance
+                    if rule == "dent":
+                        delta = -direction * (amount * weight)
+                    else:  # bulge
+                        delta = direction * (amount * weight)
+
+        if delta.length > 1e-9:
+            block.data[index].co = co + delta
+            moved += 1
+
+    mesh.update()
+    result = {
+        "name": obj.name,
+        "key": key,
+        "rule": rule,
+        "amount": amount,
+        "vertices_moved": moved,
+        "keys": [k.name for k in mesh.shape_keys.key_blocks],
+    }
+    if moved == 0:
+        result["note"] = (
+            f"no vertices were affected — every vert is outside radius {radius} of "
+            f"center {[round(c, 3) for c in center]}. Raise `radius`, or omit `center` "
+            "to act around the mesh's own bounds centre."
+        )
+    return result
+
+
+@op(
+    "morph.set",
+    summary="Set a shape key's slider value (0..1) for review renders — pose the dent at 60% before render.contact_sheet so the still shows the damaged state.",
+    params={
+        "name": ("str", None, "Mesh object with the shape key"),
+        "key": ("str", None, "Shape key name (from morph.add or morph.list)"),
+        "value": ("num", 1.0, "Slider weight, clamped to 0..1: 0 is Basis, 1 is the full morph"),
+    },
+    tags=["morph"],
+)
+def morph_set(ctx, name, key, value):
+    block = _get_key(name, key)
+    block.value = _clamp01(value)
+    return {"name": name, "key": key, "value": block.value}
+
+
+@op(
+    "morph.animate",
+    summary="Keyframe a shape key's weight over time so glTF exports a morph-target animation channel — a crate denting on impact, a chest lid swell, a pulsing crystal. Follows the same action idiom as char.animate.",
+    params={
+        "name": ("str", None, "Mesh object with the shape key"),
+        "key": ("str", None, "Shape key name to animate"),
+        "frames": ("num[]", None, "Frame numbers, e.g. [1, 12, 24]; must be the same length as `values`"),
+        "values": ("num[]", None, "Weight at each frame (0..1), e.g. [0, 1, 0] pops the morph and settles back"),
+    },
+    tags=["morph", "anim"],
+)
+def morph_animate(ctx, name, key, frames, values):
+    block = _get_key(name, key)
+    if len(frames) != len(values):
+        raise OpError(
+            f"frames ({len(frames)}) and values ({len(values)}) must be the same length, "
+            "e.g. frames=[1, 12, 24], values=[0, 1, 0]"
+        )
+    if not frames:
+        raise OpError("frames must not be empty — give at least one (frame, value) key")
+
+    obj = _get_mesh(name)
+    keys = obj.data.shape_keys
+    if keys.animation_data is None:
+        keys.animation_data_create()
+    action = bpy.data.actions.new(scene_lib.sanitize(f"{obj.name}_{key}"))
+    keys.animation_data.action = action
+
+    for frame, value in zip(frames, values, strict=True):
+        block.value = _clamp01(value)
+        block.keyframe_insert(data_path="value", frame=frame)
+
+    scene = bpy.context.scene
+    scene.frame_start = min(scene.frame_start, int(min(frames)))
+    scene.frame_end = max(scene.frame_end, int(max(frames)))
+
+    # Keep the action reachable even after a later animate call replaces it —
+    # glTF exports every action it can reach, and a zero-user action is garbage
+    # collected. Same trick char.animate relies on.
+    action.use_fake_user = True
+
+    return {
+        "name": obj.name,
+        "key": key,
+        "action": action.name,
+        "keyframes": len(frames),
+        "all_actions": [a.name for a in bpy.data.actions],
+    }
+
+
+@op(
+    "morph.list",
+    summary="Report an object's shape keys: names, slider ranges and current values. Check this before morph.animate — the key name must match exactly.",
+    params={
+        "name": ("str", None, "Mesh object to inspect"),
+    },
+    tags=["morph", "inspect"],
+    mutates=False,
+)
+def morph_list(ctx, name):
+    obj = _get_mesh(name)
+    keys = obj.data.shape_keys
+    if keys is None:
+        ctx.note(f"'{name}' has no shape keys — morph.add creates them.")
+        return {"name": obj.name, "keys": [], "count": 0}
+    entries = [
+        {
+            "key": block.name,
+            "value": round(block.value, 4),
+            "slider_min": block.slider_min,
+            "slider_max": block.slider_max,
+            "muted": block.mute,
+        }
+        for block in keys.key_blocks
+    ]
+    return {"name": obj.name, "keys": entries, "count": len(entries)}
+
+
+def _falloff(t01, falloff):
+    """Weight at a normalised distance: 1 at the centre, 0 at the radius."""
+    if t01 >= 1.0:
+        return 0.0
+    t01 = max(0.0, t01)
+    if falloff == "linear":
+        return 1.0 - t01
+    return 1.0 - t01 * t01 * (3.0 - 2.0 * t01)  # smoothstep-shaped ease-out
+
+
+def _clamp01(value):
+    return max(0.0, min(1.0, value))
+
+
+def _local_bounds(mesh):
+    xs = [v.co.x for v in mesh.vertices]
+    ys = [v.co.y for v in mesh.vertices]
+    zs = [v.co.z for v in mesh.vertices]
+    return (min(xs), min(ys), min(zs)), (max(xs), max(ys), max(zs))
+
+
+def _get_mesh(name):
+    try:
+        obj = scene_lib.get_object(name)
+    except ValueError as exc:
+        raise OpError(str(exc)) from exc
+    if obj.type != "MESH":
+        raise OpError(f"'{name}' is a {obj.type}, not a mesh — shape keys live on meshes")
+    return obj
+
+
+def _get_key(name, key):
+    obj = _get_mesh(name)
+    keys = obj.data.shape_keys
+    if keys is None or key not in keys.key_blocks:
+        available = [] if keys is None else [k.name for k in keys.key_blocks]
+        raise OpError(
+            f"no shape key '{key}' on '{name}'. Keys: {available or '(none)'} "
+            "— morph.add creates one, morph.list shows what exists."
+        )
+    return keys.key_blocks[key]

--- a/tools/bforge/runtime/ops/paint.py
+++ b/tools/bforge/runtime/ops/paint.py
@@ -1,0 +1,330 @@
+"""Vertex-colour painting — the textureless way to make an asset read.
+
+Vertex colours export to glTF as COLOR_0 and every engine multiplies them into
+the material for free. For low-poly game assets this replaces a whole class of
+textures: dust at the base of a wall, a snow line, waterline grime, dirt baked
+into crevices, edge wear, mottled rust or moss. No UVs, no image memory, no
+bake step.
+
+Colours are stored on a CORNER-domain BYTE_COLOR attribute (one colour per
+loop), which is what the glTF exporter turns into COLOR_0. Everything is
+computed from mesh geometry with sin/cos maths only — same params, same seed,
+same bytes, on any platform.
+"""
+
+from __future__ import annotations
+
+import builtins
+import math
+
+from lib import mat as mat_lib
+from lib import mesh as mesh_lib
+from lib import scene as scene_lib
+from registry import OpError, op
+
+WHITE = (1.0, 1.0, 1.0, 1.0)
+
+
+def _layer(obj, layer):
+    """Get or create the CORNER-domain byte colour attribute the exporter wants."""
+    mesh = obj.data
+    attr = mesh.color_attributes.get(layer)
+    if attr is None:
+        attr = mesh.color_attributes.new(name=layer, type="BYTE_COLOR", domain="CORNER")
+        # A fresh attribute defaults to black, which would multiply the material
+        # down to nothing in-engine. Start at white instead, so a paint op that
+        # only touches part of the mesh leaves the rest visually unchanged.
+        attr.data.foreach_set("color", list(WHITE) * len(mesh.loops))
+        mesh.update()
+    return attr
+
+
+def _loop_vertex_map(mesh):
+    """loop index -> vertex index, so per-vertex maths can paint per-loop data."""
+    mapping = [0] * len(mesh.loops)
+    mesh.loops.foreach_get("vertex_index", mapping)
+    return mapping
+
+
+def _write_per_vertex(obj, attr, vertex_colors):
+    """Expand one RGBA per vertex onto that vertex's loops."""
+    mesh = obj.data
+    flat = [0.0] * (4 * len(mesh.loops))
+    for loop_index, vertex_index in enumerate(_loop_vertex_map(mesh)):
+        flat[loop_index * 4 : loop_index * 4 + 4] = vertex_colors[vertex_index]
+    attr.data.foreach_set("color", flat)
+    mesh.update()
+
+
+def _read_loops(attr, mesh):
+    flat = [0.0] * (4 * len(mesh.loops))
+    attr.data.foreach_get("color", flat)
+    return flat
+
+
+def _lerp(a, b, t):
+    return tuple(a[i] + (b[i] - a[i]) * t for i in range(4))
+
+
+def _clamp01(value):
+    return max(0.0, min(1.0, value))
+
+
+def _mean_edge_length(mesh):
+    if not mesh.edges:
+        return 0.0
+    verts = mesh.vertices
+    total = 0.0
+    for edge in mesh.edges:
+        total += (verts[edge.vertices[0]].co - verts[edge.vertices[1]].co).length
+    return total / len(mesh.edges)
+
+
+@op(
+    "paint.fill",
+    summary="Set every loop of a mesh to one vertex colour. The base coat for the other paint.* ops — fill white before paint.cavity so unpainted areas stay neutral, or fill a flat tint for a stylised asset.",
+    params={
+        "name": ("str", None, "Mesh object to paint"),
+        "color": ("colorref", None, "Colour: palette name, #rrggbb, or linear [r,g,b]. White leaves the material unchanged when the engine multiplies COLOR_0 in"),
+        "layer": ("str", "color", "Colour attribute name; the glTF exporter ships the active one as COLOR_0"),
+    },
+    tags=["paint"],
+)
+def paint_fill(ctx, name, color, layer):
+    obj = _get_mesh(name)
+    rgba = _color(color)
+    attr = _layer(obj, layer)
+    mesh = obj.data
+    attr.data.foreach_set("color", list(rgba) * len(mesh.loops))
+    mesh.update()
+    return {
+        "name": obj.name,
+        "layer": layer,
+        "loops_painted": len(mesh.loops),
+        "color": [round(c, 4) for c in rgba],
+    }
+
+
+@op(
+    "paint.height",
+    summary="Paint a two-colour gradient along an axis — dust at the base of a wall, a snow line on a peak, waterline grime on a hull. Cheaper than any texture and it can never stretch or seam.",
+    params={
+        "name": ("str", None, "Mesh object to paint"),
+        "low": ("colorref", None, "Colour at the bottom of the range: palette name, #rrggbb, or linear [r,g,b]"),
+        "high": ("colorref", None, "Colour at the top of the range"),
+        "axis": ("enum:x|y|z", "z", "Axis the gradient runs along (z is up). Measured in the mesh's LOCAL space, like material.face_assign"),
+        "min": ("num", None, "Axis value for 100% `low`; omit to use the mesh's own lower bound. Set both min and max to share one gradient across several objects"),
+        "max": ("num", None, "Axis value for 100% `high`; omit to use the mesh's upper bound"),
+        "curve": ("enum:linear|smooth", "linear", "Gradient easing; smooth eases in and out, which hides the band edges"),
+        "layer": ("str", "color", "Colour attribute name; the glTF exporter ships the active one as COLOR_0"),
+    },
+    tags=["paint"],
+)
+def paint_height(ctx, name, low, high, axis, min, max, curve, layer):
+    obj = _get_mesh(name)
+    low_rgba = _color(low)
+    high_rgba = _color(high)
+    mesh = obj.data
+    index = {"x": 0, "y": 1, "z": 2}[axis]
+    coords = [v.co[index] for v in mesh.vertices]
+    if not coords:
+        raise OpError(f"'{name}' has no vertices to paint")
+    lo = min if min is not None else builtins.min(coords)
+    hi = max if max is not None else builtins.max(coords)
+    span = hi - lo
+    if span < 1e-6:
+        kind = "inverted" if span < 0 else "flat"
+        raise OpError(
+            f"'{name}' has a {kind} range along {axis} (min {lo:.4f}, max {hi:.4f}) — "
+            "a height gradient needs max > min along its axis. The mesh's own lower "
+            f"bound is {builtins.min(coords):.4f} and upper is {builtins.max(coords):.4f}; "
+            "pass min/max inside that span, or omit both to auto-range the whole mesh."
+        )
+    vertex_colors = []
+    for value in coords:
+        t = _clamp01((value - lo) / span)
+        if curve == "smooth":
+            t = t * t * (3.0 - 2.0 * t)
+        vertex_colors.append(_lerp(low_rgba, high_rgba, t))
+    attr = _layer(obj, layer)
+    _write_per_vertex(obj, attr, vertex_colors)
+    return {
+        "name": obj.name,
+        "layer": layer,
+        "loops_painted": len(mesh.loops),
+        "axis": axis,
+        "range": [round(lo, 5), round(hi, 5)],
+        "curve": curve,
+    }
+
+
+@op(
+    "paint.cavity",
+    summary="Bake 'dirt in the crevices' or 'edge wear' without textures: a deterministic geometric curvature estimate per vertex. Concave spots (recesses, grooves, inside corners) take the colour in cavity mode; convex ridges take it in edge mode. Blends over the existing layer, so fill white first if the mesh is unpainted.",
+    params={
+        "name": ("str", None, "Mesh object to paint — needs real surface relief; a flat quad has no curvature to find"),
+        "color": ("colorref", None, "Colour blended into the crevices/edges: palette name, #rrggbb, or linear [r,g,b]. Dark browns read as grime, light greys as worn edges"),
+        "mode": ("enum:cavity|edge", "cavity", "cavity paints concave spots (dirt), edge paints convex ridges (wear)"),
+        "strength": ("num", 1.0, "Blend strength multiplier; the deepest cavity gets the full colour at 1.0"),
+        "invert": ("bool", False, "Flip the result — paint everything EXCEPT the crevices/edges"),
+        "layer": ("str", "color", "Colour attribute name; the glTF exporter ships the active one as COLOR_0"),
+    },
+    tags=["paint"],
+)
+def paint_cavity(ctx, name, color, mode, strength, invert, layer):
+    obj = _get_mesh(name)
+    rgba = _color(color)
+    mesh = obj.data
+    if len(mesh.vertices) < 3:
+        raise OpError(f"'{name}' has too few vertices for a curvature estimate")
+
+    # Curvature estimate: the centroid of a vertex's linked face centres sits
+    # INSIDE the material for a convex ridge (a cube corner: dot with the vertex
+    # normal is negative) and OUTSIDE it for a concave crease (the recess walls
+    # fold away from the vertex: dot is positive). Purely geometric — no ray
+    # casts, no randomness, identical on every platform.
+    bm = mesh_lib.obj_bmesh(obj)
+    bm.verts.ensure_lookup_table()
+    bm.normal_update()
+    signed = [0.0] * len(bm.verts)
+    for vert in bm.verts:
+        if not vert.link_faces:
+            continue
+        centroid = vert.link_faces[0].calc_center_median().copy()
+        for face in vert.link_faces[1:]:
+            centroid += face.calc_center_median()
+        centroid /= len(vert.link_faces)
+        signed[vert.index] = (centroid - vert.co).dot(vert.normal)
+    bm.free()
+
+    scale = builtins.max((abs(v) for v in signed), default=0.0)
+    if scale < 1e-9:
+        raise OpError(
+            f"'{name}' has no measurable curvature (a flat or fully symmetric mesh) — "
+            "nothing to paint. Cut a recess with build.extrude, or paint.noise for "
+            "variation that does not need relief."
+        )
+
+    weights = []
+    for value in signed:
+        t = _clamp01((value / scale) * (-1.0 if mode == "edge" else 1.0) * strength)
+        weights.append(1.0 - t if invert else t)
+
+    attr = _layer(obj, layer)
+    existing = _read_loops(attr, mesh)
+    mapping = _loop_vertex_map(mesh)
+    painted = 0
+    for loop_index, vertex_index in enumerate(mapping):
+        t = weights[vertex_index]
+        if t <= 0.004:  # below byte-colour quantisation — nothing changes
+            continue
+        base = existing[loop_index * 4 : loop_index * 4 + 4]
+        blended = _lerp(base, rgba, t)
+        existing[loop_index * 4 : loop_index * 4 + 4] = blended
+        painted += 1
+    attr.data.foreach_set("color", existing)
+    mesh.update()
+
+    result = {
+        "name": obj.name,
+        "layer": layer,
+        "mode": mode,
+        "loops_painted": painted,
+        "loops_total": len(mesh.loops),
+        "painted_fraction": round(painted / max(1, len(mesh.loops)), 4),
+    }
+    if painted == 0:
+        result["note"] = (
+            "no loops crossed the paint threshold — the mesh may be too smooth for "
+            f"mode='{mode}'. Try invert=true, or give it relief with build.extrude first."
+        )
+    return result
+
+
+@op(
+    "paint.noise",
+    summary="Blend two colours by deterministic fBm noise sampled at vertex positions — mottled wear, rust patches, moss, dirt variation. Breaks up flat fills so large surfaces stop looking computer-perfect.",
+    params={
+        "name": ("str", None, "Mesh object to paint"),
+        "color_a": ("colorref", None, "Colour where the noise is low: palette name, #rrggbb, or linear [r,g,b]"),
+        "color_b": ("colorref", None, "Colour where the noise is high"),
+        "scale": ("num", 2.0, "Noise frequency in 1/metres — higher gives smaller, busier patches"),
+        "seed": ("int", 0, "Random seed; same seed gives the same pattern forever"),
+        "octaves": ("int", 3, "Fractal detail levels; more octaves, finer grain"),
+        "layer": ("str", "color", "Colour attribute name; the glTF exporter ships the active one as COLOR_0"),
+    },
+    tags=["paint"],
+)
+def paint_noise(ctx, name, color_a, color_b, scale, seed, octaves, layer):
+    obj = _get_mesh(name)
+    rgba_a = _color(color_a)
+    rgba_b = _color(color_b)
+    mesh = obj.data
+    if not mesh.vertices:
+        raise OpError(f"'{name}' has no vertices to paint")
+
+    vertex_colors = []
+    for vert in mesh.vertices:
+        value = _fbm3(vert.co.x * scale, vert.co.y * scale, vert.co.z * scale,
+                      seed, octaves)
+        vertex_colors.append(_lerp(rgba_a, rgba_b, _clamp01(value * 0.5 + 0.5)))
+    attr = _layer(obj, layer)
+    _write_per_vertex(obj, attr, vertex_colors)
+
+    result = {
+        "name": obj.name,
+        "layer": layer,
+        "loops_painted": len(mesh.loops),
+        "scale": scale,
+        "seed": seed,
+        "octaves": octaves,
+    }
+    # Vertex colour can only show detail the mesh has vertices for. Fewer than
+    # ~4 vertices per noise wavelength aliases the pattern into mush.
+    edge = _mean_edge_length(mesh)
+    if edge > 1e-9 and (2.0 * math.pi) / (scale * edge) < 4.0:
+        result["note"] = (
+            f"average edge length is {edge:.3f} m, too coarse for noise at scale "
+            f"{scale} — the pattern will alias. Run build.subdivide name='{obj.name}' "
+            "or lower `scale`."
+        )
+    return result
+
+
+def _fbm3(x, y, z, seed, octaves=3):
+    """3D value-noise fBm built from sin/cos, in the spirit of env._fbm: no
+    external noise library, bit-identical across platforms, so CI can regenerate
+    an asset and diff the colours."""
+    total = 0.0
+    amplitude = 1.0
+    frequency = 1.0
+    norm = 0.0
+    for octave in range(max(1, octaves)):
+        phase = seed * 0.7919 + octave * 12.9898
+        total += amplitude * (
+            math.sin(x * frequency + phase) * math.cos(y * frequency * 1.13 - phase * 0.7)
+            + 0.6
+            * math.sin((y + z) * frequency * 0.61 + phase * 1.7)
+            * math.cos((x - z) * frequency * 0.83 - phase * 1.3)
+        )
+        norm += amplitude * 1.6
+        amplitude *= 0.5
+        frequency *= 2.0
+    return total / max(norm, 1e-6)
+
+
+def _color(value):
+    try:
+        return mat_lib.resolve_color(value)
+    except ValueError as exc:
+        raise OpError(str(exc)) from exc
+
+
+def _get_mesh(name):
+    try:
+        obj = scene_lib.get_object(name)
+    except ValueError as exc:
+        raise OpError(str(exc)) from exc
+    if obj.type != "MESH":
+        raise OpError(f"'{name}' is a {obj.type}, not a mesh — paint the render mesh")
+    return obj

--- a/tools/bforge/runtime/ops/render.py
+++ b/tools/bforge/runtime/ops/render.py
@@ -15,6 +15,7 @@ speed where a GPU context exists, with an automatic fallback.
 
 from __future__ import annotations
 
+import json
 import math
 
 import bpy
@@ -816,3 +817,194 @@ def render_turntable(ctx, out_dir, objects, frames, resolution, samples, elevati
         "directory": str(base), "rel": ctx.rel(base), "frames": len(paths),
         "files": paths, "engine": used,
     }
+
+
+def _impostor_normal_material():
+    """World-space normal -> emission colour, the standard impostor bake.
+
+    The Geometry node's Normal output is the world-space shading normal in
+    -1..1; a billboard shader expects the 0..1 texture encoding, so scale by
+    0.5 and bias by 0.5. Emission makes the pass independent of the light rig.
+    """
+    material = bpy.data.materials.get("_bforge_impostor_normal")
+    if material is not None:
+        return material
+    material = bpy.data.materials.new("_bforge_impostor_normal")
+    material.use_nodes = True
+    tree = material.node_tree
+    tree.nodes.clear()
+    output = tree.nodes.new("ShaderNodeOutputMaterial")
+    emission = tree.nodes.new("ShaderNodeEmission")
+    geometry = tree.nodes.new("ShaderNodeNewGeometry")
+    multiply = tree.nodes.new("ShaderNodeVectorMath")
+    multiply.operation = "MULTIPLY"
+    multiply.inputs[1].default_value = (0.5, 0.5, 0.5)
+    add = tree.nodes.new("ShaderNodeVectorMath")
+    add.operation = "ADD"
+    add.inputs[1].default_value = (0.5, 0.5, 0.5)
+    tree.links.new(geometry.outputs["Normal"], multiply.inputs[0])
+    tree.links.new(multiply.outputs[0], add.inputs[0])
+    tree.links.new(add.outputs[0], emission.inputs["Color"])
+    tree.links.new(emission.outputs[0], output.inputs["Surface"])
+    return material
+
+
+def _save_sheet_png(numpy, grid, path, cols, rows, size):
+    """Same compositing path as render.contact_sheet: a data-API image saved
+    directly, so no GUI-dependent writer is involved."""
+    image = bpy.data.images.new(
+        "_bforge_impostor", width=cols * size, height=rows * size, alpha=True
+    )
+    # Blender images are bottom-up; the grid is laid out top-down.
+    image.pixels = numpy.flipud(grid).ravel().tolist()
+    image.filepath_raw = str(path)
+    image.file_format = "PNG"
+    image.save()
+    bpy.data.images.remove(image)
+
+
+@op(
+    "render.impostor",
+    summary="Bake an object into a billboard impostor sprite sheet: N orthographic views orbiting it, packed left-to-right then top-to-bottom into ONE transparent PNG, plus a JSON sidecar (grid layout, yaw angles, bounds) with everything a game engine needs to billboard it. This is THE distant-LOD technique — swap the real mesh for a camera-facing quad with this sheet beyond a few hundred metres and a browser can show thousands of instances at full frame rate. Pass normals=True to also bake a world-space normal sheet so the billboard can react to scene lighting.",
+    params={
+        "name": ("str", None, "Object to bake; its children are baked with it. Use object.list if you are unsure of the exact name"),
+        "out": ("path", "impostor.png", "Sprite-sheet PNG path. The JSON sidecar is written next to it as <stem>.json"),
+        "views": ("int", 8, "Yaw angles around the object, evenly spaced over 360 degrees. 8 is the standard for props; 4 is enough for near-symmetric ones and halves the bake time"),
+        "size": ("int", 128, "Pixel size of each frame (frames are square). Billboards are only ever seen at distance, so 64-256 is the useful range — bigger just costs render time"),
+        "normals": ("bool", False, "Also write <stem>_normal.png: world-space normals packed into 0..1 colour, so the billboard can be lit instead of looking pasted on. Doubles render cost"),
+        "samples": ("int", 16, "Cycles samples per frame. 16 is plenty at these sizes; raise only if the sprites look grainy"),
+        "elevation": ("num", 0.0, "Camera height above the horizon in degrees, the same for every view. Ground props read best at 0-15; high values waste frame area on the top face"),
+    },
+    tags=["render"],
+)
+def render_impostor(ctx, name, out, views, size, normals, samples, elevation):
+    try:
+        import numpy
+    except ImportError as exc:  # pragma: no cover - Blender bundles numpy
+        raise OpError(
+            "numpy is unavailable in this Blender build; use render.turntable instead"
+        ) from exc
+
+    try:
+        root = scene_lib.get_object(name)
+    except ValueError as exc:
+        raise OpError(f"{exc} Run 'object.list' to see the names in the scene.") from exc
+    meshes = [o for o in [root, *root.children_recursive] if o.type == "MESH"]
+    triangles = sum(mesh_lib.tri_count(o) for o in meshes)
+    if triangles == 0:
+        raise OpError(
+            f"'{name}' has no triangles to bake — it and its children are not meshes. "
+            "Bake a mesh object: build one with build.*/prop.* first, or run "
+            "'session.info' to see what every object in the scene actually is."
+        )
+
+    views = max(1, min(64, views))
+    size = max(8, min(1024, size))
+    cols = math.ceil(math.sqrt(views))
+    rows = math.ceil(views / cols)
+
+    # Frame from the world AABB of the whole hierarchy. The diagonal is the
+    # worst-case projected extent over every yaw angle, so sizing the ortho
+    # frame to it guarantees the subject fills ~90% of the square frame at its
+    # widest and never clips at any other angle.
+    bpy.context.view_layer.update()  # world matrices must be current to frame anything
+    points = [o.matrix_world @ Vector(c) for o in meshes for c in o.bound_box]
+    lo = Vector((min(p[i] for p in points) for i in range(3)))
+    hi = Vector((max(p[i] for p in points) for i in range(3)))
+    centre = (lo + hi) * 0.5
+    diagonal = max((hi - lo).length, 1e-6)
+
+    hidden = _hide_others(meshes)
+    _setup_world(0.6)
+    lights = _setup_lights(centre, diagonal * 0.5)
+    used = _configure_engine("cycles", samples, size)
+    scene = bpy.context.scene
+    scene.render.film_transparent = True
+    scene.render.image_settings.color_mode = "RGBA"
+
+    camera_data = bpy.data.cameras.new("_bforge_impostor")
+    camera = bpy.data.objects.new("_bforge_impostor", camera_data)
+    scene.collection.objects.link(camera)
+    scene.camera = camera
+    camera_data.type = "ORTHO"
+    camera_data.ortho_scale = diagonal / 0.9
+    distance = diagonal * 2.0
+    camera_data.clip_start = max(0.01, distance * 0.01)
+    camera_data.clip_end = distance * 4.0
+
+    sheet_path = ctx.out_path(out, ".png")
+    normal_path = sheet_path.with_name(f"{sheet_path.stem}_normal.png")
+    sidecar_path = sheet_path.with_suffix(".json")
+    scratch = ctx.out_dir / "_impostor"
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    tilt = math.radians(elevation)
+
+    def _render_frames(stem):
+        # Empty grid cells (views not filling the last row) stay transparent.
+        grid = numpy.zeros((rows * size, cols * size, 4), dtype=numpy.float32)
+        for index in range(views):
+            # The camera orbits while the light rig stays fixed — the sprite
+            # lighting is then consistent across frames, as if the object spun.
+            yaw = math.tau * index / views
+            offset = Vector(
+                (
+                    math.cos(yaw) * math.cos(tilt),
+                    math.sin(yaw) * math.cos(tilt),
+                    math.sin(tilt),
+                )
+            ) * distance
+            camera.location = centre + offset
+            camera.rotation_euler = (-offset).to_track_quat("-Z", "Y").to_euler()
+            _render_to(scratch / f"{stem}_{index:03d}.png")
+            pixels = _load_pixels(numpy, scratch / f"{stem}_{index:03d}.png", size)
+            row, column = divmod(index, cols)
+            grid[row * size : (row + 1) * size, column * size : (column + 1) * size] = pixels
+        return grid
+
+    try:
+        _save_sheet_png(numpy, _render_frames("beauty"), sheet_path, cols, rows, size)
+        if normals:
+            swapped = _swap_materials(meshes, _impostor_normal_material())
+            view = scene.view_settings
+            previous_transform = view.view_transform
+            try:
+                # A normal map is data, not a beauty image: Raw writes the
+                # remapped 0..1 normal to the PNG exactly, skipping the display
+                # transform the colour pass wants.
+                try:
+                    view.view_transform = "Raw"
+                except TypeError:
+                    pass
+                _save_sheet_png(numpy, _render_frames("normal"), normal_path, cols, rows, size)
+            finally:
+                view.view_transform = previous_transform
+                _restore_materials(swapped)
+    finally:
+        _cleanup_rig(lights + [camera])
+        for obj in hidden:
+            obj.hide_render = False
+
+    sidecar = {
+        "frames": views,
+        "cols": cols,
+        "rows": rows,
+        "frame_px": size,
+        "yaw_degrees": [round(360.0 * i / views, 6) for i in range(views)],
+        "elevation": elevation,
+        "object": root.name,
+        "bounds_m": [round(v, 5) for v in (hi - lo)],
+    }
+    sidecar_path.write_text(json.dumps(sidecar, indent=2) + "\n", encoding="utf-8")
+
+    result = {
+        "sheet": ctx.rel(sheet_path),
+        "sidecar": ctx.rel(sidecar_path),
+        "frames": views,
+        "cols": cols,
+        "rows": rows,
+        "bytes": sheet_path.stat().st_size,
+    }
+    if normals:
+        result["normal_sheet"] = ctx.rel(normal_path)
+    return result

--- a/tools/bforge/runtime/ops/session.py
+++ b/tools/bforge/runtime/ops/session.py
@@ -18,7 +18,11 @@ def reset_scene(ctx, unit_scale=1.0):
     scene.unit_settings.system = "METRIC"
     scene.unit_settings.scale_length = unit_scale
     scene.unit_settings.length_unit = "METERS"
-    scene.render.engine = "BLENDER_EEVEE"
+    # EEVEE was renamed to EEVEE Next in Blender 4.2; pick whichever exists.
+    engines = {item.identifier for item in scene.render.bl_rna.properties["engine"].enum_items}
+    scene.render.engine = (
+        "BLENDER_EEVEE_NEXT" if "BLENDER_EEVEE_NEXT" in engines else "BLENDER_EEVEE"
+    )
     scene.render.fps = 30
     scene.frame_start = 1
     scene.frame_end = 1

--- a/tools/bforge/tests/test_char_outfit.py
+++ b/tools/bforge/tests/test_char_outfit.py
@@ -1,0 +1,164 @@
+"""Live tests for char.outfit / char.face / char.hands — the anti 'brown blob'
+character layer. Verifies fit (shield outside the torso silhouette — the
+warden failure), material separation measured through check.materials, rig
+following, and byte-level determinism.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_outfit_test_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+
+def read_glb_json(path: Path) -> dict:
+    data = path.read_bytes()
+    assert data[:4] == b"glTF", "not a GLB"
+    chunk_len, chunk_type = struct.unpack_from("<I4s", data, 12)
+    assert chunk_type == b"JSON"
+    return json.loads(data[20 : 20 + chunk_len])
+
+
+def _humanoid(name="warden", height=1.8):
+    FORGE.call("char.humanoid", name=name, height=height, build="heroic", seed=3)
+    return name
+
+
+class Outfit(ForgeCase):
+    def test_pieces_fit_and_are_named(self):
+        body = _humanoid()
+        for piece in ("cuirass", "pteruges", "greaves", "bracers", "helmet", "shield"):
+            result = FORGE.call("char.outfit", name=body, piece=piece, height=1.8)
+            self.assertEqual(result["piece"], piece)
+            self.assertTrue(result["object"].startswith(body))
+            self.assertLess(result["triangles"], 4000, f"{piece} too heavy")
+
+    def test_shield_does_not_eat_the_character(self):
+        """The warden failure: shield centred on the torso, hiding the body."""
+        body = _humanoid()
+        FORGE.call("char.outfit", name=body, piece="cuirass", height=1.8)
+        shield = FORGE.call("char.outfit", name=body, piece="shield", height=1.8)
+        info = FORGE.call("object.inspect", name=shield["object"])
+        center_x = (info["bounds"]["min"][0] + info["bounds"]["max"][0]) / 2.0
+        torso_r = 1.8 * 0.078 * 1.18  # heroic bulk
+        self.assertGreater(
+            abs(center_x), torso_r,
+            f"shield centre |x|={abs(center_x):.3f} is inside the torso silhouette "
+            f"(torso_r={torso_r:.3f}) — the warden failure",
+        )
+
+    def test_materials_are_separated_by_construction(self):
+        body = _humanoid()
+        FORGE.call("char.outfit", name=body, piece="cuirass", height=1.8)   # bronze
+        FORGE.call("char.outfit", name=body, piece="pteruges", height=1.8)  # leather
+        FORGE.call("char.outfit", name=body, piece="helmet", height=1.8)    # bronze
+        FORGE.call("char.outfit", name=body, piece="bracers", height=1.8)   # leather
+        result = FORGE.call("check.materials")
+        errors = [f for f in result["findings"] if f["severity"] == "error"]
+        self.assertEqual(errors, [], f"outfit defaults must pass the blob gate: {errors}")
+        self.assertGreater(result["max_delta_e"], 12.0)
+
+    def test_pieces_follow_the_rig(self):
+        body = _humanoid()
+        rig = FORGE.call("char.rig", name=body, height=1.8, build="heroic")
+        helmet = FORGE.call("char.outfit", name=body, piece="helmet", height=1.8)
+        shield = FORGE.call("char.outfit", name=body, piece="shield", height=1.8)
+        self.assertIn("head", helmet["follows"])
+        self.assertIn("forearm_l", shield["follows"])
+        glb = FORGE.call("export.gltf", out="rigged.glb", objects=[rig["armature"], body,
+                                                                   helmet["object"],
+                                                                   shield["object"]])
+        parsed = read_glb_json(Path(glb["path"]))
+        self.assertGreaterEqual(len(parsed.get("skins", [])), 1)
+        # Bone-parented pieces export as children of their joint node.
+        nodes = parsed["nodes"]
+        parent_of = {}
+        for index, node in enumerate(nodes):
+            for child in node.get("children", []):
+                parent_of[child] = index
+        for piece_name, bone in ((helmet["object"], "head"),
+                                 (shield["object"], "forearm_l")):
+            piece_idx = next(i for i, n in enumerate(nodes) if n.get("name") == piece_name)
+            self.assertEqual(nodes[parent_of[piece_idx]].get("name"), bone)
+
+    def test_outfit_exports_cleanly(self):
+        body = _humanoid()
+        FORGE.call("char.outfit", name=body, piece="cuirass", height=1.8)
+        FORGE.call("char.outfit", name=body, piece="shield", height=1.8)
+        glb = FORGE.call("export.gltf", out="outfit.glb")
+        parsed = read_glb_json(Path(glb["path"]))
+        self.assertGreaterEqual(len(parsed["meshes"]), 3)
+
+
+class FaceHands(ForgeCase):
+    def test_face_adds_readable_features(self):
+        body = _humanoid()
+        before = FORGE.call("object.inspect", name=body)["triangles"]
+        result = FORGE.call("char.face", name=body, height=1.8)
+        self.assertGreater(result["faces_added"], 0)
+        after = FORGE.call("object.inspect", name=body)["triangles"]
+        self.assertGreater(after, before)
+        self.assertLess(after - before, 3000, "face must stay cheap")
+
+    def test_hands_add_fingers(self):
+        body = _humanoid()
+        result = FORGE.call("char.hands", name=body, height=1.8, curl=0.35)
+        self.assertGreater(result["faces_added"], 0)
+        FORGE.call("export.gltf", out="hands.glb")  # parses without error
+
+    def test_determinism(self):
+        def build_once(out):
+            FORGE.call("session.reset")
+            body = _humanoid()
+            FORGE.call("char.face", name=body, height=1.8)
+            FORGE.call("char.hands", name=body, height=1.8)
+            FORGE.call("char.outfit", name=body, piece="cuirass", height=1.8)
+            FORGE.call("char.outfit", name=body, piece="helmet", height=1.8)
+            FORGE.call("char.outfit", name=body, piece="shield", height=1.8)
+            return Path(FORGE.call("export.gltf", out=out)["path"]).read_bytes()
+
+        self.assertEqual(build_once("det_a.glb"), build_once("det_b.glb"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bforge/tests/test_creature.py
+++ b/tools/bforge/tests/test_creature.py
@@ -1,0 +1,178 @@
+"""Live tests for char.creature / char.creature_rig and the quadruped gaits."""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_creature_test_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+
+def read_glb_json(path: Path) -> dict:
+    data = path.read_bytes()
+    assert data[:4] == b"glTF", "not a GLB"
+    chunk_len, chunk_type = struct.unpack_from("<I4s", data, 12)
+    assert chunk_type == b"JSON"
+    return json.loads(data[20 : 20 + chunk_len])
+
+
+class Creature(ForgeCase):
+    def test_body_builds_within_budget(self):
+        result = FORGE.call("char.creature", name="hound", length=1.3, shoulder=0.85,
+                            plan="canine", seed=5)
+        self.assertEqual(result["plan"], "canine")
+        self.assertLess(result["triangles"], 6000)
+        bounds = result["bounds"]["size"]
+        self.assertGreater(bounds[1], bounds[2] * 0.8,
+                           "a quadruped is longer than it is tall")
+
+    def test_all_plans_build(self):
+        for plan in ("equine", "feline", "generic"):
+            result = FORGE.call("char.creature", name=f"beast_{plan}", plan=plan, seed=9)
+            self.assertGreater(result["triangles"], 200)
+
+    def test_rig_has_quadruped_bones_and_single_root(self):
+        FORGE.call("char.creature", name="hound", length=1.3, shoulder=0.85, seed=5)
+        rig = FORGE.call("char.creature_rig", name="hound", length=1.3, shoulder=0.85)
+        bones = set(rig["bones"])
+        for expected in ("hips", "spine", "chest", "neck", "head", "tail_1", "tail_2",
+                         "front_upper_l", "front_lower_l", "front_paw_l",
+                         "rear_upper_r", "rear_lower_r", "rear_paw_r"):
+            self.assertIn(expected, bones)
+        self.assertEqual(rig["bone_count"], 19)
+        self.assertGreater(rig["weighted_vertices"], 0)
+
+    def test_gaits_export_as_animation_clips(self):
+        FORGE.call("char.creature", name="hound", length=1.3, shoulder=0.85, seed=5)
+        rig = FORGE.call("char.creature_rig", name="hound", length=1.3, shoulder=0.85)
+        for clip in ("walk", "trot", "gallop", "graze", "idle"):
+            result = FORGE.call("char.animate", rig=rig["armature"], clip=clip, length=24)
+            self.assertGreater(result["keyframes"], 10, f"{clip} produced no keys")
+        glb = FORGE.call("export.gltf", out="hound.glb",
+                         objects=[rig["armature"], "hound"])
+        parsed = read_glb_json(Path(glb["path"]))
+        self.assertEqual(len(parsed.get("skins", [])), 1)
+        self.assertEqual(len(parsed["skins"][0]["joints"]), 19)
+        self.assertEqual(len(parsed.get("animations", [])), 5)
+
+    def test_wrong_family_clip_is_a_helpful_error(self):
+        FORGE.call("char.creature", name="hound", length=1.3, shoulder=0.85, seed=5)
+        rig = FORGE.call("char.creature_rig", name="hound", length=1.3, shoulder=0.85)
+        with self.assertRaises(ForgeError) as ctx:
+            FORGE.call("char.animate", rig=rig["armature"], clip="attack")
+        self.assertIn("quadruped", str(ctx.exception))
+        FORGE.call("session.reset")
+        FORGE.call("char.humanoid", name="warden", height=1.8, seed=3)
+        rig2 = FORGE.call("char.rig", name="warden", height=1.8)
+        with self.assertRaises(ForgeError) as ctx2:
+            FORGE.call("char.animate", rig=rig2["armature"], clip="trot")
+        self.assertIn("humanoid", str(ctx2.exception))
+
+    def test_determinism(self):
+        def build_once(out):
+            FORGE.call("session.reset")
+            FORGE.call("char.creature", name="hound", length=1.3, shoulder=0.85, seed=5)
+            rig = FORGE.call("char.creature_rig", name="hound", length=1.3, shoulder=0.85)
+            FORGE.call("char.animate", rig=rig["armature"], clip="trot", length=24)
+            return Path(FORGE.call("export.gltf", out=out)["path"]).read_bytes()
+
+        self.assertEqual(build_once("det_a.glb"), build_once("det_b.glb"))
+
+    def test_creature_passes_the_quality_gate(self):
+        FORGE.call("char.creature", name="hound", length=1.3, shoulder=0.85, seed=5)
+        review = FORGE.call("gameready.review", objects=["hound"])
+        self.assertTrue(review["passed"], f"findings: {review['findings']}")
+
+
+class Hexapod(ForgeCase):
+    def test_insect_body_and_rig(self):
+        result = FORGE.call("char.creature", name="scarab", plan="insect",
+                            length=0.9, shoulder=0.35, skin="#3d3226", seed=17)
+        self.assertEqual(result["plan"], "insect")
+        self.assertLess(result["triangles"], 8000)
+        rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
+                         length=0.9, shoulder=0.35)
+        bones = set(rig["bones"])
+        for expected in ("hips", "chest", "head",
+                         "front_upper_l", "mid_upper_l", "rear_upper_l",
+                         "mid_lower_r", "mid_paw_r", "rear_paw_l"):
+            self.assertIn(expected, bones)
+        self.assertEqual(rig["bone_count"], 21)
+        self.assertGreater(rig["weighted_vertices"], 0)
+
+    def test_tripod_walk_exports(self):
+        FORGE.call("char.creature", name="scarab", plan="insect",
+                   length=0.9, shoulder=0.35, seed=17)
+        rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
+                         length=0.9, shoulder=0.35)
+        walk = FORGE.call("char.animate", rig=rig["armature"], clip="walk", length=24)
+        self.assertGreater(walk["keyframes"], 10)
+        glb = FORGE.call("export.gltf", out="scarab.glb",
+                         objects=[rig["armature"], "scarab"])
+        parsed = read_glb_json(Path(glb["path"]))
+        self.assertEqual(len(parsed["skins"][0]["joints"]), 21)
+        self.assertEqual(len(parsed.get("animations", [])), 1)
+
+    def test_quadruped_gait_on_hexapod_is_a_helpful_error(self):
+        FORGE.call("char.creature", name="scarab", plan="insect",
+                   length=0.9, shoulder=0.35, seed=17)
+        rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
+                         length=0.9, shoulder=0.35)
+        with self.assertRaises(ForgeError) as ctx:
+            FORGE.call("char.animate", rig=rig["armature"], clip="trot")
+        self.assertIn("hexapod", str(ctx.exception))
+
+    def test_determinism(self):
+        def build_once(out):
+            FORGE.call("session.reset")
+            FORGE.call("char.creature", name="scarab", plan="insect",
+                       length=0.9, shoulder=0.35, seed=17)
+            rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
+                             length=0.9, shoulder=0.35)
+            FORGE.call("char.animate", rig=rig["armature"], clip="walk", length=24)
+            return Path(FORGE.call("export.gltf", out=out)["path"]).read_bytes()
+
+        self.assertEqual(build_once("hex_a.glb"), build_once("hex_b.glb"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bforge/tests/test_impostor.py
+++ b/tools/bforge/tests/test_impostor.py
@@ -1,0 +1,154 @@
+"""Live tests for render.impostor — billboard sprite-sheet baking.
+
+Same pattern as test_forge.py: one shared daemon for the whole module
+(booting Blender costs ~5 s), skipping cleanly when Blender is absent or
+BFORGE_SKIP_LIVE is set. PNG dimensions are read from the IHDR chunk with
+struct — stdlib only, no PIL.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_impostor_test_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+def png_size(path) -> tuple[int, int]:
+    """(width, height) from the PNG IHDR chunk, stdlib only."""
+    data = Path(path).read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise AssertionError(f"{path} is not a PNG file")
+    length, kind = struct.unpack_from(">I4s", data, 8)
+    if kind != b"IHDR":
+        raise AssertionError(f"{path}: first chunk is {kind!r}, not IHDR")
+    width, height = struct.unpack_from(">II", data, 16)
+    return width, height
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+    def out_file(self, rel: str) -> Path:
+        return Path(TEMP.name) / rel
+
+
+class Impostor(ForgeCase):
+    def test_sheet_layout_sidecar_and_pixel_dimensions(self):
+        self.forge.call("build.box", name="crateish", size=[0.8, 0.6, 1.2], bevel=0.0)
+        result = self.forge.call(
+            "render.impostor",
+            name="crateish",
+            out="imp.png",
+            views=4,
+            size=64,
+            samples=8,
+            _timeout=900,
+        )
+        self.assertEqual(result["frames"], 4)
+        self.assertEqual(result["cols"], 2)
+        self.assertEqual(result["rows"], 2)
+
+        sheet = self.out_file(result["sheet"])
+        self.assertTrue(sheet.is_file(), f"sheet missing: {sheet}")
+        self.assertEqual(png_size(sheet), (2 * 64, 2 * 64))
+        self.assertEqual(result["bytes"], sheet.stat().st_size)
+
+        sidecar_path = self.out_file(result["sidecar"])
+        self.assertTrue(sidecar_path.is_file(), f"sidecar missing: {sidecar_path}")
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        self.assertEqual(sidecar["frames"], 4)
+        self.assertEqual(sidecar["cols"], 2)
+        self.assertEqual(sidecar["rows"], 2)
+        self.assertEqual(sidecar["frame_px"], 64)
+        self.assertEqual(sidecar["yaw_degrees"], [0.0, 90.0, 180.0, 270.0])
+        self.assertEqual(sidecar["elevation"], 0.0)
+        self.assertEqual(sidecar["object"], "crateish")
+        for axis, want in enumerate((0.8, 0.6, 1.2)):
+            self.assertAlmostEqual(sidecar["bounds_m"][axis], want, places=3)
+
+    def test_normals_true_writes_the_normal_sheet(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1], bevel=0.0)
+        result = self.forge.call(
+            "render.impostor",
+            name="b",
+            out="lit.png",
+            views=4,
+            size=64,
+            samples=8,
+            normals=True,
+            _timeout=900,
+        )
+        self.assertIn("normal_sheet", result)
+        normal = self.out_file(result["normal_sheet"])
+        self.assertEqual(normal.name, "lit_normal.png")
+        self.assertTrue(normal.is_file(), f"normal sheet missing: {normal}")
+        self.assertEqual(png_size(normal), (result["cols"] * 64, result["rows"] * 64))
+
+    def test_identical_calls_produce_identical_output(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1], bevel=0.0)
+        first = self.forge.call(
+            "render.impostor", name="b", out="a.png", views=4, size=64, samples=8,
+            _timeout=900,
+        )
+        second = self.forge.call(
+            "render.impostor", name="b", out="b.png", views=4, size=64, samples=8,
+            _timeout=900,
+        )
+        self.assertEqual(
+            self.out_file(first["sidecar"]).read_bytes(),
+            self.out_file(second["sidecar"]).read_bytes(),
+            "sidecar JSON must be byte-identical run to run",
+        )
+        # This pipeline (Cycles CPU, fixed seed, Blender's PNG writer) embeds no
+        # timestamps, so the whole PNG compares byte-identical. If a future
+        # Blender adds a tIME chunk, compare IHDR+IDAT chunks only.
+        self.assertEqual(
+            self.out_file(first["sheet"]).read_bytes(),
+            self.out_file(second["sheet"]).read_bytes(),
+            "sheet PNG must be byte-identical run to run",
+        )
+
+    def test_missing_object_names_the_listing_op(self):
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("render.impostor", name="ghost", views=1, size=8, samples=1)
+        self.assertIn("object.list", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bforge/tests/test_morph.py
+++ b/tools/bforge/tests/test_morph.py
@@ -1,0 +1,180 @@
+"""Live Blender integration tests for morph.* — shape keys must reach glTF as
+morph targets (extras.targetNames + primitives[].targets), and morph.animate
+must produce a weights animation channel.
+
+Same pattern as test_forge.py: one shared daemon per module, clean skips when
+Blender is absent or BFORGE_SKIP_LIVE is set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_test_morph_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+
+def read_glb_json(path: Path) -> dict:
+    """Parse a GLB container's JSON chunk — same stdlib-only proof as test_forge."""
+    data = path.read_bytes()
+    magic, _version, _length = struct.unpack_from("<III", data, 0)
+    assert magic == 0x46546C67, f"not a GLB file: magic={magic:#x}"
+    chunk_length, chunk_type = struct.unpack_from("<II", data, 12)
+    assert chunk_type == 0x4E4F534A, "first GLB chunk is not JSON"
+    return json.loads(data[20 : 20 + chunk_length].decode("utf-8"))
+
+
+class Add(ForgeCase):
+    def test_add_exports_a_morph_target_with_the_key_name(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        self.forge.call("morph.add", name="b", key="dented", rule="dent", amount=0.2, radius=2.0)
+        exported = self.forge.call("export.gltf", out="morphed.glb")
+        gltf = read_glb_json(Path(exported["path"]))
+        mesh = gltf["meshes"][0]
+        targets = mesh["primitives"][0].get("targets", [])
+        self.assertEqual(len(targets), 1, "one shape key -> one morph target")
+        self.assertIn("POSITION", targets[0])
+        self.assertEqual(mesh.get("extras", {}).get("targetNames"), ["dented"])
+
+    def test_add_reports_moved_vertices_and_keys(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        result = self.forge.call(
+            "morph.add", name="b", key="inflate", rule="inflate", amount=0.1, radius=5.0
+        )
+        self.assertGreater(result["vertices_moved"], 0)
+        self.assertEqual(result["keys"], ["Basis", "inflate"])
+
+    def test_add_with_a_tiny_radius_warns_instead_of_silently_no_op(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        result = self.forge.call(
+            "morph.add", name="b", key="poke", rule="dent", center=[9, 9, 9], radius=0.1
+        )
+        self.assertEqual(result["vertices_moved"], 0)
+        self.assertIn("note", result)
+
+    def test_add_a_duplicate_key_is_a_helpful_error(self):
+        self.forge.call("build.box", name="b")
+        self.forge.call("morph.add", name="b", key="dent", rule="dent")
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("morph.add", name="b", key="dent", rule="bulge")
+        self.assertIn("already exists", str(ctx.exception))
+
+    def test_rules_actually_displace_different_verts(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        dent = self.forge.call("morph.add", name="b", key="dent", rule="dent",
+                               amount=0.2, radius=2.0)
+        self.forge.call("session.reset")
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        taper = self.forge.call("morph.add", name="b", key="taper", rule="taper",
+                                amount=0.5, radius=2.0)
+        self.assertGreater(dent["vertices_moved"], 0)
+        self.assertGreater(taper["vertices_moved"], 0)
+
+
+class SetAndList(ForgeCase):
+    def test_set_updates_the_slider_and_list_reports_it(self):
+        self.forge.call("build.box", name="b")
+        self.forge.call("morph.add", name="b", key="dent", rule="dent")
+        result = self.forge.call("morph.set", name="b", key="dent", value=0.6)
+        self.assertAlmostEqual(result["value"], 0.6, places=4)
+        listing = self.forge.call("morph.list", name="b")
+        dent = [k for k in listing["keys"] if k["key"] == "dent"]
+        self.assertEqual(len(dent), 1)
+        self.assertAlmostEqual(dent[0]["value"], 0.6, places=4)
+        self.assertEqual(dent[0]["slider_min"], 0.0)
+        self.assertEqual(dent[0]["slider_max"], 1.0)
+
+    def test_set_clamps_out_of_range_values(self):
+        self.forge.call("build.box", name="b")
+        self.forge.call("morph.add", name="b", key="dent", rule="dent")
+        result = self.forge.call("morph.set", name="b", key="dent", value=4.0)
+        self.assertEqual(result["value"], 1.0)
+
+    def test_list_without_keys_reports_empty(self):
+        self.forge.call("build.box", name="b")
+        listing = self.forge.call("morph.list", name="b")
+        self.assertEqual(listing["keys"], [])
+        self.assertEqual(listing["count"], 0)
+
+    def test_set_an_unknown_key_lists_what_exists(self):
+        self.forge.call("build.box", name="b")
+        self.forge.call("morph.add", name="b", key="dent", rule="dent")
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("morph.set", name="b", key="nope", value=1.0)
+        self.assertIn("dent", str(ctx.exception))
+
+
+class Animate(ForgeCase):
+    def test_animate_exports_a_weights_channel(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        self.forge.call("morph.add", name="b", key="dented", rule="dent", amount=0.2, radius=2.0)
+        result = self.forge.call(
+            "morph.animate", name="b", key="dented",
+            frames=[1, 12, 24], values=[0.0, 1.0, 0.0],
+        )
+        self.assertEqual(result["keyframes"], 3)
+        exported = self.forge.call("export.gltf", out="morph_anim.glb")
+        gltf = read_glb_json(Path(exported["path"]))
+        paths = [
+            channel["target"]["path"]
+            for animation in gltf.get("animations", [])
+            for channel in animation["channels"]
+        ]
+        self.assertIn("weights", paths, f"no morph-weights channel exported: {paths}")
+
+    def test_animate_rejects_mismatched_frame_and_value_lists(self):
+        self.forge.call("build.box", name="b")
+        self.forge.call("morph.add", name="b", key="dent", rule="dent")
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("morph.animate", name="b", key="dent",
+                            frames=[1, 12], values=[0.0])
+        self.assertIn("same length", str(ctx.exception))
+
+    def test_animate_requires_an_existing_key(self):
+        self.forge.call("build.box", name="b")
+        with self.assertRaises(ForgeError):
+            self.forge.call("morph.animate", name="b", key="ghost",
+                            frames=[1, 12], values=[0.0, 1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bforge/tests/test_paint.py
+++ b/tools/bforge/tests/test_paint.py
@@ -1,0 +1,232 @@
+"""Live Blender integration tests for paint.* — vertex colours must reach glTF
+as COLOR_0, gradients must actually vary, and noise must be bit-deterministic.
+
+Same pattern as test_forge.py: one shared daemon per module, clean skips when
+Blender is absent or BFORGE_SKIP_LIVE is set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_test_paint_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+
+def read_glb(path: Path):
+    """Split a GLB into (json dict, BIN chunk bytes) with stdlib only."""
+    data = path.read_bytes()
+    magic, _version, _length = struct.unpack_from("<III", data, 0)
+    assert magic == 0x46546C67, f"not a GLB file: magic={magic:#x}"
+    offset = 12
+    gltf, binary = None, b""
+    while offset < len(data):
+        chunk_length, chunk_type = struct.unpack_from("<II", data, offset)
+        chunk = data[offset + 8 : offset + 8 + chunk_length]
+        if chunk_type == 0x4E4F534A:
+            gltf = json.loads(chunk.decode("utf-8"))
+        elif chunk_type == 0x004E4942:
+            binary = chunk
+        offset += 8 + chunk_length
+    assert gltf is not None, "GLB has no JSON chunk"
+    return gltf, binary
+
+
+_COMPONENT = {5120: ("b", 1, None), 5121: ("B", 1, 255), 5122: ("h", 2, None),
+              5123: ("H", 2, 65535), 5125: ("I", 4, None), 5126: ("f", 4, None)}
+_TYPE_LEN = {"SCALAR": 1, "VEC2": 2, "VEC3": 3, "VEC4": 4}
+
+
+def read_accessor(gltf, binary, index):
+    """Decode an accessor into a list of tuples, honouring `normalized`."""
+    accessor = gltf["accessors"][index]
+    view = gltf["bufferViews"][accessor["bufferView"]]
+    fmt, size, norm_max = _COMPONENT[accessor["componentType"]]
+    width = _TYPE_LEN[accessor["type"]]
+    stride = view.get("byteStride") or size * width
+    base = view.get("byteOffset", 0) + accessor.get("byteOffset", 0)
+    out = []
+    for i in range(accessor["count"]):
+        at = base + i * stride
+        values = struct.unpack_from(f"<{width}{fmt}", binary, at)
+        if norm_max is not None and accessor.get("normalized"):
+            values = tuple(v / norm_max for v in values)
+        out.append(values)
+    return out
+
+
+def read_colors(path: Path):
+    """The exported COLOR_0 of the first primitive, as (r, g, b, a) 0..1 rows."""
+    gltf, binary = read_glb(path)
+    primitive = gltf["meshes"][0]["primitives"][0]
+    return gltf, read_accessor(gltf, binary, primitive["attributes"]["COLOR_0"])
+
+
+class Fill(ForgeCase):
+    def test_fill_exports_color0(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        result = self.forge.call("paint.fill", name="b", color="#8899aa")
+        self.assertEqual(result["layer"], "color")
+        self.assertGreater(result["loops_painted"], 0)
+        exported = self.forge.call("export.gltf", out="filled.glb")
+        gltf, _binary = read_glb(Path(exported["path"]))
+        primitive = gltf["meshes"][0]["primitives"][0]
+        self.assertIn("COLOR_0", primitive["attributes"])
+
+    def test_fill_paints_every_loop_the_same_colour(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        result = self.forge.call("paint.fill", name="b", color="#8899aa")
+        exported = self.forge.call("export.gltf", out="filled_uniform.glb")
+        _gltf, colors = read_colors(Path(exported["path"]))
+        self.assertEqual(len(colors), result["loops_painted"])
+        for channel in range(3):
+            values = [c[channel] for c in colors]
+            self.assertLessEqual(
+                max(values) - min(values), 0.02,
+                "a flat fill must come back uniform",
+            )
+        # #8899aa is a cool grey: blue channel clearly above red.
+        self.assertGreater(colors[0][2], colors[0][0])
+
+    def test_fill_accepts_a_palette_name(self):
+        self.forge.call("build.box", name="b")
+        result = self.forge.call("paint.fill", name="b", color="leaf_green")
+        self.assertGreater(result["loops_painted"], 0)
+
+    def test_fill_on_a_missing_object_is_a_clean_error(self):
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("paint.fill", name="does_not_exist", color="#ffffff")
+        self.assertIn("does_not_exist", str(ctx.exception))
+
+
+class Height(ForgeCase):
+    def test_height_gradient_varies_from_bottom_to_top(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 2], origin="center")
+        self.forge.call("paint.height", name="b", low="#000000", high="#ffffff", axis="z")
+        exported = self.forge.call("export.gltf", out="gradient.glb")
+        _gltf, colors = read_colors(Path(exported["path"]))
+        luma = [0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2] for c in colors]
+        self.assertGreater(
+            max(luma) - min(luma), 0.5,
+            f"a black-to-white gradient over 2 m must span most of the range: {min(luma):.3f}..{max(luma):.3f}",
+        )
+
+    def test_height_reports_the_auto_range(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 2], origin="bottom")
+        result = self.forge.call("paint.height", name="b", low="#000000", high="#ffffff")
+        self.assertEqual(result["range"], [0.0, 2.0])
+
+    def test_height_on_a_flat_axis_is_a_clear_error(self):
+        self.forge.call("build.plane", name="flat", size=[2, 2])
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("paint.height", name="flat", low="#000000", high="#ffffff", axis="z")
+        self.assertIn("flat", str(ctx.exception))
+
+
+class Noise(ForgeCase):
+    def test_noise_is_deterministic_for_a_seed(self):
+        def bake(out):
+            self.forge.call("build.plane", name="p", size=[4, 4], cuts=8)
+            self.forge.call("paint.noise", name="p", color_a="#000000", color_b="#ffffff",
+                            scale=2.0, seed=7)
+            exported = self.forge.call("export.gltf", out=out)
+            _gltf, colors = read_colors(Path(exported["path"]))
+            return colors
+
+        first = bake("noise_a.glb")
+        self.forge.call("session.reset")
+        second = bake("noise_b.glb")
+        self.assertEqual(first, second, "same seed + same params must give identical colours")
+
+    def test_different_seeds_give_different_patterns(self):
+        self.forge.call("build.plane", name="p", size=[4, 4], cuts=8)
+        self.forge.call("paint.noise", name="p", color_a="#000000", color_b="#ffffff", seed=1)
+        first = read_colors(Path(self.forge.call("export.gltf", out="n1.glb")["path"]))[1]
+        self.forge.call("session.reset")
+        self.forge.call("build.plane", name="p", size=[4, 4], cuts=8)
+        self.forge.call("paint.noise", name="p", color_a="#000000", color_b="#ffffff", seed=2)
+        second = read_colors(Path(self.forge.call("export.gltf", out="n2.glb")["path"]))[1]
+        self.assertNotEqual(first, second)
+
+    def test_noise_actually_varies_across_the_mesh(self):
+        self.forge.call("build.plane", name="p", size=[4, 4], cuts=8)
+        self.forge.call("paint.noise", name="p", color_a="#000000", color_b="#ffffff",
+                        scale=2.0, seed=7)
+        exported = self.forge.call("export.gltf", out="noise_var.glb")
+        _gltf, colors = read_colors(Path(exported["path"]))
+        luma = {round(c[0], 2) for c in colors}
+        self.assertGreater(len(luma), 4, "noise should paint more than a handful of values")
+
+
+class Cavity(ForgeCase):
+    def test_cavity_paints_a_recess_but_not_the_flat_surround(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        # Sink a panel into the top: the recess walls are concave, the rest flat.
+        self.forge.call("build.extrude", name="b", direction="up", distance=-0.2, inset=0.2)
+        result = self.forge.call("paint.cavity", name="b", color="#000000", mode="cavity")
+        self.assertGreater(result["loops_painted"], 0)
+        exported = self.forge.call("export.gltf", out="cavity.glb")
+        _gltf, colors = read_colors(Path(exported["path"]))
+        dark = sum(1 for c in colors if c[0] < 0.9)
+        fraction = dark / len(colors)
+        self.assertGreater(fraction, 0.01, "the recess should take the dirt colour")
+        self.assertLess(fraction, 0.9, "flat faces around the recess must stay unpainted")
+
+    def test_edge_mode_paints_convex_ridges_instead(self):
+        self.forge.call("build.box", name="b", size=[1, 1, 1])
+        cavity = self.forge.call("paint.cavity", name="b", color="#000000", mode="cavity")
+        edge = self.forge.call("paint.cavity", name="b", color="#ffffff", mode="edge",
+                               layer="wear")
+        # A bevelled box has both concave-free flats and convex chamfer edges;
+        # the two modes must not agree on zero.
+        self.assertGreaterEqual(cavity["loops_painted"], 0)
+        self.assertGreater(edge["loops_painted"], 0)
+
+    def test_cavity_on_a_flat_plane_is_advice_not_silence(self):
+        self.forge.call("build.plane", name="flat", size=[2, 2])
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("paint.cavity", name="flat", color="#000000")
+        self.assertIn("curvature", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bforge/tests/test_quality_gate.py
+++ b/tools/bforge/tests/test_quality_gate.py
@@ -1,0 +1,150 @@
+"""Live tests for the quality gate: check.materials, gameready.review, and the
+export.asset gate. Regression coverage for the '8 materials, all the same
+brown' failure — an asset whose materials are perceptually identical must not
+ship without an explicit override.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_gate_test_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+
+def _three_mud_materials(forge: Forge, name="blob"):
+    """One mesh with three perceptually-identical brown materials: the warden."""
+    forge.call("build.box", name=name, size=[1.0, 1.0, 1.0])
+    for slot, (brown, mat_name) in enumerate(
+        (("#4a3828", "m_mud_a"), ("#4b3929", "m_mud_b"), ("#493827", "m_mud_c"))
+    ):
+        forge.call(
+            "material.set", object=name, preset="metal", name=mat_name, slot=slot,
+            color=brown, roughness=0.7, metallic=0.0,
+        )
+    return name
+
+
+class Materials(ForgeCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    def test_mud_blob_is_caught(self):
+        name = _three_mud_materials(FORGE)
+        result = FORGE.call("check.materials", objects=[name])
+        self.assertFalse(result["separated"])
+        self.assertLess(result["max_delta_e"], 12.0)
+        issues = [f["issue"] for f in result["findings"]]
+        self.assertIn("perceptually identical materials", issues)
+        errors = [f for f in result["findings"] if f["severity"] == "error"]
+        self.assertTrue(errors, "mud blob must be an error-level finding")
+        self.assertIn("paint.cavity", errors[0]["fix"])
+
+    def test_separated_materials_pass(self):
+        FORGE.call("build.box", name="good", size=[1.0, 1.0, 1.0])
+        FORGE.call("material.set", object="good", preset="metal", name="m_red_cloth", slot=0,
+                   color="#8c1f1f", roughness=0.85, metallic=0.0)
+        FORGE.call("material.set", object="good", preset="metal", name="m_brass", slot=1,
+                   color="#c8b06a", roughness=0.3, metallic=1.0)
+        FORGE.call("material.set", object="good", preset="metal", name="m_slate", slot=2,
+                   color="#2a4a6a", roughness=0.6, metallic=0.0)
+        result = FORGE.call("check.materials", objects=["good"])
+        self.assertTrue(result["separated"], f"unexpected findings: {result['findings']}")
+        self.assertGreater(result["max_delta_e"], 12.0)
+
+    def test_single_and_dual_material_assets_are_not_punished(self):
+        FORGE.call("prop.barrel", name="barrel", height=1.1, bands=3, seed=7)
+        result = FORGE.call("check.materials", objects=["barrel"])
+        errors = [f for f in result["findings"] if f["severity"] == "error"]
+        self.assertEqual(errors, [], "two distinct materials must not trip the blob detector")
+
+
+class Review(ForgeCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    def test_review_fails_the_mud_blob(self):
+        name = _three_mud_materials(FORGE)
+        result = FORGE.call("gameready.review", objects=[name])
+        self.assertFalse(result["passed"])
+        self.assertGreater(result["blocking"], 0)
+
+    def test_review_passes_a_clean_prop(self):
+        FORGE.call("prop.barrel", name="barrel", height=1.1, bands=3, seed=7)
+        result = FORGE.call("gameready.review", objects=["barrel"])
+        self.assertTrue(result["passed"], f"findings: {result['findings']}")
+
+    def test_realistic_style_fails_all_flat_materials(self):
+        FORGE.call("prop.barrel", name="barrel", height=1.1, bands=3, seed=7)
+        result = FORGE.call("gameready.review", objects=["barrel"], style="realistic")
+        self.assertFalse(result["passed"])
+        issues = [f["issue"] for f in result["findings"]]
+        self.assertIn("flat colours only under a realistic brief", issues)
+
+
+class ExportGate(ForgeCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    def test_gate_blocks_the_mud_blob(self):
+        name = _three_mud_materials(FORGE)
+        FORGE.call("uv.unwrap", object=name, style="smart_packed")
+        with self.assertRaises(ForgeError) as ctx:
+            FORGE.call("export.asset", asset_id="mud_blob", objects=[name],
+                       contact_sheet=False)
+        self.assertIn("gameready.review", str(ctx.exception))
+        self.assertIn("gate=false", str(ctx.exception))
+
+    def test_gate_false_exports_anyway(self):
+        name = _three_mud_materials(FORGE)
+        FORGE.call("uv.unwrap", object=name, style="smart_packed")
+        result = FORGE.call("export.asset", asset_id="mud_blob_forced", objects=[name],
+                            contact_sheet=False, gate=False)
+        self.assertEqual(result["asset_id"], "mud_blob_forced")
+
+    def test_gate_passes_a_clean_prop(self):
+        FORGE.call("prop.barrel", name="barrel", height=1.1, bands=3, seed=7)
+        result = FORGE.call("export.asset", asset_id="barrel_gated", objects=["barrel"],
+                            contact_sheet=False)
+        self.assertEqual(result["asset_id"], "barrel_gated")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bforge/tests/test_style.py
+++ b/tools/bforge/tests/test_style.py
@@ -1,0 +1,115 @@
+"""Live tests for check.style / check.conformance — the art-director layer.
+
+A set of same-style assets must score coherent; a palette- or texel-drifting
+asset must be caught with the right axis named.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_style_test_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+
+def _styled_box(name, color="#777777", uv_scale=1.0):
+    FORGE.call("build.box", name=name, size=[1.0, 1.0, 1.0],
+               material="metal", color=color, uv="box", uv_scale=uv_scale)
+    return name
+
+
+class Style(ForgeCase):
+    def test_fingerprint_reports_the_style_axes(self):
+        _styled_box("crate_a")
+        result = FORGE.call("check.style")
+        fp = result["objects"][0]
+        for key in ("palette", "texel_density", "hard_edge_ratio", "materials",
+                    "tris_per_m3", "uv_coverage"):
+            self.assertIn(key, fp)
+        self.assertEqual(fp["materials"], 1)
+        self.assertGreater(fp["texel_density"], 0)
+        self.assertTrue(fp["palette"][0]["hex"].startswith("#"))
+        self.assertIn("median_texel_density", result["set"])
+
+
+class Conformance(ForgeCase):
+    def test_same_style_set_is_coherent(self):
+        _styled_box("a")
+        _styled_box("b")
+        result = FORGE.call("check.conformance")
+        self.assertEqual(result["outliers"], [])
+        for row in result["objects"]:
+            self.assertEqual(row["verdict"], "coherent",
+                             f"{row['object']} should be coherent: {row}")
+
+    def test_palette_and_texel_drift_are_caught_and_named(self):
+        _styled_box("a")
+        _styled_box("b")
+        _styled_box("drifter", color="#b020e0", uv_scale=20.0)
+        result = FORGE.call("check.conformance")
+        worst = result["objects"][0]  # sorted by score ascending
+        self.assertEqual(worst["object"], "drifter")
+        self.assertIn(worst["verdict"], ("drifting", "outlier"))
+        self.assertIn(worst["worst_axis"], ("palette", "texel_density"))
+        self.assertTrue(worst["fix"], "a finding must name the fixing op")
+        good = {r["object"]: r for r in result["objects"][1:]}
+        self.assertEqual(good["a"]["verdict"], "coherent")
+        self.assertEqual(good["b"]["verdict"], "coherent")
+
+    def test_reference_mode(self):
+        _styled_box("hero")
+        _styled_box("same_as_hero")
+        _styled_box("off", color="#1010c0")
+        result = FORGE.call("check.conformance", reference="hero")
+        rows = {r["object"]: r for r in result["objects"]}
+        self.assertEqual(rows["same_as_hero"]["verdict"], "coherent")
+        self.assertLess(rows["off"]["score"], rows["same_as_hero"]["score"])
+
+    def test_real_pack_conforms(self):
+        """The props a real recipe produces must not trip the gate."""
+        FORGE.call("prop.crate", name="crate", seed=3)
+        FORGE.call("prop.barrel", name="barrel", height=1.1, bands=3, seed=7)
+        result = FORGE.call("check.conformance")
+        self.assertEqual(result["outliers"], [],
+                         f"stock props should look like one game: {result['objects']}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The loop that produced the 'brown blob' characters (8 materials of identical brown, a shield hiding the whole body, unused UVs) made every quality step optional — so agents skipped all of them. This PR makes low quality hard to ship, and closes the character/creature capability gap that caused it.

## What

**The enforced quality loop**
- `check.materials` — perceptual material separation (CIELAB ΔE76): the mud-blob detector, error-level
- `gameready.review` — pass/fail quality gate; `export.asset` runs it by default (`gate=false` overrides deliberately, for blockouts)
- `check.style` / `check.conformance` — set-level art direction: palette/texel/edge/density fingerprints, naming the failing axis and the fixing op

**Characters and creatures**
- `char.outfit` — fitted armour (cuirass, pteruges, greaves, bracers, helmet, shield) derived from the body's own proportions, bone-parented, materials distinct *by construction*; the shield mounts on the forearm, never the torso
- `char.face` / `char.hands` — readable features and fingers
- `char.creature` + `char.creature_rig` — quadruped plans (canine/equine/feline/generic) and the hexapod scarab class; walk/trot/gallop/graze + tripod gait tables in `char.animate`, with family-aware errors

**Surface and LOD**
- `paint.*` — vertex-colour wear (fill/height/cavity/noise) → glTF COLOR_0 (export now ships the active attribute)
- `morph.*` — shape keys with keyframable weights → glTF morph targets/animations
- `render.impostor` — billboard sprite sheets + world-normal sheets + JSON sidecar (distant LOD)

**Fixes**
- Blender 4.5 compatibility: EEVEE Next enum selection (the daemon could not boot)
- Determinism: `spin` seam-merge was permuting index buffers run-to-run; faces are now canonicalised (`_canonicalize_faces`)

## Verification

- **171 tests green** (was 162): 25 paint/morph, 9 quality gate, 8 outfit, 11 creature, 5 style, 4 impostor + all pre-existing
- `catalog.json` + `docs/bforge/OPS.md` regenerated (109 → 127 ops), README + skill synced
- Proof case: warden v1 (mud blob) → v2 (bronze/leather separated at ΔE 27.6, forearm shield, gate green), contact-sheet reviewed
- Byte-determinism asserted for paint, morph, outfit, quadruped and hexapod exports