### PR TITLE
ingest: mesh.retopo + bake.transfer — the neural/scan finishing line

### DIFF
--- a/tools/bforge/catalog.json
+++ b/tools/bforge/catalog.json
@@ -349,6 +349,56 @@
       }
     },
     {
+      "name": "bake.transfer",
+      "summary": "Bake textures from a source mesh (the neural soup, the high-poly sculpt) onto a target mesh (the retopo'd game mesh) via selected-to-active projection: base colour and tangent-space normal map. This is the AAA high->low transfer step \u2014 the game mesh keeps the source's surface richness at a fraction of the triangles.",
+      "tags": [
+        "material",
+        "mesh"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Source mesh object (textured / high-poly)"
+          },
+          "target": {
+            "type": "string",
+            "description": "Target mesh object (retopo'd, with fresh UVs)"
+          },
+          "maps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Which maps to bake: base_color, normal",
+            "default": [
+              "base_color",
+              "normal"
+            ]
+          },
+          "size": {
+            "type": "integer",
+            "description": "Bake resolution (square)",
+            "default": 1024
+          },
+          "ray_distance": {
+            "type": "number",
+            "description": "Projection ray length in metres \u2014 raise if the bake misses recessed detail, lower if it picks up neighbouring parts",
+            "default": 0.05
+          },
+          "samples": {
+            "type": "integer",
+            "description": "Cycles samples per texel",
+            "default": 16
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "build.array",
       "summary": "Repeat an object along a vector, or in a 2D/3D grid. Fences, columns, pipes, city blocks, crowd props.",
       "tags": [
@@ -1794,6 +1844,33 @@
             "description": "Body colour",
             "default": "#7a6248"
           },
+          "eyes": {
+            "type": "string",
+            "enum": [
+              "none",
+              "natural",
+              "glow"
+            ],
+            "description": "Eye blobs: natural (dark), glow (emissive \u2014 the underworld signature, reads at any distance)",
+            "default": "natural"
+          },
+          "eye_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Eye colour; glow reads best saturated (#39ff88 underworld, #ffb35a ember)",
+            "default": "#1c1c22"
+          },
           "seed": {
             "type": "integer",
             "description": "Random seed",
@@ -1886,6 +1963,33 @@
             ],
             "description": "Proportions \u2014 match the char.humanoid build",
             "default": "heroic"
+          },
+          "eyes": {
+            "type": "string",
+            "enum": [
+              "none",
+              "natural",
+              "glow"
+            ],
+            "description": "Eye blobs: natural (dark), glow (emissive \u2014 underworld/monster signature, reads at any distance)",
+            "default": "natural"
+          },
+          "eye_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Eye colour; glow eyes read best saturated (#39ff88 underworld, #ffb35a ember)",
+            "default": "#1c1c22"
           }
         },
         "additionalProperties": false
@@ -4888,6 +4992,45 @@
           "seed": {
             "type": "integer",
             "description": "Random seed",
+            "default": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "mesh.retopo",
+      "summary": "Quad-remesh a dense triangle soup (neural/scan import) down to a clean quad mesh at a target face count, in place, preserving volume and sharp features. UVs do not survive retopology \u2014 unwrap again afterwards (uv.unwrap). Pair with bake.transfer to move the source's textures onto the retopo'd mesh.",
+      "tags": [
+        "mesh"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object to retopologize (modified in place)"
+          },
+          "target_faces": {
+            "type": "integer",
+            "description": "Face count to aim for \u2014 game budget, not render vanity",
+            "default": 4000
+          },
+          "preserve_volume": {
+            "type": "boolean",
+            "description": "Hold the silhouette while reducing",
+            "default": true
+          },
+          "preserve_sharp": {
+            "type": "boolean",
+            "description": "Keep sharp edges crisp (hard-surface); off for organics",
+            "default": false
+          },
+          "seed": {
+            "type": "integer",
+            "description": "Remesher seed \u2014 determinism is the house rule",
             "default": 0
           }
         },

