### PR TITLE
docs: correct the counts to the verified figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Official Godot stays the upstream. We own the distribution, not the engine
 Most Blender-AI integrations are remote controls for a GUI Blender: arbitrary
 code into a live session, a different mesh every run, nothing CI can test.
 **bforge inverts that** — a persistent headless Blender daemon driven through
-127 whitelisted, typed, deterministic operations. Same params + same seed →
+130 whitelisted, typed, deterministic operations. Same params + same seed →
 byte-identical GLB, forever. It is how this toolkit's games get their art, and
 it works identically on a laptop, in CI, and on a headless build box.
 
@@ -115,7 +115,7 @@ it works identically on a laptop, in CI, and on a headless build box.
   (hero/front/side/top/wireframe/UV-checker), luminance and palette
   measurement, silhouette scoring, impostor sprite sheets for distant LOD,
   and concept-image → extruded-mesh with a silhouette-IoU fidelity score.
-- **171 tests, all live against real Blender.** Schema, MCP protocol, and
+- **174 tests, all live against real Blender.** Schema, MCP protocol, and
   per-op integration — including byte-determinism asserted on exports.
 
 Full reference: [`tools/bforge/README.md`](tools/bforge/README.md) ·

--- a/tools/bforge/README.md
+++ b/tools/bforge/README.md
@@ -130,7 +130,7 @@ tools/bforge/
     daemon.py          JSON-line RPC loop
     registry.py        @op decorator: types, coercion, schema generation
     lib/               mesh, uvs, materials, scene-graph, finishing pass
-    ops/               the 127 operations, grouped by namespace
+    ops/               the 130 operations, grouped by namespace
   catalog.json       committed op snapshot (so tools/list needs no Blender)
   tests/             unit + live-integration + visual gallery
 ```
@@ -211,7 +211,7 @@ wrong" that no metric shows.
 
 ## What it can make
 
-127 ops across 18 namespaces. Full reference: [`docs/bforge/OPS.md`](../../docs/bforge/OPS.md).
+130 ops across 19 namespaces. Full reference: [`docs/bforge/OPS.md`](../../docs/bforge/OPS.md).
 
 - **`prop.*`** — crate, barrel, chest, sack, rock, crystal, tree, pillar, torch,
   fence, furniture, weapon, banner, debris


### PR DESCRIPTION
The claim audit found drift: the suite runs 174 tests (not the 171/188 claimed in places), and the merged pipeline makes it 130 ops across 19 namespaces (image.* is a namespace of its own). Marketing that survives scrutiny is marketing that matches the runner.