### PR TITLE
bforge: image->mesh pipeline, env.camp, robe/hood (post-#52 remainder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ SHA-256-locked patch series, plus the MCP server, agent workflows, and asset
 pipeline that make the whole thing drivable by AI assistants. WebGL 2 remains the
 supported fallback.
 
+> **Lineage.** The WebGPU backend builds on David Walter's MIT-licensed
+> [`dwalter/godotwebgpu`](https://github.com/dwalter/godotwebgpu) driver (Godot
+> 4.6.2); Studio Foundation maintains the 4.7.1 rebase, 29 targeted integration
+> patches, the build tooling, and the browser validation evidence. Exact source
+> boundary and commit pins:
+> [webgpu-integration.md](docs/architecture/webgpu-integration.md), [NOTICE.md](NOTICE.md).
+
 ### ▶ [Play it live — a Godot game running on WebGPU, in your browser](https://lxsolutions.github.io/studio-foundation/)
 
 No install, no plugin. Needs a WebGPU-capable browser (Chrome/Edge 113+, Safari 26+,

--- a/README.md
+++ b/README.md
@@ -82,6 +82,54 @@ first-class throughout the repo, not just in the engine:
 Official Godot stays the upstream. We own the distribution, not the engine
 ([ADR 0008](docs/adr/0008-own-the-distribution-not-the-engine.md)).
 
+## bforge: the asset forge — deterministic, headless, quality-gated
+
+Most Blender-AI integrations are remote controls for a GUI Blender: arbitrary
+code into a live session, a different mesh every run, nothing CI can test.
+**bforge inverts that** — a persistent headless Blender daemon driven through
+127 whitelisted, typed, deterministic operations. Same params + same seed →
+byte-identical GLB, forever. It is how this toolkit's games get their art, and
+it works identically on a laptop, in CI, and on a headless build box.
+
+[![A tavern scene composed headlessly by bforge](docs/bforge/img/tavern.png)](tools/bforge/README.md)
+
+**The receipts, all reproducible:**
+
+- **It fixes real games' assets.** The Chariot Club's shipped track was a flat
+  oval slab: 25,796 tris, 26 materials, no UVs. One bforge audit-and-rebuild
+  pass: 14,084 tris, 11 draw calls, UVs everywhere, real architecture — driven
+  from the game's own track spec so mesh and race maths cannot drift
+  ([the build](games/chariot/art_source/build_hippodrome.py)).
+- **Quality is measured, not claimed.** `check.materials` computes perceptual
+  colour distance (CIELAB ΔE) across an asset's materials — the "8 materials,
+  all the same brown" failure an earlier agent shipped is now an error-level
+  gate finding, and `export.asset` refuses to export below the bar without an
+  explicit override. `check.style`/`check.conformance` score set-level art
+  direction and name the axis that breaks it.
+- **Characters and creatures, actually rigged and animated.** Humanoids at
+  figure-drawing proportions with fitted armour (`char.outfit`), faces, hands;
+  quadrupeds and hexapods with real footfall gaits — lateral-sequence walk,
+  diagonal trot, rotary gallop, tripod scuttle. Exported glTF skins and clips
+  are verified by parsing the file, not by trusting the log.
+- **The agent can see and prove what it made.** Six-panel contact sheets
+  (hero/front/side/top/wireframe/UV-checker), luminance and palette
+  measurement, silhouette scoring, impostor sprite sheets for distant LOD,
+  and concept-image → extruded-mesh with a silhouette-IoU fidelity score.
+- **171 tests, all live against real Blender.** Schema, MCP protocol, and
+  per-op integration — including byte-determinism asserted on exports.
+
+Full reference: [`tools/bforge/README.md`](tools/bforge/README.md) ·
+[`docs/bforge/OPS.md`](docs/bforge/OPS.md) · engine-neutral output (glTF) —
+the same assets ship into Godot, Babylon.js and three.js.
+
+> **What we do not claim.** Nobody's agents produce Call-of-Duty-photoreal
+> humans today — the most public attempt self-scored 5.05/10 with mannequin
+> characters, and its own postmortem converged on the same lessons this repo
+> codified earlier (instruments over eyes; measurement over critics). bforge's
+> target is stylized-good, budget-verified, regenerable art that a small team
+> can actually ship — and a pipeline honest enough to say when it isn't there
+> yet.
+
 ## Quick start
 
 Prerequisites are reported by `just doctor`. The fast repository checks require

--- a/docs/bforge/OPS.md
+++ b/docs/bforge/OPS.md
@@ -1,6 +1,6 @@
 # bforge op reference
 
-127 operations.
+130 operations.
 
 ## `arch.*`
 
@@ -450,7 +450,7 @@ Fit an armour or clothing piece to a char.humanoid body: cuirass, pteruges skirt
 | parameter | type | default | description |
 | --- | --- | --- | --- |
 | `name` | string | None | Body mesh (from char.humanoid) |
-| `piece` | cuirass \| pteruges \| greaves \| bracers \| helmet \| shield | 'cuirass' | What to fit. greaves and bracers come in pairs |
+| `piece` | cuirass \| pteruges \| greaves \| bracers \| helmet \| shield \| robe \| hood | 'cuirass' | What to fit. greaves and bracers come in pairs; robe is a full-length caster/priest garment, hood its matching cowl |
 | `height` | number | 0.0 | Character height; 0 measures the mesh bounds |
 | `build` | realistic \| heroic \| stylized \| chibi \| lithe | 'heroic' | Proportions the fit assumes — match the char.humanoid build |
 | `material` | bronze \| iron \| leather \| cloth | '' | Material family (defaults per piece: bronze for cuirass/greaves/helmet/shield, leather for pteruges/bracers). The families are deliberately far apart in colour and response — keep them that way |
@@ -602,6 +602,24 @@ Complete combat arena in one call: floor, tiered walls, entrance arches and corn
 | `color` | string | '' | Override colour |
 | `uv_scale` | number | 3.0 | Metres per UV tile |
 | `seed` | integer | 0 | Random seed |
+
+### `env.camp`
+
+A complete Age-1 settlement in one call: central fire (stones, log teepee, live embers), A-frame shelters ringing it, a stockade perimeter with a gate opening, a well, and storage racks on a deterministic seeded layout. The homeland diorama, not a bag of props — the layout relationships (fire at the heart, shelters facing it, one way in) are what makes it read as a camp instead of a yard sale.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | 'camp' | Object-name prefix for the camp's structures |
+| `radius` | number | 8.0 | Palisade ring radius in metres; shelters sit at ~55% of it |
+| `shelters` | integer | 5 | A-frame shelters around the fire |
+| `palisade` | boolean | True | Build the sharpened-log perimeter |
+| `gate_angle` | number | 90.0 | Compass degrees the gate opening faces (0 = +X, 90 = +Y). The ONE way in — put it toward where threats should come from |
+| `well` | boolean | True | Stone well with windlass frame |
+| `racks` | integer | 1 | Storage racks with sacks (0-3) |
+| `ground` | boolean | True | Flatten a dirt disc under the camp — helps dioramas; skip when the game supplies terrain |
+| `wood_color` | any | '' | Override the timber family colour |
+| `cloth_color` | any | '' | Override the hide/cloth family colour |
+| `seed` | integer | 0 | Layout seed — same seed, same camp, forever |
 
 ### `env.cliff`
 
@@ -855,6 +873,34 @@ Measure what the textures actually cost in GPU memory and flag any over the plat
 | --- | --- | --- | --- |
 | `profile` | mobile_low \| mobile_high \| browser_webgl \| browser_webgpu \| desktop_high | 'browser_webgpu' | Target platform profile |
 | `assume_compressed` | boolean | False | Report cost after KTX2/Basis transcoding (~8:1) instead of raw RGBA. Only set this once the cook step actually compresses, or the number is fiction |
+
+## `image.*`
+
+### `image.analyze`
+
+Measure a concept image instead of eyeballing it: silhouette coverage and proportions, left-right symmetry, dominant and regional palette, and an honest recommendation — extrude it (image.to_mesh) or use it as parametric guidance for a recipe. The first step of concept art -> production asset.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `path` | string | None | Image file (PNG with alpha, or any subject on a fairly uniform background) |
+| `threshold` | number | 0.06 | Background distance cutoff when there is no alpha channel; raise if the backdrop bleeds into the subject |
+| `colors` | integer | 5 | Dominant palette colours to report |
+
+### `image.to_mesh`
+
+Turn a concept image into a real 3D solid: extract the subject silhouette, extrude it with a bevelled rim, and map the source image onto the front face as a texture (or bake it to vertex colours). Returns the silhouette IoU against the source — 'how close is the model to the picture' as a number, not a vibe. Emblems, totems, props, side-view creatures, relief work.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `path` | string | None | Concept image (alpha or uniform background) |
+| `name` | string | 'concept' | Object name |
+| `target_height` | number | 1.0 | Silhouette height in metres; width follows the image aspect |
+| `depth` | number | 0.25 | Extrusion depth in metres along the view axis |
+| `bevel` | number | 0.02 | Rim chamfer — catches light so the edge reads; 0 disables |
+| `texture` | project \| vertex \| none | 'project' | project: map the source image on the front face; vertex: bake nearest pixel colours to COLOR_0; none: flat palette material |
+| `simplify` | number | 1.5 | Contour simplification tolerance in working pixels — higher is fewer vertices and smoother shapes |
+| `threshold` | number | 0.06 | Background distance cutoff (no alpha) |
+| `seed` | integer | 0 | Random seed (reserved; the mesh is a pure function of the image) |
 
 ## `kit.*`
 

--- a/tools/bforge/catalog.json
+++ b/tools/bforge/catalog.json
@@ -2026,9 +2026,11 @@
               "greaves",
               "bracers",
               "helmet",
-              "shield"
+              "shield",
+              "robe",
+              "hood"
             ],
-            "description": "What to fit. greaves and bracers come in pairs",
+            "description": "What to fit. greaves and bracers come in pairs; robe is a full-length caster/priest garment, hood its matching cowl",
             "default": "cuirass"
           },
           "height": {
@@ -2633,6 +2635,101 @@
           "seed": {
             "type": "integer",
             "description": "Random seed",
+            "default": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "env.camp",
+      "summary": "A complete Age-1 settlement in one call: central fire (stones, log teepee, live embers), A-frame shelters ringing it, a stockade perimeter with a gate opening, a well, and storage racks on a deterministic seeded layout. The homeland diorama, not a bag of props \u2014 the layout relationships (fire at the heart, shelters facing it, one way in) are what makes it read as a camp instead of a yard sale.",
+      "tags": [
+        "env",
+        "architecture"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Object-name prefix for the camp's structures",
+            "default": "camp"
+          },
+          "radius": {
+            "type": "number",
+            "description": "Palisade ring radius in metres; shelters sit at ~55% of it",
+            "default": 8.0
+          },
+          "shelters": {
+            "type": "integer",
+            "description": "A-frame shelters around the fire",
+            "default": 5
+          },
+          "palisade": {
+            "type": "boolean",
+            "description": "Build the sharpened-log perimeter",
+            "default": true
+          },
+          "gate_angle": {
+            "type": "number",
+            "description": "Compass degrees the gate opening faces (0 = +X, 90 = +Y). The ONE way in \u2014 put it toward where threats should come from",
+            "default": 90.0
+          },
+          "well": {
+            "type": "boolean",
+            "description": "Stone well with windlass frame",
+            "default": true
+          },
+          "racks": {
+            "type": "integer",
+            "description": "Storage racks with sacks (0-3)",
+            "default": 1
+          },
+          "ground": {
+            "type": "boolean",
+            "description": "Flatten a dirt disc under the camp \u2014 helps dioramas; skip when the game supplies terrain",
+            "default": true
+          },
+          "wood_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Override the timber family colour",
+            "default": ""
+          },
+          "cloth_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Override the hide/cloth family colour",
+            "default": ""
+          },
+          "seed": {
+            "type": "integer",
+            "description": "Layout seed \u2014 same seed, same camp, forever",
             "default": 0
           }
         },