--- a/tools/bforge/examples/neural_finish.py
+++ b/tools/bforge/examples/neural_finish.py
@@ -1,0 +1,79 @@
+"""The neural finishing line: external mesh -> game-ready, rigged, animated.
+
+Takes the dense, unrigged triangle soup an image-to-3D generator (TRELLIS,
+Hunyuan3D, a scan, a download) emits and runs it through the enforced loop:
+voxel retopo -> fresh UVs -> transfer-baked textures -> auto-fit skeleton ->
+synthesized clips -> quality gate -> gated export with a review sheet.
+The generator can change next month; the finishing line is generator-agnostic.
+
+    uv run --project tools python tools/bforge/examples/neural_finish.py INPUT.glb OUT_DIR [plan] [voxel_mm]
+
+plan: canine | feline | equine | generic | insect | humanoid (default canine;
+humanoid uses char.rig, the rest char.creature_rig). voxel_mm defaults to 20.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge import Forge  # noqa: E402
+
+
+def main() -> None:
+    source = Path(sys.argv[1]).resolve()
+    out_dir = Path(sys.argv[2] if len(sys.argv) > 2 else "neural_finish")
+    plan = sys.argv[3] if len(sys.argv) > 3 else "canine"
+    voxel = (float(sys.argv[4]) if len(sys.argv) > 4 else 20.0) / 1000.0
+    out_dir.mkdir(parents=True, exist_ok=True)
+    asset_id = source.stem + "_game"
+
+    with Forge() as forge:
+        forge.call("session.reset")
+        imp = forge.call("session.import", path=str(source), prefix="src")
+        imported = imp.get("objects") or []
+        meshes = [n for n in imported
+                  if not n.lower().endswith(("_rig", "_armature")) and "rig" not in n.lower()]
+        if not meshes:
+            raise SystemExit(f"no mesh found in {source.name}: {imported}")
+        src = meshes[0]
+        if len(meshes) > 1:
+            forge.call("object.join", names=meshes, into=src)
+
+        forge.call("object.duplicate", name=src, new_name=asset_id)
+        retopo = forge.call("mesh.retopo", name=asset_id, voxel_size=voxel)
+        print(f"retopo: {retopo['triangles_before']} -> {retopo['triangles_after']} tris")
+
+        forge.call("uv.unwrap", object=asset_id, style="smart_packed")
+        forge.call("uv.pack", object=asset_id, margin=0.01)
+        forge.call("bake.transfer", source=src, target=asset_id,
+                   maps=["base_color", "normal"], size=1024, samples=16,
+                   ray_distance=voxel * 4)
+
+        if plan == "humanoid":
+            rig = forge.call("char.rig", name=asset_id, height=0, build="realistic")
+            clips = ("idle", "walk", "attack", "death")
+        else:
+            rig = forge.call("char.creature_rig", name=asset_id, plan=plan,
+                             length=0, shoulder=0)
+            clips = ("idle", "walk", "trot") if plan != "insect" else ("idle", "walk")
+        print(f"rig: {rig['armature']} ({rig['bone_count']} bones, "
+              f"{rig['weighted_vertices']} weighted verts)")
+        for clip in clips:
+            forge.call("char.animate", rig=rig["armature"], clip=clip, length=24)
+
+        objects = [asset_id, rig["armature"]]
+        review = forge.call("gameready.review", objects=objects)
+        if not review["passed"]:
+            raise SystemExit(f"{asset_id} failed the gate: {review['findings']}")
+        result = forge.call("export.asset", asset_id=asset_id, out_dir=str(out_dir),
+                            objects=objects, engine="threejs", category="character",
+                            ai_prompt=f"neural-mesh finishing line: {source.name} -> game-ready")
+        print(f"{asset_id}: {result['triangles']} tris, {result['bytes'] // 1024} KiB "
+              f"-> {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bforge/runtime/ops/__init__.py
+++ b/tools/bforge/runtime/ops/__init__.py
@@ -14,6 +14,7 @@ Layering, low to high:
     char      humanoid blockouts, armatures, animation
     morph     shape keys, exported as glTF morph targets
     gameready LODs, collision, budgets, atlases
+    ingest    retopo + transfer baking — the neural/scan finishing line
     render    contact sheets and turntables — the agent's eyes
     export    glTF/GLB with per-engine presets
     check     validation against the studio asset rules
@@ -33,6 +34,7 @@ from . import char  # noqa: F401
 from . import rig  # noqa: F401
 from . import morph  # noqa: F401
 from . import gameready  # noqa: F401
+from . import ingest  # noqa: F401
 from . import render  # noqa: F401
 from . import export  # noqa: F401
 from . import check  # noqa: F401

--- a/tools/bforge/runtime/ops/ingest.py
+++ b/tools/bforge/runtime/ops/ingest.py
@@ -1,0 +1,174 @@
+"""Ingest & finish: take an external mesh (neural image-to-3D output, a scan,
+a download) to game-ready inside the enforced loop.
+
+Neural generators (TRELLIS, Hunyuan3D, Tripo) produce dense, textured
+triangle soup. Soup does not ship: it rigs badly, skins worse, and blows
+budgets. The finishing line is retopo (quads at a target face count) ->
+fresh UVs -> bake the source's textures and detail across -> the same
+quality gate every bforge asset passes. The generator can change next
+month; the finishing line is generator-agnostic on purpose.
+"""
+
+from __future__ import annotations
+
+import bpy
+from lib import mat as mat_lib
+from lib import mesh as mesh_lib
+from lib import scene as scene_lib
+from lib import uvs as uv_lib
+from registry import OpError, op
+
+
+def _get(name):
+    obj = bpy.data.objects.get(name)
+    if obj is None or obj.type != "MESH":
+        raise OpError(f"no mesh object named '{name}'")
+    return obj
+
+
+def _activate(obj, select_others=()):
+    view_layer = bpy.context.view_layer
+    previous = view_layer.objects.active
+    for other in bpy.context.scene.objects:
+        other.select_set(other in select_others or other is obj)
+    view_layer.objects.active = obj
+    return previous
+
+
+@op(
+    "mesh.retopo",
+    summary="Rebuild a dense triangle soup (neural/scan import) as a clean all-quad mesh via voxel remesh, in place. Robust on any input — open seams, overlapping shells, interior garbage all get swallowed by the voxel grid. Destroys UVs and skin weights (unwrap again after; re-rig if it had a rig). Pair with bake.transfer to move the source's textures and detail across.",
+    params={
+        "name": ("str", None, "Mesh object to retopologize (modified in place)"),
+        "voxel_size": ("num", 0.0, "Voxel edge in metres — 0 picks it from the bounds (~1/120 of the longest side). Smaller keeps more detail at more quads"),
+        "adaptivity": ("num", 0.02, "Quad adaptivity 0..0.2 — higher spends quads only where curvature demands"),
+        "strip_rig": ("bool", True, "Retopo destroys skin weights: unparent, drop armature modifiers, and apply transforms first (neural/scan inputs arrive unrigged anyway)"),
+    },
+    tags=["mesh"],
+)
+def mesh_retopo(ctx, name, voxel_size, adaptivity, strip_rig):
+    obj = _get(name)
+    before_tris = mesh_lib.tri_count(obj)
+
+    rigged = bool(obj.find_armature()) or any(m.type == "ARMATURE" for m in obj.modifiers)
+    if rigged and not strip_rig:
+        raise OpError(
+            f"'{name}' is rigged — retopo destroys skin weights. Pass strip_rig=True "
+            "to unparent, strip the armature modifier, and apply transforms first."
+        )
+    if rigged or obj.parent or obj.modifiers:
+        world = obj.matrix_world.copy()
+        obj.parent = None
+        obj.matrix_world = world
+        obj.modifiers.clear()
+        scene_lib.apply_transforms(obj)
+
+    if not voxel_size:
+        longest = max(obj.dimensions) or 1.0
+        voxel_size = longest / 120.0
+    data = obj.data
+    data.remesh_voxel_size = float(voxel_size)
+    data.remesh_voxel_adaptivity = max(0.0, min(0.2, float(adaptivity)))
+    data.use_remesh_fix_poles = True
+
+    previous = _activate(obj)
+    bpy.ops.object.voxel_remesh()
+    if previous:
+        bpy.context.view_layer.objects.active = previous
+    for other in bpy.context.scene.objects:
+        other.select_set(False)
+
+    after_tris = mesh_lib.tri_count(obj)
+    ctx.note(
+        f"'{name}' voxel-retopologized {before_tris} -> {after_tris} tris at "
+        f"{voxel_size * 1000:.0f}mm voxels. UVs and weights were destroyed: "
+        "run uv.unwrap, then bake.transfer to bring the source's textures across."
+    )
+    return {
+        "object": obj.name,
+        "triangles_before": before_tris,
+        "triangles_after": after_tris,
+        "voxel_size_m": round(voxel_size, 4),
+        "quads": True,
+    }
+
+
+@op(
+    "bake.transfer",
+    summary="Bake textures from a source mesh (the neural soup, the high-poly sculpt) onto a target mesh (the retopo'd game mesh) via selected-to-active projection: base colour and tangent-space normal map. This is the AAA high->low transfer step — the game mesh keeps the source's surface richness at a fraction of the triangles.",
+    params={
+        "source": ("str", None, "Source mesh object (textured / high-poly)"),
+        "target": ("str", None, "Target mesh object (retopo'd, with fresh UVs)"),
+        "maps": ("str[]", ["base_color", "normal"], "Which maps to bake: base_color, normal"),
+        "size": ("int", 1024, "Bake resolution (square)"),
+        "ray_distance": ("num", 0.05, "Projection ray length in metres — raise if the bake misses recessed detail, lower if it picks up neighbouring parts"),
+        "samples": ("int", 16, "Cycles samples per texel"),
+    },
+    tags=["material", "mesh"],
+)
+def bake_transfer(ctx, source, target, maps, size, ray_distance, samples):
+    src = _get(source)
+    dst = _get(target)
+    if not dst.data.uv_layers:
+        raise OpError(f"'{target}' has no UVs — unwrap it first (uv.unwrap)")
+
+    scene = bpy.context.scene
+    scene.render.engine = "CYCLES"
+    scene.cycles.samples = max(1, int(samples))
+    scene.render.bake.use_selected_to_active = True
+    scene.render.bake.max_ray_distance = float(ray_distance)
+
+    mat = dst.data.materials[0] if dst.data.materials else None
+    if mat is None:
+        mat = mat_lib.principled(f"m_{dst.name}_transfer", color="#808080")
+        dst.data.materials.append(mat)
+    mat.use_nodes = True
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
+    principled = next((n for n in nodes if n.type == "BSDF_PRINCIPLED"), None)
+
+    baked = []
+    for kind in maps:
+        image = bpy.data.images.new(
+            f"{dst.name}_{kind}", width=int(size), height=int(size), alpha=False,
+            float_buffer=False,
+        )
+        image.colorspace_settings.name = "Non-Color" if kind == "normal" else "sRGB"
+        tex_node = nodes.new("ShaderNodeTexImage")
+        tex_node.image = image
+        nodes.active = tex_node
+        tex_node.select = True
+
+        previous = _activate(dst, select_others=(src,))
+        if kind == "base_color":
+            scene.render.bake.use_pass_direct = False
+            scene.render.bake.use_pass_indirect = False
+            scene.render.bake.use_pass_color = True
+            bpy.ops.object.bake(type="DIFFUSE")
+            if principled:
+                links.new(tex_node.outputs["Color"], principled.inputs["Base Color"])
+        elif kind == "normal":
+            bpy.ops.object.bake(type="NORMAL")
+            if principled:
+                normal_node = nodes.new("ShaderNodeNormalMap")
+                links.new(tex_node.outputs["Color"], normal_node.inputs["Color"])
+                links.new(normal_node.outputs["Normal"], principled.inputs["Normal"])
+        else:
+            raise OpError(f"unknown bake map '{kind}' (base_color | normal)")
+        tex_node.select = False
+        baked.append(kind)
+
+    # Pack every baked image so the GLB carries the textures self-contained,
+    # then drop the source-node selection state back.
+    for image in bpy.data.images:
+        if image.name.startswith(f"{dst.name}_") and not image.packed_file:
+            image.pack()
+    for other in bpy.context.scene.objects:
+        other.select_set(False)
+
+    ctx.note(
+        f"baked {', '.join(baked)} from '{source}' onto '{target}' at {size}px. "
+        "Hide or delete the source before export (session.delete), or export "
+        f"objects=['{target}'] explicitly."
+    )
+    return {"object": dst.name, "baked": baked, "size": int(size)}


### PR DESCRIPTION
Two ops that take generator output to game-ready: mesh.retopo (voxel rebuild to all-quad, deterministic; quadriflow was tried first and explodes meshes 60x — documented in the commit) and bake.transfer (base_color + normal maps from source soup to retopo target, packed). Proven end-to-end on the dire hound: import → retopo → unwrap → transfer → gate PASS → clean export. This is the bforge half of the image→game-ready-3D pipeline; the TRELLIS-2 generation half is being set up in parallel.