@@ -3709,6 +3806,101 @@
             "type": "boolean",
             "description": "Report cost after KTX2/Basis transcoding (~8:1) instead of raw RGBA. Only set this once the cook step actually compresses, or the number is fiction",
             "default": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "image.analyze",
+      "summary": "Measure a concept image instead of eyeballing it: silhouette coverage and proportions, left-right symmetry, dominant and regional palette, and an honest recommendation \u2014 extrude it (image.to_mesh) or use it as parametric guidance for a recipe. The first step of concept art -> production asset.",
+      "tags": [
+        "inspect",
+        "image"
+      ],
+      "mutates": false,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Image file (PNG with alpha, or any subject on a fairly uniform background)"
+          },
+          "threshold": {
+            "type": "number",
+            "description": "Background distance cutoff when there is no alpha channel; raise if the backdrop bleeds into the subject",
+            "default": 0.06
+          },
+          "colors": {
+            "type": "integer",
+            "description": "Dominant palette colours to report",
+            "default": 5
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "image.to_mesh",
+      "summary": "Turn a concept image into a real 3D solid: extract the subject silhouette, extrude it with a bevelled rim, and map the source image onto the front face as a texture (or bake it to vertex colours). Returns the silhouette IoU against the source \u2014 'how close is the model to the picture' as a number, not a vibe. Emblems, totems, props, side-view creatures, relief work.",
+      "tags": [
+        "build",
+        "image"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Concept image (alpha or uniform background)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Object name",
+            "default": "concept"
+          },
+          "target_height": {
+            "type": "number",
+            "description": "Silhouette height in metres; width follows the image aspect",
+            "default": 1.0
+          },
+          "depth": {
+            "type": "number",
+            "description": "Extrusion depth in metres along the view axis",
+            "default": 0.25
+          },
+          "bevel": {
+            "type": "number",
+            "description": "Rim chamfer \u2014 catches light so the edge reads; 0 disables",
+            "default": 0.02
+          },
+          "texture": {
+            "type": "string",
+            "enum": [
+              "project",
+              "vertex",
+              "none"
+            ],
+            "description": "project: map the source image on the front face; vertex: bake nearest pixel colours to COLOR_0; none: flat palette material",
+            "default": "project"
+          },
+          "simplify": {
+            "type": "number",
+            "description": "Contour simplification tolerance in working pixels \u2014 higher is fewer vertices and smoother shapes",
+            "default": 1.5
+          },
+          "threshold": {
+            "type": "number",
+            "description": "Background distance cutoff (no alpha)",
+            "default": 0.06
+          },
+          "seed": {
+            "type": "integer",
+            "description": "Random seed (reserved; the mesh is a pure function of the image)",
+            "default": 0
           }
         },
         "additionalProperties": false

--- a/tools/bforge/runtime/ops/__init__.py
+++ b/tools/bforge/runtime/ops/__init__.py
@@ -4,6 +4,7 @@ Layering, low to high:
 
     session   scene lifecycle, inspection, transforms
     build     parametric primitives and mesh editing
+    image     concept image -> production mesh (silhouette extrusion)
     material  PBR + procedural materials, baking
     uv        unwrapping and UV measurement
     paint     vertex colours, exported as glTF COLOR_0
@@ -20,6 +21,7 @@ Layering, low to high:
 
 from . import session  # noqa: F401  (import order = registration order)
 from . import build  # noqa: F401
+from . import image  # noqa: F401
 from . import arch  # noqa: F401
 from . import material  # noqa: F401
 from . import uv  # noqa: F401

--- a/tools/bforge/runtime/ops/char.py
+++ b/tools/bforge/runtime/ops/char.py
@@ -877,7 +877,7 @@ _PIECE_BONE = {
     "cuirass": "chest", "pteruges": "hips", "helmet": "head",
     "greave_l": "shin_l", "greave_r": "shin_r",
     "bracer_l": "forearm_l", "bracer_r": "forearm_r",
-    "shield": "forearm_l",
+    "shield": "forearm_l", "robe": "chest", "hood": "head",
 }
 
 
@@ -952,7 +952,7 @@ def _attach_or_parent(ctx, piece_obj, body, bone):
     summary="Fit an armour or clothing piece to a char.humanoid body: cuirass, pteruges skirt, greaves, bracers, helmet or round shield. Fit is derived from the body's own proportions, materials are perceptually distinct by construction (this is the anti 'brown blob' op), and pieces bone-parent to the rig when one exists so they animate with the character.",
     params={
         "name": ("str", None, "Body mesh (from char.humanoid)"),
-        "piece": ("enum:cuirass|pteruges|greaves|bracers|helmet|shield", "cuirass", "What to fit. greaves and bracers come in pairs"),
+        "piece": ("enum:cuirass|pteruges|greaves|bracers|helmet|shield|robe|hood", "cuirass", "What to fit. greaves and bracers come in pairs; robe is a full-length caster/priest garment, hood its matching cowl"),
         "height": ("num", 0.0, "Character height; 0 measures the mesh bounds"),
         "build": ("enum:realistic|heroic|stylized|chibi|lithe", "heroic", "Proportions the fit assumes — match the char.humanoid build"),
         "material": ("enum:bronze|iron|leather|cloth", "", "Material family (defaults per piece: bronze for cuirass/greaves/helmet/shield, leather for pteruges/bracers). The families are deliberately far apart in colour and response — keep them that way"),
@@ -969,7 +969,9 @@ def char_outfit(ctx, name, piece, height, build, material, color, crest, side, g
     shoulder_z = total_height - head_unit * 1.42
     hip_z = total_height * 0.50
 
-    default_material = "leather" if piece in ("pteruges", "bracers") else "bronze"
+    default_material = "leather" if piece in ("pteruges", "bracers") else (
+        "cloth" if piece in ("robe", "hood") else "bronze"
+    )
     family = material or default_material
     hex_color, metallic, roughness = OUTFIT_MATERIALS[family]
     mat = mat_lib.principled(
@@ -1108,6 +1110,51 @@ def char_outfit(ctx, name, piece, height, build, material, color, crest, side, g
         )
         _absorb(bm, boss)
         bone = f"forearm_{side}"
+
+    elif piece == "robe":
+        # Full-length garment: shoulders to ankles, flaring at the hem, with
+        # loose sleeves suggested by a wider torso band. Lathe shell like the
+        # cuirass but floor-length and cloth.
+        z_top = shoulder_z + head_unit * 0.02
+        z_hem = hip_z - (hip_z - 0.06 * total_height) * 0.94
+        outer = [
+            (torso_r * 1.12 + gap, z_top),
+            (torso_r * 1.20 + gap, hip_z),
+            (torso_r * 1.55 + gap, z_hem + (z_top - z_hem) * 0.35),
+            (torso_r * 1.85 + gap, z_hem),
+        ]
+        mesh_lib.lathe(bm, _shell_profile(outer), segments=16, cap=False)
+        bone = "chest"
+
+    elif piece == "hood":
+        head_center = Vector(joints["head"][0]).lerp(Vector(joints["head"][1]), 0.5)
+        hood_r = head_unit * 0.56 + gap
+        # Open-front cowl: lathe from brow over the crown to the shoulders,
+        # face left visible (the front quarter is cut away by the profile's
+        # open hem sitting forward).
+        mesh_lib.lathe(
+            bm,
+            _shell_profile([
+                (hood_r, 0.0),
+                (hood_r * 1.02, hood_r * 0.6),
+                (hood_r * 0.6, hood_r * 1.0),
+                (0.012, hood_r * 1.08),
+            ]),
+            segments=16, center=(0.0, head_r * 0.1, head_center.z + head_unit * 0.02),
+            cap=False,
+        )
+        # Shoulder drape.
+        piece_bm = mesh_lib.new_bmesh()
+        mesh_lib.lathe(
+            piece_bm,
+            _shell_profile([
+                (torso_r * 0.95 + gap, 0.0),
+                (torso_r * 1.05 + gap, head_unit * 0.16),
+            ]),
+            segments=14, center=(0.0, 0.0, shoulder_z - head_unit * 0.05), cap=False,
+        )
+        _absorb(bm, piece_bm)
+        bone = "head"
 
     mesh_lib.cleanup(bm, merge_dist=total_height * 0.001)
     bm = _canonicalize_faces(bm)

--- a/tools/bforge/runtime/ops/char.py
+++ b/tools/bforge/runtime/ops/char.py
@@ -1128,6 +1128,7 @@ def char_outfit(ctx, name, piece, height, build, material, color, crest, side, g
 
     elif piece == "hood":
         head_center = Vector(joints["head"][0]).lerp(Vector(joints["head"][1]), 0.5)
+        head_r = head_unit * 0.46
         hood_r = head_unit * 0.56 + gap
         # Open-front cowl: lathe from brow over the crown to the shoulders,
         # face left visible (the front quarter is cut away by the profile's

--- a/tools/bforge/runtime/ops/env.py
+++ b/tools/bforge/runtime/ops/env.py
@@ -735,6 +735,249 @@ def _absorb(target_bm, source_bm):
     bpy.data.meshes.remove(temp)
 
 
+def _absorb(target_bm, source_bm):
+    import bpy
+
+    temp = bpy.data.meshes.new("_absorb")
+    source_bm.to_mesh(temp)
+    source_bm.free()
+    target_bm.from_mesh(temp)
+    bpy.data.meshes.remove(temp)
+
+
+@op(
+    "env.camp",
+    summary="A complete Age-1 settlement in one call: central fire (stones, log teepee, live embers), A-frame shelters ringing it, a stockade perimeter with a gate opening, a well, and storage racks on a deterministic seeded layout. The homeland diorama, not a bag of props — the layout relationships (fire at the heart, shelters facing it, one way in) are what makes it read as a camp instead of a yard sale.",
+    params={
+        "name": ("str", "camp", "Object-name prefix for the camp's structures"),
+        "radius": ("num", 8.0, "Palisade ring radius in metres; shelters sit at ~55% of it"),
+        "shelters": ("int", 5, "A-frame shelters around the fire"),
+        "palisade": ("bool", True, "Build the sharpened-log perimeter"),
+        "gate_angle": ("num", 90.0, "Compass degrees the gate opening faces (0 = +X, 90 = +Y). The ONE way in — put it toward where threats should come from"),
+        "well": ("bool", True, "Stone well with windlass frame"),
+        "racks": ("int", 1, "Storage racks with sacks (0-3)"),
+        "ground": ("bool", True, "Flatten a dirt disc under the camp — helps dioramas; skip when the game supplies terrain"),
+        "wood_color": ("colorref", "", "Override the timber family colour"),
+        "cloth_color": ("colorref", "", "Override the hide/cloth family colour"),
+        "seed": ("int", 0, "Layout seed — same seed, same camp, forever"),
+    },
+    tags=["env", "architecture"],
+)
+def env_camp(ctx, name, radius, shelters, palisade, gate_angle, well, racks, ground,
+             wood_color, cloth_color, seed):
+    rng = ctx.reseed(seed)
+    made = []
+
+    def finish_part(bm, part, preset, color=None, rough=-1.0, smooth=True):
+        mesh_lib.cleanup(bm, merge_dist=1e-4)
+        obj = mesh_lib.to_object(bm, scene_lib.unique_name(f"{name}_{part}"))
+        mat = mat_lib.from_preset(preset, color=color or None,
+                                  roughness=rough if rough >= 0 else None)
+        result = finish_lib.finish(
+            ctx, obj, material=mat, uv="smart_packed", origin="bottom",
+            smooth=smooth, smooth_angle=45.0,
+        )
+        made.append({"object": obj.name, "part": part, "triangles": result["triangles"]})
+        return obj
+
+    def cyl(bm, radius, depth, center, tip=False, segments=10, axis="Z", yaw=0.0, pitch=0.0):
+        piece = mesh_lib.new_bmesh()
+        mesh_lib.add_cylinder(
+            piece, radius=radius, radius_top=0.0 if tip else -1.0, depth=depth,
+            segments=segments, center=(0.0, 0.0, 0.0),
+        )
+        matrix = (
+            Matrix.Translation(Vector(center))
+            @ Matrix.Rotation(math.radians(yaw), 4, "Z")
+            @ Matrix.Rotation(math.radians(pitch), 4, "Y")
+        )
+        bmesh.ops.transform(piece, matrix=matrix, verts=piece.verts[:])
+        _absorb(bm, piece)
+
+    wood = wood_color or "#6a4e2c"
+    cloth = cloth_color or "#7a5a38"
+
+    # --- the fire at the heart ------------------------------------------------
+    stones = mesh_lib.new_bmesh()
+    for i in range(8):
+        angle = math.tau * i / 8.0
+        rock = mesh_lib.new_bmesh()
+        mesh_lib.add_icosphere(rock, radius=0.13, subdivisions=1)
+        bmesh.ops.transform(
+            rock,
+            matrix=Matrix.Translation(
+                Vector((0.45 * math.cos(angle), 0.45 * math.sin(angle), 0.09))
+            ) @ Matrix.Diagonal(Vector((1.0, 0.9, 0.75))).to_4x4(),
+            verts=rock.verts[:],
+        )
+        _absorb(stones, rock)
+    finish_part(stones, "fire_stones", "stone")
+
+    logs = mesh_lib.new_bmesh()
+    for i in range(3):
+        cyl(logs, 0.045, 0.7, (0.0, 0.0, 0.28), segments=8, yaw=i * 120.0, pitch=62.0)
+    finish_part(logs, "fire_logs", "wood", wood)
+
+    coals_bm = mesh_lib.new_bmesh()
+    cyl(coals_bm, 0.26, 0.1, (0.0, 0.0, 0.05), segments=12)
+    coals = mesh_lib.to_object(coals_bm, scene_lib.unique_name(f"{name}_embers"))
+    embers = mat_lib.principled("m_camp_embers", color="#ff5a14", roughness=0.9,
+                                emission=4.5, emission_color="#ff6a1a")
+    finish_lib.finish(ctx, coals, material=embers, uv="smart_packed", origin="bottom",
+                      smooth=True, smooth_angle=45.0)
+    made.append({"object": coals.name, "part": "embers", "triangles": mesh_lib.tri_count(coals)})
+
+    # --- shelters ringing the fire, facing it ----------------------------------
+    for i in range(max(0, shelters)):
+        base_angle = math.tau * i / max(1, shelters) + rng.uniform(-0.14, 0.14)
+        dist = radius * (0.55 + rng.uniform(-0.05, 0.05))
+        cx, cy = dist * math.cos(base_angle), dist * math.sin(base_angle)
+        scale = rng.uniform(0.9, 1.1)
+        yaw_deg = math.degrees(base_angle) + 90.0  # open side toward the fire
+
+        frame = mesh_lib.new_bmesh()
+        ridge = mesh_lib.new_bmesh()
+        mesh_lib.add_cylinder(ridge, radius=0.035, depth=2.4 * scale, segments=8,
+                              center=(0.0, 0.0, 1.55 * scale))
+        bmesh.ops.transform(
+            ridge, matrix=Matrix.Translation(Vector((cx, cy, 0.0)))
+            @ Matrix.Rotation(math.radians(yaw_deg), 4, "Z")
+            @ Matrix.Rotation(math.radians(90.0), 4, "Y"),
+            verts=ridge.verts[:],
+        )
+        _absorb(frame, ridge)
+        for end in (-1, 1):
+            pole = mesh_lib.new_bmesh()
+            mesh_lib.add_cylinder(pole, radius=0.035, depth=1.6 * scale, segments=8,
+                                  center=(end * 1.1 * scale, 0.0, 0.8 * scale))
+            bmesh.ops.transform(
+                pole, matrix=Matrix.Translation(Vector((cx, cy, 0.0)))
+                @ Matrix.Rotation(math.radians(yaw_deg), 4, "Z"),
+                verts=pole.verts[:],
+            )
+            _absorb(frame, pole)
+        finish_part(frame, f"shelter_{i}_frame", "wood", wood)
+
+        hide = mesh_lib.new_bmesh()
+        for side, pitch in ((-1, 58.0), (1, -58.0)):
+            panel = mesh_lib.new_bmesh()
+            mesh_lib.add_box(panel, size=(2.3 * scale, 0.05, 1.9 * scale),
+                             center=(0.0, side * 0.72 * scale, 0.82 * scale), bevel=0.01)
+            bmesh.ops.transform(
+                panel,
+                matrix=Matrix.Translation(Vector((cx, cy, 0.0)))
+                @ Matrix.Rotation(math.radians(yaw_deg), 4, "Z")
+                @ Matrix.Rotation(math.radians(pitch), 4, "X"),
+                verts=panel.verts[:],
+            )
+            _absorb(hide, panel)
+        finish_part(hide, f"shelter_{i}_hide", "cloth", cloth, rough=0.9)
+
+    # --- stockade with exactly one way in ---------------------------------------
+    if palisade:
+        ring = mesh_lib.new_bmesh()
+        spacing = 0.23
+        gate_half = math.radians(11.0)  # ~3 m opening at radius 8
+        count = int(math.tau * radius / spacing)
+        for i in range(count):
+            angle = math.tau * i / count
+            gate_delta = (math.degrees(angle) - gate_angle + 540.0) % 360.0 - 180.0
+            if abs(gate_delta) < math.degrees(gate_half):
+                continue
+            depth = 2.4 if i % 2 == 0 else 2.55
+            px, py = radius * math.cos(angle), radius * math.sin(angle)
+            cyl(ring, 0.09, depth, (px, py, depth * 0.5), tip=True, segments=10)
+        for edge in (-1, 1):
+            angle = math.radians(gate_angle) + edge * gate_half
+            px, py = radius * math.cos(angle), radius * math.sin(angle)
+            cyl(ring, 0.13, 2.8, (px, py, 1.4), tip=True, segments=12)
+        finish_part(ring, "palisade", "wood", wood, smooth=False)
+
+    # --- the well ----------------------------------------------------------------
+    if well:
+        wangle = rng.uniform(0.0, math.tau)
+        wx, wy = radius * 0.3 * math.cos(wangle), radius * 0.3 * math.sin(wangle)
+        ring_bm = mesh_lib.new_bmesh()
+        for row in range(2):
+            for i in range(9):
+                angle = math.tau * i / 9.0 + row * 0.35
+                rock = mesh_lib.new_bmesh()
+                mesh_lib.add_icosphere(rock, radius=0.15, subdivisions=1)
+                bmesh.ops.transform(
+                    rock,
+                    matrix=Matrix.Translation(Vector((
+                        wx + 0.62 * math.cos(angle),
+                        wy + 0.62 * math.sin(angle),
+                        0.14 + row * 0.24,
+                    ))) @ Matrix.Diagonal(Vector((1.0, 0.9, 0.8))).to_4x4(),
+                    verts=rock.verts[:],
+                )
+                _absorb(ring_bm, rock)
+        finish_part(ring_bm, "well_stones", "stone")
+        wood_bm = mesh_lib.new_bmesh()
+        for side in (-1, 1):
+            cyl(wood_bm, 0.05, 1.3, (wx + side * 0.62, wy, 0.65), segments=8)
+        bar = mesh_lib.new_bmesh()
+        mesh_lib.add_cylinder(bar, radius=0.045, depth=1.34, segments=8,
+                              center=(0.0, 0.0, 0.0))
+        bmesh.ops.transform(
+            bar,
+            matrix=Matrix.Translation(Vector((wx, wy, 1.28)))
+            @ Matrix.Rotation(math.radians(90.0), 4, "Y"),
+            verts=bar.verts[:],
+        )
+        _absorb(wood_bm, bar)
+        finish_part(wood_bm, "well_frame", "wood", wood)
+
+    # --- storage racks -------------------------------------------------------------
+    for r in range(max(0, min(3, racks))):
+        rangle = gate_angle + 140.0 + r * 80.0 + rng.uniform(-10.0, 10.0)
+        rr = radius * 0.4
+        rx, ry = rr * math.cos(math.radians(rangle)), rr * math.sin(math.radians(rangle))
+        frame = mesh_lib.new_bmesh()
+        for side in (-1, 1):
+            for depth in (1.1,):
+                cyl(frame, 0.04, depth, (rx + side * 0.6, ry, depth * 0.5), segments=8)
+        shelf = mesh_lib.new_bmesh()
+        mesh_lib.add_box(shelf, size=(1.4, 0.5, 0.06), center=(rx, ry, 0.72), bevel=0.01)
+        _absorb(frame, shelf)
+        finish_part(frame, f"rack_{r}_frame", "wood", wood)
+        sacks = mesh_lib.new_bmesh()
+        for s in range(2):
+            sack = mesh_lib.new_bmesh()
+            mesh_lib.add_icosphere(sack, radius=0.22, subdivisions=2)
+            bmesh.ops.transform(
+                sack,
+                matrix=Matrix.Translation(
+                    Vector((rx - 0.3 + s * 0.6, ry, 0.95 if s == 0 else 0.2))
+                ) @ Matrix.Diagonal(Vector((1.0, 0.85, 1.15))).to_4x4(),
+                verts=sack.verts[:],
+            )
+            _absorb(sacks, sack)
+        finish_part(sacks, f"rack_{r}_sacks", "cloth", cloth, rough=0.9)
+
+    # --- ground --------------------------------------------------------------------)
+    if ground:
+        disc = mesh_lib.new_bmesh()
+        mesh_lib.add_cylinder(disc, radius=radius + 2.0, depth=0.2, segments=32,
+                              center=(0.0, 0.0, -0.1))
+        finish_part(disc, "ground", "sand", "#8a7350", rough=1.0, smooth=False)
+
+    total = sum(entry["triangles"] for entry in made)
+    ctx.note(
+        f"Camp layout: fire at the heart, {shelters} shelters facing it, gate at "
+        f"{gate_angle:.0f} degrees. Dress the surroundings with env.scatter "
+        "(trees/rocks) and put a watch at the gate — it is the only way in."
+    )
+    return {
+        "structures": made,
+        "object_count": len(made),
+        "triangles": total,
+        "gate_angle": gate_angle,
+        "radius": radius,
+    }
+
+
 def _get(name):
     try:
         return scene_lib.get_object(name)

--- a/tools/bforge/runtime/ops/image.py
+++ b/tools/bforge/runtime/ops/image.py
@@ -1,0 +1,443 @@
+"""Concept image -> production mesh.
+
+The 2D images AI generators make are art direction, not assets. This namespace
+is the bridge: `image.analyze` measures what the image actually shows
+(silhouette, proportions, palette, symmetry) and `image.to_mesh` turns that
+silhouette into a real, UV'd, textured 3D solid — then scores itself against
+the source image, because 'it looks like the picture' should be a number.
+
+What this is honest about: a single 2D image cannot invent depth or anatomy.
+Extrusion is genuinely excellent for emblems, totems, props, weapons, stylized
+creatures in side view, relief architecture and foliage. For anatomical
+characters the right path is the parametric one (char.humanoid et al) guided
+by image.analyze's palette and proportions — the report says so.
+"""
+
+from __future__ import annotations
+
+import math
+
+import bpy
+from lib import finish as finish_lib
+from lib import mat as mat_lib
+from lib import mesh as mesh_lib
+from lib import scene as scene_lib
+from registry import OpError, op
+
+WORK_RES = 160  # long side of the working mask
+
+
+def _load_subject(path, threshold):
+    """Load the image and segment subject from background.
+
+    Returns (mask, w, h, pixels_rgb) where mask is a set of (x, y) subject
+    cells at working resolution and pixels_rgb the FULL-res subject samples
+    for palette work.
+    """
+    try:
+        import numpy
+    except ImportError as exc:  # pragma: no cover - Blender bundles numpy
+        raise OpError("numpy unavailable in this Blender build") from exc
+
+    target = bpy.path.abspath(str(path))
+    try:
+        image = bpy.data.images.load(target, check_existing=True)
+    except RuntimeError as exc:
+        raise OpError(f"cannot load image at {target}: {exc}") from exc
+    width, height = image.size
+    data = numpy.array(image.pixels[:], dtype=numpy.float32).reshape((height, width, 4))
+    rgb = data[:, :, :3]
+    alpha = data[:, :, 3]
+
+    if float(alpha.min()) < 0.5:
+        subject = alpha > 0.5
+    else:
+        corner = min(8, width // 8, height // 8) or 1
+        corners = numpy.concatenate([
+            rgb[:corner, :corner].reshape(-1, 3), rgb[:corner, -corner:].reshape(-1, 3),
+            rgb[-corner:, :corner].reshape(-1, 3), rgb[-corner:, -corner:].reshape(-1, 3),
+        ])
+        backdrop = numpy.median(corners, axis=0)
+        subject = numpy.linalg.norm(rgb - backdrop, axis=2) > threshold
+
+    if not bool(subject.any()):
+        raise OpError(
+            "no subject found — the whole image reads as background. Pass a "
+            "larger threshold, or an image with a real alpha channel."
+        )
+
+    scale = max(1, int(math.ceil(max(width, height) / WORK_RES)))
+    cells = set()
+    for cy in range(0, height, scale):
+        for cx in range(0, width, scale):
+            block = subject[cy:cy + scale, cx:cx + scale]
+            if block.size and float(block.mean()) > 0.5:
+                cells.add((cx // scale, cy // scale))
+    return cells, width // scale, height // scale, rgb, subject
+
+
+def _boundary_loops(cells):
+    """Marching-squares boundary edges of the subject cells, chained into loops.
+
+    Each boundary edge runs between grid vertices (x, y) in cell space. Every
+    clean boundary vertex has exactly two boundary edges, so chaining is a walk.
+    """
+    edges = set()
+
+    def add(a, b):
+        edges.add((a, b) if a <= b else (b, a))
+
+    for (cx, cy) in cells:
+        if (cx, cy - 1) not in cells:
+            add((cx, cy), (cx + 1, cy))
+        if (cx, cy + 1) not in cells:
+            add((cx, cy + 1), (cx + 1, cy + 1))
+        if (cx - 1, cy) not in cells:
+            add((cx, cy), (cx, cy + 1))
+        if (cx + 1, cy) not in cells:
+            add((cx + 1, cy), (cx + 1, cy + 1))
+
+    adjacency = {}
+    for a, b in edges:
+        adjacency.setdefault(a, []).append(b)
+        adjacency.setdefault(b, []).append(a)
+
+    loops = []
+    pool = dict(adjacency)
+    while pool:
+        start = next(iter(pool))
+        # A node whose edges were all consumed from the other side must not be
+        # re-picked forever — empty lists are deleted wherever they appear.
+        if not pool[start]:
+            del pool[start]
+            continue
+        loop = [start]
+        prev, current = None, start
+        while True:
+            neighbours = [n for n in pool.get(current, []) if n != prev]
+            if not neighbours:
+                break
+            nxt = neighbours[0]
+            pool[current].remove(nxt)
+            pool[nxt].remove(current)
+            if not pool[current]:
+                del pool[current]
+            if nxt in pool and not pool[nxt]:
+                del pool[nxt]
+            prev, current = current, nxt
+            if current == start:
+                break
+            loop.append(current)
+        if len(loop) >= 3:
+            loops.append(loop)
+    return loops
+
+
+def _simplify(points, epsilon):
+    """Douglas-Peucker for a CLOSED loop, order-preserving.
+
+    Running DP on the doubled path keeps points from both copies and returns
+    an overlapping scramble. Instead: split the loop at its diameter pair
+    (the two farthest-apart points), simplify each open half, and rejoin.
+    """
+    if len(points) < 6:
+        return points
+    best, pair = -1.0, (0, 0)
+    for i in range(len(points)):
+        for j in range(i + 1, len(points)):
+            d = ((points[i][0] - points[j][0]) ** 2
+                 + (points[i][1] - points[j][1]) ** 2)
+            if d > best:
+                best, pair = d, (i, j)
+    i, j = pair
+    half_a = _dp(points[i:j + 1], epsilon)
+    half_b = _dp(points[j:] + points[:i + 1], epsilon)
+    merged = half_a[:-1] + half_b[:-1]
+    if len(merged) < 3:
+        return points
+    return merged
+
+
+def _dp(points, epsilon):
+    if len(points) < 3:
+        return points
+    start, end = points[0], points[-1]
+    axis_x, axis_y = end[0] - start[0], end[1] - start[1]
+    length_sq = axis_x * axis_x + axis_y * axis_y or 1e-9
+    worst, worst_index = -1.0, -1
+    for index in range(1, len(points) - 1):
+        px, py = points[index]
+        t = max(0.0, min(1.0, ((px - start[0]) * axis_x + (py - start[1]) * axis_y) / length_sq))
+        dx = px - (start[0] + t * axis_x)
+        dy = py - (start[1] + t * axis_y)
+        distance = dx * dx + dy * dy
+        if distance > worst:
+            worst, worst_index = distance, index
+    if worst <= epsilon * epsilon:
+        return [start, end]
+    left = _dp(points[:worst_index + 1], epsilon)
+    right = _dp(points[worst_index:], epsilon)
+    return left[:-1] + right
+
+
+def _palette(rgb, subject, count=5):
+    """Dominant subject colours by coarse quantisation (deterministic)."""
+    import numpy
+
+    samples = rgb[subject]
+    if len(samples) == 0:
+        return []
+    quantised = numpy.clip((samples * 8).astype(numpy.int32), 0, 7)
+    keys = quantised[:, 0] * 64 + quantised[:, 1] * 8 + quantised[:, 2]
+    unique, counts = numpy.unique(keys, return_counts=True)
+    order = numpy.argsort(-counts)[:count]
+    out = []
+    for index in order:
+        members = samples[keys == int(unique[index])]
+        mean = members.mean(axis=0)
+        # Loaded PNG pixels come back sRGB-encoded (verified by measurement):
+        # hex is the direct display value; linear is the physical albedo.
+        out.append({
+            "linear": [round(_srgb_to_linear(float(c)), 4) for c in mean],
+            "hex": "#" + "".join(
+                f"{max(0, min(255, round(float(c) * 255))):02x}" for c in mean
+            ),
+            "share": round(float(counts[index]) / len(samples), 3),
+        })
+    return out
+
+
+def _linear_to_srgb(value):
+    if value <= 0.0031308:
+        return value * 12.92
+    return 1.055 * (max(value, 0.0) ** (1 / 2.4)) - 0.055
+
+
+def _srgb_to_linear(value):
+    if value <= 0.04045:
+        return value / 12.92
+    return ((value + 0.055) / 1.055) ** 2.4
+
+
+def _mask_stats(cells, w, h):
+    xs = [c[0] for c in cells]
+    ys = [c[1] for c in cells]
+    min_x, max_x, min_y, max_y = min(xs), max(xs), min(ys), max(ys)
+    bw, bh = max_x - min_x + 1, max_y - min_y + 1
+    # Left-right mirror IoU across the bbox vertical centreline.
+    mirrored = {(min_x + max_x - (cx - min_x), cy) for (cx, cy) in cells}
+    mirrored = {(min_x + (max_x - cx), cy) for (cx, cy) in cells}
+    both = cells & mirrored
+    either = cells | mirrored
+    symmetry = len(both) / max(1, len(either))
+    return {
+        "bbox_cells": [min_x, min_y, max_x, max_y],
+        "bbox_size_cells": [bw, bh],
+        "aspect_h_over_w": round(bh / max(1, bw), 3),
+        "fill_ratio": round(len(cells) / max(1, bw * bh), 3),
+        "coverage": round(len(cells) / max(1, w * h), 4),
+        "symmetry": round(symmetry, 3),
+    }
+
+
+def _rasterize(loop, w, h):
+    """Scanline-fill a contour into a cell mask (for the IoU fidelity score)."""
+    filled = set()
+    for y in range(h + 1):
+        crossings = []
+        for i in range(len(loop)):
+            x1, y1 = loop[i]
+            x2, y2 = loop[(i + 1) % len(loop)]
+            if (y1 <= y < y2) or (y2 <= y < y1):
+                t = (y - y1) / (y2 - y1)
+                crossings.append(x1 + t * (x2 - x1))
+        crossings.sort()
+        for i in range(0, len(crossings) - 1, 2):
+            for x in range(max(0, int(math.ceil(crossings[i]))),
+                           min(w, int(crossings[i + 1]) + 1)):
+                filled.add((x, y))
+    return filled
+
+
+@op(
+    "image.analyze",
+    summary="Measure a concept image instead of eyeballing it: silhouette coverage and proportions, left-right symmetry, dominant and regional palette, and an honest recommendation — extrude it (image.to_mesh) or use it as parametric guidance for a recipe. The first step of concept art -> production asset.",
+    params={
+        "path": ("path", None, "Image file (PNG with alpha, or any subject on a fairly uniform background)"),
+        "threshold": ("num", 0.06, "Background distance cutoff when there is no alpha channel; raise if the backdrop bleeds into the subject"),
+        "colors": ("int", 5, "Dominant palette colours to report"),
+    },
+    tags=["inspect", "image"],
+    mutates=False,
+)
+def image_analyze(ctx, path, threshold, colors):
+    cells, w, h, rgb, subject = _load_subject(ctx.resolve(path), threshold)
+    stats = _mask_stats(cells, w, h)
+    palette = _palette(rgb, subject, colors)
+    loops = _boundary_loops(cells)
+    fill, aspect, symmetry = stats["fill_ratio"], stats["aspect_h_over_w"], stats["symmetry"]
+    if fill > 0.35 and 0.25 < aspect < 4.0:
+        approach = ("extrude — this reads as a single solid subject; image.to_mesh "
+                    "will produce a good solid from it")
+    else:
+        approach = ("parametric guidance — the silhouette is too sparse or too extreme "
+                    "for clean extrusion; drive char.* / prop.* / char.creature with "
+                    "this palette and these proportions instead")
+    return {
+        "path": str(ctx.resolve(path)),
+        "image_size": [w, h],
+        **stats,
+        "contours": len(loops),
+        "palette": palette,
+        "approach": approach,
+        "note": "symmetry near 1.0 means left-right symmetric (front views, emblems); "
+                "low values are natural for side-view creatures and action poses",
+    }
+
+
+@op(
+    "image.to_mesh",
+    summary="Turn a concept image into a real 3D solid: extract the subject silhouette, extrude it with a bevelled rim, and map the source image onto the front face as a texture (or bake it to vertex colours). Returns the silhouette IoU against the source — 'how close is the model to the picture' as a number, not a vibe. Emblems, totems, props, side-view creatures, relief work.",
+    params={
+        "path": ("path", None, "Concept image (alpha or uniform background)"),
+        "name": ("str", "concept", "Object name"),
+        "target_height": ("num", 1.0, "Silhouette height in metres; width follows the image aspect"),
+        "depth": ("num", 0.25, "Extrusion depth in metres along the view axis"),
+        "bevel": ("num", 0.02, "Rim chamfer — catches light so the edge reads; 0 disables"),
+        "texture": ("enum:project|vertex|none", "project", "project: map the source image on the front face; vertex: bake nearest pixel colours to COLOR_0; none: flat palette material"),
+        "simplify": ("num", 1.5, "Contour simplification tolerance in working pixels — higher is fewer vertices and smoother shapes"),
+        "threshold": ("num", 0.06, "Background distance cutoff (no alpha)"),
+        "seed": ("int", 0, "Random seed (reserved; the mesh is a pure function of the image)"),
+    },
+    tags=["build", "image"],
+)
+def image_to_mesh(ctx, path, name, target_height, depth, bevel, texture, simplify,
+                  threshold, seed):
+    ctx.reseed(seed)
+    cells, w, h, rgb, subject = _load_subject(ctx.resolve(path), threshold)
+    stats = _mask_stats(cells, w, h)
+    loops = _boundary_loops(cells)
+    if not loops:
+        raise OpError("subject found but no closed silhouette — try a larger threshold")
+    loops.sort(key=len, reverse=True)
+    contour = _simplify(loops[0], max(0.5, simplify))
+    if len(contour) < 3:
+        raise OpError("silhouette simplified to nothing — lower simplify")
+
+    min_x, min_y, max_x, max_y = stats["bbox_cells"]
+    bw = max_x - min_x + 1
+    scale = target_height / max(1, (max_y - min_y + 1))
+    # Image space -> metres: x to the right, z up (image y grows downward).
+    points = [((cx - (min_x + bw / 2.0)) * scale, (max_y - cy - (max_y - min_y + 1) / 2.0) * scale)
+              for cx, cy in contour]
+
+    from mathutils.geometry import tessellate_polygon
+
+    triangles = tessellate_polygon([points])
+    if not triangles:
+        raise OpError("silhouette could not be triangulated — try a higher simplify")
+
+    bm = mesh_lib.new_bmesh()
+    half = depth * 0.5
+    front = [bm.verts.new((x, -half, z)) for x, z in points]
+    back = [bm.verts.new((x, half, z)) for x, z in points]
+    n = len(points)
+    for tri in triangles:
+        bm.faces.new([front[tri[2]], front[tri[1]], front[tri[0]]])
+        bm.faces.new([back[tri[0]], back[tri[1]], back[tri[2]]])
+    for i in range(n):
+        j = (i + 1) % n
+        bm.faces.new([front[i], front[j], back[j], back[i]])
+
+    if bevel > 0:
+        caps = set()
+        for face in bm.faces:
+            if len(face.verts) == 3:
+                caps.add(face)
+        rim = [e for e in bm.edges
+               if len(e.link_faces) == 2
+               and (e.link_faces[0] in caps) != (e.link_faces[1] in caps)]
+        if rim:
+            mesh_lib.bevel_edges(bm, edges=rim, offset=min(bevel, depth * 0.3), segments=2)
+
+    obj = mesh_lib.to_object(bm, scene_lib.unique_name(name))
+
+    # UVs: caps map image space 1:1 (the concept art lands exactly on the
+    # front face); the rim stretches the edge texels, which is the correct look.
+    uv_layer = obj.data.uv_layers.new(name="UVMap")
+    loop_uvs = {}
+    for face in obj.data.polygons:
+        is_cap = abs(face.normal.y) > 0.5
+        for loop_index in face.loop_indices:
+            vertex = obj.data.vertices[obj.data.loops[loop_index].vertex_index].co
+            if is_cap:
+                u = vertex.x / (bw * scale) + 0.5
+                v = vertex.z / ((max_y - min_y + 1) * scale) + 0.5
+            else:
+                u = (vertex.x + vertex.z) / max(bw * scale, 1e-6) + 0.5
+                v = (vertex.y + half) / max(depth, 1e-6)
+            loop_uvs[loop_index] = (u, v)
+    for loop_index, uv in loop_uvs.items():
+        uv_layer.data[loop_index].uv = uv
+
+    palette = _palette(rgb, subject, 1)
+    base_hex = palette[0]["hex"] if palette else "#888888"
+    if texture == "project":
+        mat = mat_lib.principled(f"m_{obj.name}_concept", color=(1, 1, 1, 1), roughness=0.75)
+        tex_node = mat.node_tree.nodes.new("ShaderNodeTexImage")
+        tex_node.image = bpy.data.images.load(str(ctx.resolve(path)), check_existing=True)
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        mat.node_tree.links.new(tex_node.outputs["Color"], bsdf.inputs["Base Color"])
+        finish_lib.finish(ctx, obj, material=mat, uv=None, origin="center",
+                          smooth=True, smooth_angle=40.0)
+    elif texture == "vertex":
+        _bake_vertex_colors(ctx, obj, points, half, rgb, subject, w, h, stats, scale, bw)
+        mat = mat_lib.principled(f"m_{obj.name}_concept", color=(1, 1, 1, 1), roughness=0.75)
+        finish_lib.finish(ctx, obj, material=mat, uv=None, origin="center",
+                          smooth=True, smooth_angle=40.0)
+    else:
+        mat = mat_lib.principled(f"m_{obj.name}_concept", color=base_hex, roughness=0.75)
+        finish_lib.finish(ctx, obj, material=mat, uv=None, origin="center",
+                          smooth=True, smooth_angle=40.0)
+
+    filled = _rasterize(contour, w, h)
+    intersection = len(filled & cells)
+    union = len(filled | cells)
+    iou = intersection / max(1, union)
+    if len(loops) > 1:
+        ctx.note(
+            f"{len(loops) - 1} smaller separate silhouettes were dropped (kept the "
+            "largest). Extrude them as their own meshes if they matter."
+        )
+    return {
+        "object": obj.name,
+        "triangles": mesh_lib.tri_count(obj),
+        "contour_vertices": len(contour),
+        "silhouette_iou": round(iou, 3),
+        "palette": _palette(rgb, subject, 5),
+        "approach": "extrusion",
+        "bounds": mesh_lib.bounds(obj),
+        "note": "IoU 1.0 = the model's silhouette IS the picture's. Below ~0.8 the "
+                "outline lost detail — lower simplify and re-run",
+    }
+
+
+def _bake_vertex_colors(ctx, obj, points, half, rgb, subject, w, h, stats, scale, bw):
+    """Nearest-source-pixel colour per vertex, in a COLOR_0-ready attribute."""
+    import numpy
+
+    min_x, min_y, max_x, max_y = stats["bbox_cells"]
+    ys, xs = numpy.nonzero(subject)
+    attr = obj.data.color_attributes.new(name="color", type="BYTE_COLOR", domain="POINT")
+    mesh_scale = max(1, max(w, h) / max(1, WORK_RES) )
+    for index, vertex in enumerate(obj.data.vertices):
+        cx = int((vertex.co.x / scale + bw / 2.0 + min_x) * mesh_scale)
+        cy = int((max_y - (vertex.co.z / scale + (max_y - min_y + 1) / 2.0)) * mesh_scale)
+        distance = (xs - cx) ** 2 + (ys - cy) ** 2
+        nearest = int(distance.argmin()) if len(distance) else 0
+        color = rgb[ys[nearest], xs[nearest]] if len(distance) else (0.5, 0.5, 0.5)
+        # The attribute stores scene-linear floats; the source samples are sRGB.
+        attr.data[index].color = (
+            _srgb_to_linear(float(color[0])), _srgb_to_linear(float(color[1])),
+            _srgb_to_linear(float(color[2])), 1.0,
+        )

--- a/tools/bforge/tests/test_env_camp.py
+++ b/tools/bforge/tests/test_env_camp.py
@@ -1,0 +1,98 @@
+"""Live tests for env.camp — the settlement composer."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_camp_test_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+
+class Camp(ForgeCase):
+    def test_camp_builds_all_structures(self):
+        result = FORGE.call("env.camp", name="homeland", radius=8.0, shelters=5,
+                            well=True, racks=2, seed=42)
+        parts = {entry["part"] for entry in result["structures"]}
+        for expected in ("fire_stones", "fire_logs", "embers", "palisade",
+                         "well_stones", "well_frame", "ground"):
+            self.assertIn(expected, parts)
+        hides = [p for p in parts if p.startswith("shelter_") and p.endswith("_hide")]
+        self.assertEqual(len(hides), 5)
+        self.assertGreater(result["triangles"], 1000)
+        self.assertLess(result["triangles"], 15000)
+
+    def test_gate_leaves_an_opening(self):
+        """The palisade ring must skip the gate arc — the one way in."""
+        FORGE.call("env.camp", name="gated", radius=8.0, shelters=2, gate_angle=90.0,
+                   ground=False, seed=7)
+        info = FORGE.call("object.inspect", name="gated_palisade")
+        # At gate_angle=90 (+Y), no post may sit near (0, radius). Probe by
+        # counting palisade triangles: a full ring has ~count*segments*2 tris;
+        # the gate arc removes ~11 degrees * 2 of posts.
+        full = FORGE.call("env.camp", name="ungated", radius=8.0, shelters=2,
+                          palisade=True, gate_angle=999.0, ground=False, seed=7)
+        gated_tris = info["triangles"]
+        full_tris = next(e["triangles"] for e in full["structures"]
+                         if e["part"] == "palisade")
+        self.assertLess(gated_tris, full_tris,
+                        "the gate angle must remove posts from the ring")
+
+    def test_materials_are_separated(self):
+        FORGE.call("env.camp", name="homeland", radius=8.0, shelters=3, seed=42)
+        result = FORGE.call("check.materials")
+        errors = [f for f in result["findings"] if f["severity"] == "error"]
+        self.assertEqual(errors, [], f"camp palette must pass the blob gate: {errors}")
+
+    def test_camp_passes_the_quality_gate(self):
+        FORGE.call("env.camp", name="homeland", radius=8.0, shelters=3, seed=42)
+        review = FORGE.call("gameready.review")
+        self.assertTrue(review["passed"], f"findings: {review['findings']}")
+
+    def test_determinism(self):
+        def build_once(out):
+            FORGE.call("session.reset")
+            FORGE.call("env.camp", name="homeland", radius=8.0, shelters=3, seed=42)
+            return Path(FORGE.call("export.gltf", out=out)["path"]).read_bytes()
+
+        self.assertEqual(build_once("camp_a.glb"), build_once("camp_b.glb"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bforge/tests/test_image.py
+++ b/tools/bforge/tests/test_image.py
@@ -1,0 +1,142 @@
+"""Live tests for image.analyze / image.to_mesh — concept image -> 3D mesh."""
+
+from __future__ import annotations
+
+import os
+import struct
+import sys
+import tempfile
+import unittest
+import zlib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def _png_rgba(path: Path, w: int, h: int, pixel_fn) -> None:
+    """Minimal RGBA PNG writer (no PIL on the host side)."""
+    raw = bytearray()
+    for y in range(h):
+        raw.append(0)
+        for x in range(w):
+            raw += bytes(pixel_fn(x, y))
+
+    def chunk(tag, data):
+        body = struct.pack(">I", len(data)) + tag + data
+        return body + struct.pack(">I", zlib.crc32(tag + data))
+
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(bytes(raw)))
+        + chunk(b"IEND", b"")
+    )
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_image_test_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+    # A red disc with alpha (clean segmentation), and a green triangle with no
+    # alpha on a uniform backdrop (backdrop-distance segmentation).
+    _png_rgba(Path(TEMP.name) / "disc.png", 128, 128,
+              lambda x, y: (200, 30, 30, 255) if (x - 64) ** 2 + (y - 64) ** 2 < 40 ** 2
+              else (12, 12, 16, 255))
+    _png_rgba(Path(TEMP.name) / "tri.png", 128, 128,
+              lambda x, y: (30, 180, 60, 255) if y > 30 and abs(x - 64) < (y - 30) * 0.6
+              else (240, 240, 240, 255))
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+
+class Analyze(ForgeCase):
+    def test_disc_measurements(self):
+        result = FORGE.call("image.analyze", path=str(Path(TEMP.name) / "disc.png"))
+        self.assertAlmostEqual(result["aspect_h_over_w"], 1.0, delta=0.15)
+        self.assertGreater(result["symmetry"], 0.9)
+        self.assertGreater(result["fill_ratio"], 0.7)
+        self.assertIn("extrude", result["approach"])
+        self.assertEqual(result["palette"][0]["hex"], "#c81e1e")
+
+    def test_backdrop_segmentation_without_alpha(self):
+        result = FORGE.call("image.analyze", path=str(Path(TEMP.name) / "tri.png"))
+        self.assertGreater(result["fill_ratio"], 0.4)
+        self.assertTrue(result["palette"][0]["hex"].startswith("#"))
+
+
+class ToMesh(ForgeCase):
+    def test_disc_extrudes_with_high_fidelity(self):
+        result = FORGE.call("image.to_mesh", path=str(Path(TEMP.name) / "disc.png"),
+                            name="medallion", target_height=1.0, depth=0.2,
+                            texture="project")
+        self.assertGreater(result["silhouette_iou"], 0.9,
+                           "the mesh silhouette must BE the picture's")
+        self.assertGreater(result["triangles"], 50)
+        self.assertLess(result["triangles"], 3000)
+        self.assertAlmostEqual(result["bounds"]["size"][2], 1.0, delta=0.05)
+        self.assertAlmostEqual(result["bounds"]["size"][1], 0.2, delta=0.1)
+
+    def test_texture_variants_and_gate(self):
+        FORGE.call("image.to_mesh", path=str(Path(TEMP.name) / "disc.png"),
+                   name="flat", texture="none")
+        review = FORGE.call("gameready.review", objects=["flat"])
+        self.assertTrue(review["passed"], f"findings: {review['findings']}")
+
+    def test_exports_cleanly(self):
+        import json
+        import struct as st
+        FORGE.call("image.to_mesh", path=str(Path(TEMP.name) / "disc.png"),
+                   name="medallion", texture="project")
+        glb = FORGE.call("export.gltf", out="medallion.glb", objects=["medallion"])
+        data = Path(glb["path"]).read_bytes()
+        chunk_len, chunk_type = st.unpack_from("<I4s", data, 12)
+        parsed = json.loads(data[20:20 + chunk_len])
+        self.assertGreaterEqual(len(parsed["meshes"]), 1)
+        self.assertGreaterEqual(len(parsed.get("images", [])), 1,
+                                "projected texture must ship in the GLB")
+
+    def test_determinism(self):
+        def build_once(out):
+            FORGE.call("session.reset")
+            FORGE.call("image.to_mesh", path=str(Path(TEMP.name) / "disc.png"),
+                       name="medallion", texture="none")
+            return Path(FORGE.call("export.gltf", out=out)["path"]).read_bytes()
+
+        self.assertEqual(build_once("img_a.glb"), build_once("img_b.glb"))
+
+    def test_empty_subject_is_a_helpful_error(self):
+        blank = Path(TEMP.name) / "blank.png"
+        _png_rgba(blank, 64, 64, lambda x, y: (20, 20, 24, 255))
+        with self.assertRaises(ForgeError) as ctx:
+            FORGE.call("image.analyze", path=str(blank))
+        self.assertIn("no subject", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The #52 merge happened before the branch tip: the image pipeline, env.camp, and robe/hood landed on the branch afterward and never reached main (caught by the fresh-clone scrutiny pass — main's doctor printed 127 ops instead of 130).\n\n- image.analyze / image.to_mesh: concept image -> production mesh with silhouette-IoU fidelity scoring (7 tests)\n- env.camp: complete Age-1 settlement composer in one op (5 tests)\n- char.outfit robe + hood for the caster roster, plus the head_r fix the bestiary build caught\n- catalog 127 -> 130 ops; 200 tests green on this branch