### PR TITLE
Truth gate + Recipe IR v1: prose/artifact consistency, schema parity, proof capsules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ STUDIO_LOG=info
 
 # --- Tool locations (auto-discovered if unset; set only if discovery fails) ---
 # GODOT_BIN=C:/path/to/Godot_v4.7.1-stable_win64_console.exe
-# BLENDER_BIN=C:/Program Files/Blender Foundation/Blender 5.2/blender.exe
+# BLENDER_BIN=C:/Program Files/Blender Foundation/Blender 4.5/blender.exe
 
 # --- Browser smoke tests ---
 # chrome | msedge | firefox (must be installed; Playwright uses the channel, no download)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Scan for committed secrets
         run: uv run --project tools python tools/ci/secret_scan.py
 
+      # The repository's prose must agree with its pinned artifacts: op counts,
+      # patch counts, test counts, and no indefensible claims. Stdlib only.
+      - name: Check public claims against the artifacts
+        run: uv run --project tools python tools/ci/check_claims.py
+
   python:
     name: python unit suites
     runs-on: ubuntu-latest
@@ -93,11 +98,26 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       # The bench drives a real Blender: official tarball, headless, CPU-only.
-      - name: install Blender 4.5 LTS
+      # The archive is hash-pinned in tools/bforge/blender-lock.toml — the same
+      # treatment the engine lock gives Godot patches and templates.
+      - name: install Blender 4.5 LTS (hash-verified)
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq libxrender1 libxi6 libxkbcommon0 libsm6 libice6 libxxf86vm1 libxfixes3 libegl1 libgl1
-          curl -sL -o /tmp/blender.tar.xz https://download.blender.org/release/Blender4.5/blender-4.5.12-linux-x64.tar.xz
+          URL=$(python3 -c 'import tomllib; print(tomllib.load(open("tools/bforge/blender-lock.toml","rb"))["blender"]["url"])')
+          curl -sL -o /tmp/blender.tar.xz "$URL"
+          python3 - <<'EOF'
+          import hashlib, tomllib
+          with open("tools/bforge/blender-lock.toml", "rb") as fh:
+              lock = tomllib.load(fh)["blender"]
+          digest = hashlib.sha256()
+          with open("/tmp/blender.tar.xz", "rb") as fh:
+              for chunk in iter(lambda: fh.read(1 << 20), b""):
+                  digest.update(chunk)
+          assert digest.hexdigest() == lock["sha256"], \
+              f"Blender archive sha256 mismatch: {digest.hexdigest()} != {lock['sha256']}"
+          print(f"verified {lock['archive']} sha256={lock['sha256'][:16]}…")
+          EOF
           sudo mkdir -p /opt/blender
           sudo tar -xJf /tmp/blender.tar.xz -C /opt/blender --strip-components=1
           /opt/blender/blender --version | head -1
@@ -106,6 +126,15 @@ jobs:
         env:
           BLENDER_BIN: /opt/blender/blender
         run: uv run --project tools python tools/bforge/bench.py
+
+      # The whole live-Blender surface, not just the schema subset — the README
+      # quotes a test count, and a count the public gate does not run is not a
+      # claim, it is a hope. One daemon is shared per module, so discovery is
+      # cheap despite booting real Blender.
+      - name: bforge full live suite
+        env:
+          BLENDER_BIN: /opt/blender/blender
+        run: uv run --project tools python -m unittest discover -s tools/bforge/tests -p "test_*.py"
 
       # The committed summary is the public number: if the tooling changed the
       # deterministic output, this diff fails and the summary must be

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ dist/
 engine/.cache/
 engine/artifacts/
 
+# --- bforge content-addressed build cache + bench output (regenerable) ---
+tools/bforge/cache/
+tools/bforge/bench/out/
+
 # --- Rust ---
 target/
 

--- a/BOOTSTRAP_REPORT.md
+++ b/BOOTSTRAP_REPORT.md
@@ -1,33 +1,42 @@
 # Studio Foundation verification report
 
-Last updated: 2026-07-22
+Last updated: 2026-08-05
 
 This report separates verified repository behavior from work still in progress.
-It is not a product roadmap.
+It is not a product roadmap. The numbers it and the README state publicly are
+enforced against the pinned artifacts by `tools/ci/check_claims.py`
+(rules: `docs/claims.toml`), so this file cannot quietly drift from the code
+again.
 
 ## Public scope
 
 Studio Foundation contains reusable Godot integration, a neutral project
 template, asset/export/release tooling, mechanics-neutral transport and service
-scaffolding, optional provider adapters, and their tests.
+scaffolding, optional provider adapters, the bforge headless-Blender asset
+forge, and their tests.
 
 It does not define a game's content, entities, mechanics, domain schema,
 identity policy, persistence semantics, or production deployment. The optional
 server and Nakama adapter carry opaque application payloads supplied by a
 consumer.
 
-## Verified in this change
+## Verified
 
 | Area | Evidence |
 |---|---|
 | Official engine source | Godot 4.7.1 stable commit `a13da4feb8d8aefc283c3763d33a2f170a18d541` is the sole active upstream pin |
-| WebGPU source preparation | Eight checksum-pinned patches pass path-containment, reusable-source preparation, candidate-isolation, dry-run, resume, and conflict-handling tests |
+| WebGPU patch series | 33 ordered patches (`engine/patches/0001`–`0033`), each SHA-256-locked in `engine-lock.toml`; `.github/workflows/patch-series.yml` re-verifies checksums and a clean-tree apply on every push and PR |
 | Build configuration | WebGPU templates explicitly use `webgpu=yes`, `opengl3=no`, and `threads=no` |
 | Template installation | The installer selects only the archive matching the lock's thread mode and rejects archives missing the WebGPU loader bridge or compiled backend marker |
-| Browser evidence | The smoke test instruments engine-owned adapter, device, and canvas-context requests and rejects any WebGL/WebGL 2 request |
-| Artifact acceptance | The recorder requires a complete release/debug pair; on 2026-07-24 the release and debug WebGPU templates were recorded by byte count and SHA-256 in `engine-lock.toml` after passing the runtime gate |
-| Current engine result | A no-threads build reaches a WebGPU adapter, device, and active canvas context under the Forward Mobile renderer without requesting WebGL, and **renders 2D/Control UI**: it passes the browser probe and a visual comparison of the neutral template's 2D menu against the WebGL baseline (1.2% diff). **The 3D-black bug is root-caused and fixed (patch 0009).** 3D was black because Tint's SPIR-V reader aborts (`TINT_UNIMPLEMENTED` decoration 21 = `Volatile`) on Godot's coherent compute shaders (`volumetric_fog.glsl`, compiled during 3D init) — a wasm trap that freezes the page. Patch 0009 strips that decoration. Verified offline (native reproducer over all 182 engine shaders: 0 crash, was 1); in-browser render verification pending a GPU-capable machine (this box has no hardware GPU). Earlier `texture.cc:606` + Emdawn `RefCounted` issues also fixed. **Lit, shadowed 3D now renders in-browser on a Tesla P40 (patches 0013 + 0014):** 0013 gives sampler/texture bind-group entries precise per-stage visibility (Forward Mobile over-declared 18 samplers per stage vs WebGPU's hard 16-per-stage limit), which made an unshaded mesh draw; 0014 then fixes the two defects that still blacked out real scenes — bindings reached only through helper-function parameters were wrongly demoted to no visibility, and depth textures were paired with Filtering samplers, which WebGPU forbids. A scene with six PBR meshes, a directional light, and real-time shadow mapping now renders at 59–60 fps, 36 draws/frame, with 0 `GPUValidationError` (was 2283) |
-| WebGPU shader translation coverage | 177 of 182 engine shaders translate to valid WGSL under the offline native reproducer (was 174). Patch 0010 makes the combined image-sampler split transitive across function call chains, so a `sampler2D` forwarded from a wrapper into a deeper helper (tonemap bicubic glow, `taa_resolve`) no longer emits invalid SPIR-V that silently fails Tint. Each fixed shader is confirmed by SPIRV-Tools validation plus a correct-WGSL spot check (separate `texture_2d` + `sampler`, `textureSampleLevel` wired to the split pair). The 5 remaining failures are fundamental WGSL feature gaps (subpass `input_attachment` ×2, storage-texture format inference, vertex-stage `read_write` storage, vertex `@builtin(position)`), not crashes |
+| Export templates | The accepted release/debug pair is recorded by filename, byte count, and SHA-256 in `engine-lock.toml [artifacts.export_templates]`; the same pair is published as release `godot-4.7.1-webgpu-p0033` |
+| 3D render, Forward Mobile | Verified in-browser on an NVIDIA Tesla P40: a minimal PBR + shadow scene at 59–60 fps / 36 draws per frame, and a full game (The Chariot Club) at a locked 60 fps, ~490–630 draws and ~23M primitives per frame — both with 0 `GPUValidationError` |
+| 3D render, Forward+ | First verified frame 2026-07-28, patch series 0023–0033, Tesla P40, headed Chrome/WebGPU, non-fallback adapter: the clustered renderer presents at 59 fps, 188 objects / 2,015,266 primitives, with 0 invalid `commandEncoder.finish` out of 10,842, 0 rejected `queue.submit`, and 0 bind-group failure classes. **Three WebGPU validation errors remain outside the presented-frame path** |
+| WebGPU shader coverage | 199 of 205 shader modules translate to valid WGSL offline with 0 GLSL compile failures, measured at the engine's real target env (Vulkan 1.1 / SPIR-V 1.3). None of the 6 remaining failures blocks Forward+: two are Forward Mobile's subpass tonemap, one is FSR's 16-bit variant (fallback translates), two are subgroup variants WebGPU does not select, one is an editor debug gizmo |
+| bforge determinism | `tools/bforge/bench.py` runs six briefs twice through the persistent daemon; all six pass the quality gate and the two GLB exports hash byte-identical (SHA-256 in `bench/report.json`). CI installs the pinned Blender 4.5.12 LTS, reruns the bench, and diffs the committed summary |
+| bforge surface | 136 whitelisted, typed operations across 21 namespaces; the committed `catalog.json` is checked against the live registry by full-schema comparison (not just op names), and `docs/bforge/OPS.md` is a generated file with a freshness gate |
+| bforge tests | 203 test methods in `tools/bforge/tests` — 164 in suites that boot a real Blender daemon, the rest pure schema/protocol/compiler units; the public CI bench job runs the full suite, not a subset |
+| Browser evidence | The runtime probe instruments engine-owned adapter, device, and canvas-context requests, rejects fallback adapters and any WebGL request, and reports `inconclusive` rather than passing on incomplete evidence |
+| Prose/artifact consistency | `tools/ci/check_claims.py` derives op, namespace, test, and patch counts from the pinned artifacts and fails the hosted policy job when a documented surface disagrees; absolute-exclusivity claims ("only public …") are rejected outright |
 | Optional Nakama bridge | The bridge carries opaque consumer-owned payloads and remains optional |
 
 ## Engine lineage
@@ -47,9 +56,12 @@ matching source and artifact provenance.
 
 ## Not yet claimed
 
-- A published OSWT (or other real-game) WebGPU capture and deployment produced from the accepted templates
+- Forward+ on any GPU other than the one NVIDIA Tesla P40 — AMD, Intel, and Apple are unmeasured, and the verification matrix so far is one scene class, one browser (headed Chrome), one OS
+- The Forward+ D24 fallback on adapters without `depth32float-stencil8` (implemented in patch 0028; the verification box has the feature, so the fallback path has never run)
+- The three remaining WebGPU validation errors outside the presented-frame path
 - Safari/iOS WebGPU behavior
 - Native Android and iOS device runs
+- A published OSWT (or other real-game) WebGPU capture and deployment produced from the accepted templates
 - Database-backed integration tests against a live disposable PostgreSQL stack
 - Console support beyond the documented licensed-provider path
 
@@ -58,6 +70,7 @@ matching source and artifact provenance.
 ```sh
 just test
 just lint
+just check-claims
 just test-generated
 just release-validate --allow-dirty
 ```

--- a/GOAL.md
+++ b/GOAL.md
@@ -19,7 +19,11 @@ Official Godot is the only client runtime standardized here. Product code,
 gameplay schemas, product-specific identity policy, and production deployments
 live in consuming repositories. Babylon.js, Capacitor, or any other runtime
 selected by a product does not become a Studio Foundation dependency unless a
-future public ADR explicitly changes that decision.
+future public ADR explicitly changes that decision. Two proposals chart paths
+past this boundary — the TypeScript/Three.js peer-runtime ADR 0017 (open draft,
+PR #50) and [ADR 0018](docs/adr/0018-brief-to-battle-world-compiler.md)
+(World IR-driven adapters). Neither is accepted; until one lands, the boundary
+above holds unchanged.
 
 The optional Rust server establishes sessions and can forward opaque
 application payloads to a handler supplied by a game. Foundation does not define

--- a/README.md
+++ b/README.md
@@ -1,29 +1,35 @@
 # Studio Foundation
 
 **An AI-native, open-source game-dev toolkit: the deterministic asset forge,
-the verification substrate, and the engine-neutral pipelines that let AI
-agents build, prove, and ship real games — into Babylon.js, three.js, Godot,
-and Rust services.**
+the verification substrate, and the pipelines that let AI agents build, prove,
+and ship real games — engine-neutral at the asset boundary (glTF/GLB into
+Godot, Babylon.js, three.js), with Godot as the standardized runtime and
+Rust services behind.**
 
 The pillars:
 
 - **bforge** — a deterministic headless-Blender asset forge for AI agents:
-  130 whitelisted, typed operations with a quality gate that rejects output
-  below the bar, byte-identical regeneration, and 174 live-Blender tests.
+  136 whitelisted, typed operations with a quality gate that rejects output
+  below the bar, byte-identical regeneration, and 203 bforge tests, 164 in suites that start a real Blender daemon.
 - **Verification** — GLB budget gates, pixel-diff captures, provenance, and
   render probes, so agent output is measured rather than trusted.
-- **Engine-neutral shipping** — glTF pipelines into Babylon.js, three.js and
-  Godot, with Rust multiplayer services behind them.
+- **Engine-neutral assets, standardized runtime** — the forge outputs portable
+  glTF/GLB consumed by Godot, Babylon.js and three.js. Godot remains the
+  standardized full runtime; promoting another runtime to peer status requires
+  a separate accepted ADR (the TypeScript/Three.js proposal,
+  [PR #50](https://github.com/lxsolutions/studio-foundation/pull/50), is still
+  an open draft; [ADR 0018](docs/adr/0018-brief-to-battle-world-compiler.md)
+  charts the World IR path), with Rust multiplayer services behind.
 
 And as the standing proof that the model works at the hard end of the stack:
-**the only maintained Godot 4.7.1 WebGPU browser backend** — a checksummed
-patch series on official Godot that renders 3D on real hardware, in public,
-with the evidence committed.
+**a maintained Godot 4.7.1 WebGPU browser backend** — a checksummed
+patch series on official Godot that renders Forward+ on real hardware, in
+public, with the evidence committed.
 
 > **Lineage.** The WebGPU backend builds on David Walter's MIT-licensed
 > [`dwalter/godotwebgpu`](https://github.com/dwalter/godotwebgpu) driver (Godot
-> 4.6.2); Studio Foundation maintains the 4.7.1 rebase, 29 targeted integration
-> patches, the build tooling, and the browser validation evidence. Exact source
+> 4.6.2); Studio Foundation maintains the 4.7.1 rebase, 33 targeted integration patches,
+> the build tooling, and the browser validation evidence. Exact source
 > boundary and commit pins:
 > [webgpu-integration.md](docs/architecture/webgpu-integration.md), [NOTICE.md](NOTICE.md).
 
@@ -32,22 +38,24 @@ with the evidence committed.
 Critics say projects like this are marketing. Here is the inventory, with the
 proof attached to every line. Hype is welcome here — it is earned.
 
-**🥇 The only public Forward+ renderer running on WebGPU — anywhere.** Not
+**🥇 Godot's Forward+ renderer, running on WebGPU, reproducibly.** Not
 the Mobile renderer: the full clustered desktop path — clustered lighting,
 SSAO, volumetric fog — that AAA-feeling games actually need. Official Godot
-ships no WebGPU support; the only other public WebGPU effort targets the
-Mobile renderer on 4.6.2. Version numbers are perishable; this capability is
-not. And the same build is also the first public, working Godot 4.7.1 on
-WebGPU. 29 checksummed patches of named engineering separate "does not draw"
-from "renders at 60 fps on a Tesla P40 with 0 `GPUValidationError`."
+ships no WebGPU support. Other public WebGPU patch stacks exist — including
+the 4.6.2 driver this one descends from — but what is rare at any version is
+the part we consider the actual product: 33 checksummed patches of named
+engineering between "does not draw" and "renders at 60 fps on a Tesla P40 with
+0 `GPUValidationError`", an evidence file that ties adapter, engine counters,
+composited pixels and command-buffer validity together, and a one-command
+reproduction path. Other implementations may exist; this one you can audit.
 [Play it in your browser](https://lxsolutions.github.io/studio-foundation/).
 
-**🔨 The only deterministic, quality-gated Blender forge for AI agents.**
-bforge is 130 typed, whitelisted operations driven into a persistent headless
+**🔨 A deterministic, quality-gated Blender forge for AI agents.**
+bforge is 136 typed, whitelisted operations driven into a persistent headless
 Blender daemon — LODs, collision, budgets, rigs, gaits, baking, validation —
-with byte-identical output run to run and 174 tests that execute against a
-real Blender. No GUI remote-control, no arbitrary code execution, no "same
-prompt, different mesh." Nothing else public does all four of those.
+with byte-identical output run to run and 203 tests, 164 of them in suites that start a real Blender daemon.
+No GUI remote-control, no arbitrary code execution, no "same
+prompt, different mesh." We know of nothing else public that does all four of those.
 
 **🛡 A toolchain that rejects its own output.** The quality gate measures
 perceptual material separation (CIELAB ΔE), texel density, triangle budgets,
@@ -99,7 +107,7 @@ open.
 Most Blender-AI integrations are remote controls for a GUI Blender: arbitrary
 code into a live session, a different mesh every run, nothing CI can test.
 **bforge inverts that** — a persistent headless Blender daemon driven through
-130 whitelisted, typed, deterministic operations. Same params + same seed →
+136 whitelisted, typed, deterministic operations. Same params + same seed →
 byte-identical GLB, forever. It is how this toolkit's games get their art, and
 it works identically on a laptop, in CI, and on a headless build box.
 
@@ -127,8 +135,9 @@ it works identically on a laptop, in CI, and on a headless build box.
   (hero/front/side/top/wireframe/UV-checker), luminance and palette
   measurement, silhouette scoring, impostor sprite sheets for distant LOD,
   and concept-image → extruded-mesh with a silhouette-IoU fidelity score.
-- **174 tests, all live against real Blender.** Schema, MCP protocol, and
-  per-op integration — including byte-determinism asserted on exports.
+- **203 tests, 164 of them in suites that start a real Blender daemon.** Schema,
+  MCP protocol, and per-op integration — including byte-determinism asserted
+  on exports.
 
 Full reference: [`tools/bforge/README.md`](tools/bforge/README.md) ·
 [`docs/bforge/OPS.md`](docs/bforge/OPS.md) · engine-neutral output (glTF) —
@@ -152,17 +161,18 @@ because claims need a floor to stand on. Official
 upstream; the WebGPU export path below is maintained here as an ordered,
 SHA-256-locked patch series. WebGL 2 remains the supported fallback.
 
-**First, and stated plainly.** Nothing else public renders Godot's Forward+
-renderer — the full clustered desktop path — through WebGPU. Not official
-Godot, which ships no WebGPU support at all
-[by their own docs](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_web.html);
-not the only other public WebGPU effort, David Walter's driver, which targets
-the Mobile renderer on 4.6.2. This build renders Forward+ in a browser tab,
-and it is also the first public, working Godot 4.7.1 on WebGPU. The version
-number will age; the capability claim will not. It is said here, with the
-evidence attached, because it is true and it is checkable.
+**Stated plainly.** This build renders Godot's Forward+ renderer — the full
+clustered desktop path — through WebGPU, in a browser tab, on real hardware,
+with the evidence committed. Official Godot ships no WebGPU support at all
+[by their own docs](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_web.html).
+Other public WebGPU patch stacks exist, including the 4.6.2 driver this work
+descends from; we claim no monopoly on the idea. What we do claim is the part
+that matters for trust: an ordered, checksum-locked patch series, a render
+probe that refuses to call a fallback adapter or a blank canvas success, and a
+published evidence file you can regenerate. The version number will age; the
+auditability will not.
 
-**What it took to make 4.7.1 draw.** 29 targeted, checksummed patches, each
+**What it took to make 4.7.1 draw.** 33 targeted, checksummed patches, each
 killing a distinct defect between "does not draw" and "renders": the
 Tint/SPIR-V translation chain (texture lowering, storage-buffer access, image
 ordering, volatile decoration), sampler/texture stage-visibility splits, lit
@@ -273,7 +283,7 @@ multi-hour engine build:
 **[Download the templates](https://github.com/lxsolutions/studio-foundation/releases/tag/godot-4.7.1-webgpu-p0033)**
 (official Godot 4.7.1 + patch series 0001–0033, single-threaded so exports run on plain
 static hosts with no COOP/COEP headers). These are the first templates that render
-**Forward+** — the earlier `p0014` release cannot, and predates the eleven patches
+**Forward+** — the earlier `p0014` release cannot, and predates the nineteen patches
 that made the clustered renderer work. Point your `web` preset's
 `custom_template/release` and `custom_template/debug` at them, then export with
 `just export-browser-webgpu` — that step applies the WebGPU handoff the official editor
@@ -293,12 +303,14 @@ a pass when it cannot establish those. **If your result differs from the
 published one, please open an issue and attach the evidence file.** Independent
 confirmation on hardware we do not own is the most useful contribution right now.
 
-**What this download is not.** It is pinned at patch **0014**, while `main`
-carries **0022**. Those eight patches are what made Forward+ work on hardware
-(0015 and 0018–0022) — so the published templates render **Forward Mobile only**,
-which is also the default and what every published demo runs. If you want to try
-Forward+, build from source below; the release cannot do it. A templates build
-matching the current series is not yet published.
+**What this download is not.** It is a beta pinned at patch series **0001–0033** —
+the series whose Forward+ frame is hardware-verified — but the verification is
+narrow: one scene class, one browser (headed Chrome), one OS, one GPU (an
+NVIDIA Tesla P40). Three WebGPU validation errors remain outside the
+presented-frame path, the uncompressed payload is about 46 MB, cold startup is
+tens of seconds, and AMD, Intel, Apple, Safari, and iOS are unverified. If
+your hardware differs from that matrix, run the probe above and send the
+evidence file either way — that is how the matrix grows.
 
 ### Build the WebGPU path yourself
 
@@ -342,7 +354,7 @@ to work here.
 | Runtime verification | Browser smoke tests observe the engine's adapter, device, and WebGPU canvas requests and reject any WebGL context request |
 | 3D shader translation | Verified in-browser on an NVIDIA Tesla P40. Patches 0009–0012 fix four distinct translation crashes; the runtime-specialized scene shader translates without crashing |
 | WebGPU shader coverage | 199 of 205 shader modules translate to valid WGSL offline, with **0 GLSL compile failures**, measured at the engine's real target env (Vulkan 1.1 / SPIR-V 1.3 — the harness previously measured 1.0 and so did not reproduce the engine; see patch 0016). **None of the 6 remaining failures blocks Forward+ under WebGPU**: two are Forward Mobile's subpass tonemap, one is FSR's 16-bit variant (the driver reports no half-float, so the engine picks the fallback, which translates), two are the subgroup variants WebGPU does not select, one is an editor debug gizmo |
-| Renderer ceiling | Every WebGPU export ran **Forward Mobile**, which hard-disables SSAO, SSIL, SSR, SDFGI, VoxelGI and volumetric fog regardless of project settings. Patches 0015 and 0017 unblock **Forward+** (clustered) — the renderer those effects need, and the better architectural fit for WebGPU, since Mobile's one untranslatable shader is also the engine's only user of subpasses. Every shader Forward+ needs now translates; **not yet hardware-verified**, so `mobile` stays the export default |
+| Renderer ceiling | **Forward+ (clustered) renders on hardware** — verified in-browser on an NVIDIA Tesla P40 with the p0033 templates: 188 objects / 2,015,266 primitives at 59 fps, 0 invalid `commandEncoder.finish` out of 10,842, 0 rejected `queue.submit`, 0 bind-group failure classes. Forward Mobile remains an export option; WebGL 2 remains the fallback. Three validation errors outside the presented-frame path and the wider hardware matrix are the open work |
 | 3D render (lit + shadowed) | **Verified in-browser on an NVIDIA Tesla P40.** Patches 0013–0014 fix per-stage sampler visibility and depth-texture sampler types. A minimal PBR + shadow scene renders at 59–60 fps / 36 draws per frame, and a full game (The Chariot Club) holds a locked 60 fps at ~490–630 draws and ~23M primitives per frame — both with 0 `GPUValidationError` |
 | Fallback | The same template project has an official WebGL 2 export preset |
 | Template behavior | Headless GDScript tests cover the shared addon and neutral starter project |
@@ -355,16 +367,18 @@ Exact test counts, artifact state, and unverified areas are in the
 
 WebGPU support is **beta**.
 
-What works, verified on real GPU hardware: the engine boots the WebGPU backend
-(Forward Mobile), translates the runtime-specialized 3D scene shaders, and renders
-lit, shadowed 3D geometry with 0 validation errors. 2D/UI renders and was gated
-against the WebGL baseline at a 1.2% visual difference.
+What works, verified on real GPU hardware: the engine boots the WebGPU backend,
+translates the shaders the runtime actually selects, and renders lit, shadowed
+3D geometry with 0 validation errors — under **Forward Mobile**, and under
+**Forward+** (the clustered desktop path) since patch series 0001–0033. 2D/UI
+renders and was gated against the WebGL baseline at a 1.2% visual difference.
 
 What does not, yet: several post-processing effects (tonemap variants, SSR, TAA,
 SDFGI/voxel-GI debug views) still fail Tint translation *gracefully* — they are
-skipped rather than crashing, so 3D renders without them. Getting to a visible frame
-took fourteen patches worth of shader-translation and binding-description fixes; each
-one is documented in [engine/patches/README.md](engine/patches/README.md) with the
+skipped rather than crashing, so 3D renders without them. Three WebGPU validation
+errors remain outside the presented-frame path. Getting here took 33 patches of
+shader-translation, binding-description, and format-invariant fixes; each one is
+documented in [engine/patches/README.md](engine/patches/README.md) with the
 exact defect it addresses.
 
 Godot's own WebGPU support is separately in development upstream. This project is

--- a/docs/adr/0006-blender-master-asset-pipeline.md
+++ b/docs/adr/0006-blender-master-asset-pipeline.md
@@ -11,7 +11,8 @@ path into the engine, automatable by CI and AI agents.
 
 ## Decision
 
-- **Blender** (pinned LTS; currently 5.2.0 LTS) is the master source. `.blend` files in
+- **Blender** (pinned LTS; currently 4.5.12 LTS — the version CI and the
+  byte-identical bench verify against) is the master source. `.blend` files in
   `assets-source/` are the only editable asset truth.
 - All automation uses **Blender background mode + Python API** (`blender -b --python`)
   through `tools/asset-pipeline/` — no GUI-only automation, no arbitrary remote code

--- a/docs/adr/0018-brief-to-battle-world-compiler.md
+++ b/docs/adr/0018-brief-to-battle-world-compiler.md
@@ -1,0 +1,98 @@
+# ADR 0018: BRIEF→BATTLE — the proof-carrying world compiler
+
+- Status: Accepted
+- Date: 2026-08-05
+- Extends: [ADR 0014](0014-bforge-agent-asset-authoring.md) (bforge),
+  [ADR 0008](0008-own-the-distribution-not-the-engine.md) (distribution, not engine)
+- Relates: the TypeScript/Three.js peer-runtime proposal (ADR 0017, PR #50) is
+  an open draft at time of writing; this ADR's milestone M2 (World IR compiled
+  to two runtimes) composes with whichever runtime decision lands.
+
+## Context
+
+bforge proved the doctrine at asset level: generate, inspect the actual
+artifact, measure it, reject failures, encode the failure as a permanent gate,
+regenerate. The quality gate, the byte-identical bench, the catalog parity
+checks, and the claims gate all exist because that loop works.
+
+Two independent reviews of the repository (2026-08) reached the same
+conclusion about what is next. The durable asset is not any single operation,
+renderer patch, or demo — it is the production substrate. And the substrate
+currently stops at the asset boundary. GLB carries geometry, skins, materials,
+and animations; it does not carry what an object *is* in a game — its parts,
+joints, affordances, state, physics, network authority, or the proof that any
+of those work.
+
+Meanwhile the field is converging on the thesis from both ends: neural
+generators produce increasingly strong geometry with weak semantics; world
+models produce convincing audiovisual experience with no durable state;
+code-native asset research (Nova3D, 3DCodeBench) shows executable source beats
+opaque meshes on editability and determinism; agentic game benchmarks
+(GameDevBench, GameEngineBench) show the whole production loop is unsolved.
+The missing middle is a system that materializes, normalizes, compiles, and
+*proves*.
+
+## Decision
+
+Studio Foundation's north star is **BRIEF→BATTLE**: given a creative brief,
+produce a playable, persistent, networkable world — and ship the proof bundle
+with it. Worlds as code. Assets as programs. AI output as untrusted input.
+Every world ships with proof.
+
+The program has four durable contracts, in dependency order:
+
+1. **Asset Recipe IR.** Assets are declared, not performed: a versioned,
+   canonical, content-hashed recipe (inputs, steps, requirements) compiled by
+   bforge workers into artifacts plus a **proof capsule** — recipe hash, tool
+   identities, gate results, artifact hashes. Content-addressed caching makes
+   regeneration free; proof makes acceptance mechanical.
+2. **World IR.** The semantic layer GLB lacks: parts, hierarchy, joints,
+   affordances, state schemas, physics/navigation contracts, network
+   authority, budgets, provenance. World IR sits *between* OpenUSD/`.blend`
+   source composition and GLB/KTX2 runtime payloads; it references artifacts
+   rather than replacing formats.
+3. **Deterministic simulation kernel.** Fixed-step, renderer-independent;
+   initial state + seed + event stream ⇒ final state hash. Native Rust server
+   and Wasm client run the same replay to the same hash. Agents steer intent,
+   never per-frame state.
+4. **BRIEF→BATTLE, the public benchmark.** One frozen brief → faction,
+   battlefield, playable battle, deterministic replay, proof package — scored
+   on validity, semantic correctness, visual quality, gameplay correctness,
+   systems quality, and agent efficiency, across models, in public.
+
+Milestone sequence: **M0** truth becomes generated (claims gate, full-schema
+catalog parity, generated status surfaces — done 2026-08-05); **M1** bforge
+becomes a compiler (Recipe IR, content-addressed builds, proof capsules);
+**M2** World IR compiled to two runtimes; **M3** deterministic simulation with
+browser/server parity; **M4** the public benchmark; **M5** constrained
+runtime (living-world) generation that must pass the same proofs before
+becoming authoritative state.
+
+## First increment (this ADR's prototype)
+
+`bforge cook` compiles a Recipe IR v1 document: canonicalize → hash inputs and
+parameters → consult the content-addressed cache → execute steps on a Blender
+worker → run the requirement gates → export → write the proof capsule. A cache
+hit returns the verified proof without booting Blender. Recipes are JSON, not
+YAML, because the tooling is deliberately stdlib-only
+([ADR 0013](0013-dependency-license-policy.md)).
+
+## What this is not (yet)
+
+- Not a new engine. Official Godot stays upstream; the WebGPU series remains
+  a replaceable distribution (ADR 0008).
+- Not a USD/glTF replacement — World IR is the semantic contract between them.
+- Not arbitrary runtime code generation: runtime creativity compiles
+  constrained World IR data through approved systems, never model-emitted
+  executable code into production state.
+- Not photorealism chasing. Structure, semantics, determinism, editability,
+  and proof are the durable advantage.
+
+## Consequences
+
+- Every production failure becomes a reusable gate, recipe, or proof field —
+  institutional knowledge compounds in executable form.
+- The public surfaces (README counts, bench numbers, proof capsules) are
+  generated or gated, so the proof system proves itself.
+- Benchmark results become comparable across models and across time because
+  briefs, recipes, and hashes are frozen and published.

--- a/docs/architecture/dependency-licenses.md
+++ b/docs/architecture/dependency-licenses.md
@@ -13,7 +13,7 @@ Exact resolved versions live in the lockfiles (`Cargo.lock`, `uv.lock`,
 | Godot Engine | 4.7.1-stable `a13da4feb…` | MIT | Primary engine | ADR 0001 |
 | Studio Foundation WebGPU integration | official 4.7.1 + local checksummed patches; source lineage `f329e39ce...` | MIT plus included third-party licenses | Browser WebGPU export backend | ADR 0002; beta; see NOTICE.md |
 | Godot export templates (web) | 4.7.1.stable official | MIT | WebGL2 browser export | installed via editor |
-| Blender | 5.2.0 LTS | GPL-2.0-or-later | Master asset tool (standalone process only) | ADR 0006 isolation note |
+| Blender | 4.5.12 LTS | GPL-2.0-or-later | Master asset tool (standalone process only) | ADR 0006 isolation note; the version CI and the byte-identical bench verify against |
 | Emscripten | 4.0.11 | MIT/UIUC | Web engine builds | pinned for the local integration |
 | Emdawn WebGPU port | `v20250531.224602` / Dawn `ea66c0fa…` | MIT/UIUC and BSD-3-Clause | Browser WebGPU C/C++ bindings | Shipped by pinned Emscripten; source and namespace backport are checksum-locked in `engine-lock.toml` |
 | SCons | 4.9.1 | MIT | Godot build system | via uv-managed venv |

--- a/docs/architecture/webgpu-runtime-status.md
+++ b/docs/architecture/webgpu-runtime-status.md
@@ -5,9 +5,10 @@
 > build/smoke logs under `engine/.cache/` and uncommitted edits in this worktree.
 > This file is the handoff — update it whenever the runtime status changes.
 >
-> **Last reconciled:** 2026-07-27, from `origin/main` @ `0f2bab8` (patch series
-> 0001–0022). Supersedes the 2026-07-23 reconciliation, which predated patches
-> 0018–0022 and still listed Forward+ on hardware as untested.
+> **Last reconciled:** 2026-08-05, patch series **0001–0033** — the series whose
+> Forward+ frame is hardware-verified (first verified frame 2026-07-28, Tesla
+> P40). Supersedes the 2026-07-27 reconciliation (0001–0022), which listed
+> Forward+ as compiling but never having rendered.
 > **Scope:** the ADR 0002 runtime-acceptance gate. The editor and WebGL fallback
 > are unaffected and green.
 
@@ -35,21 +36,19 @@ Folding that 3D render into the automated gate is the remaining CI task — host
 CI now proves the patch series (checksums + a clean-tree apply) on every change,
 but a render probe needs a GPU runner and remains self-hosted work.
 
-**One sentence on which renderer that means.** Everything shipped and published —
-the live demo, the templates, the performance A/B — is **Forward Mobile**, which
-`tools/godot/export_game.py` calls "the hardware-verified default". **Forward+**
-is opt-in (`--rendering-method forward_plus`) and, as of patch 0033, **renders**.
-As of patches 0023–0029 it gets substantially further — the scene shader
-translates, the cluster builder exists, scene pipelines are created and command
-buffers encoded, and clears attachment compatibility across 44 measured
-pipeline/pass pairs. It renders the 2D UI; the 3D scene is black. The frontier is
-now resource and bind-group compatibility.
-See §Forward+ on hardware (0023–0029). Do not read a Forward Mobile result as a
-Forward+ result, and do not read "the render loop runs" as "a frame rendered".
+**One sentence on which renderer that means.** The export default is **Forward
+Mobile** — `tools/godot/export_game.py` keeps `rendering_method="mobile"` unless
+asked otherwise — and Forward+ is opt-in (`--rendering-method forward_plus`).
+As of patch series 0001–0033, Forward+ **renders**: first verified frame
+2026-07-28, Tesla P40, headed Chrome/WebGPU (§Forward+ renders — first verified
+frame). Do not read a Forward Mobile result as a Forward+ result, and do not
+read "the render loop runs" as "a frame rendered" — both mistakes have been
+made in this file's own history, which is why the sections below are dated
+checkpoints rather than overwritten prose.
 
 | Gate | Status | Evidence |
 | --- | --- | --- |
-| Patch series (0001–0022) applies to official 4.7.1 `a13da4feb8` | ✅ **enforced in CI** | `.github/workflows/patch-series.yml` — checksums + a clean-tree apply on every push and PR |
+| Patch series (0001–0033) applies to official 4.7.1 `a13da4feb8` | ✅ **enforced in CI** | `.github/workflows/patch-series.yml` — checksums + a clean-tree apply on every push and PR |
 | Web templates compile (release + debug, `nothreads`, `webgpu=yes`) | ✅ | `bin/godot.web.template_*.wasm32.nothreads.*` |
 | Tint SPIR‑V→WGSL translation (storage‑buffer + OpImage ordering) | ✅ | patches 0007, 0008 |
 | **Emdawn/Godot `RefCounted` ODR collision** (the heap‑buffer‑overflow) | ✅ **fixed in source** | `engine/toolchain/patches/0001-emdawn-private-namespace.patch`, locked in `[toolchain.emdawnwebgpu]` |
@@ -137,6 +136,10 @@ aggressively than Mobile, and the next five patches were all things only
 hardware could show. See the section below.
 
 ## Forward+ on hardware — 168 → 18 (patches 0018–0022, 2026‑07‑25)
+
+> **Superseded checkpoint.** This section is the 2026-07-25 state, kept as the
+> record of how the abort layer was cleared. Forward+ **does render** now — see
+> §Forward+ renders — first verified frame (patches 0023–0033, 2026‑07‑28).
 
 Run on a **Tesla P40** through Chrome/WebGPU, exporting with
 `export_game.py --preset web-webgpu --rendering-method forward_plus`.
@@ -241,6 +244,10 @@ still an invalid bind group that took the whole scene command buffer with it.
 The fix was to delete the dead resource, not to describe it more accurately.
 
 ## Forward+ on hardware — 18 → the render loop runs (patches 0023–0029, 2026‑07‑28)
+
+> **Superseded checkpoint.** Same-day state before 0033 landed; kept as the
+> record of the resource/bind-group frontier. The presented frame is the next
+> section, §Forward+ renders — first verified frame.
 
 Same host: a Tesla P40 through headed Chrome/WebGPU under Xvfb, Chariot exported
 with `--rendering-method forward_plus`, measured by

--- a/docs/bforge/OPS.md
+++ b/docs/bforge/OPS.md
@@ -1,6 +1,6 @@
 # bforge op reference
 
-131 operations.
+136 operations.
 
 ## `arch.*`
 
@@ -78,6 +78,21 @@ A monumental arched gate — the triumphal entrance every Roman venue frames its
 | `material` | string | 'stone' | Material preset |
 | `color` | string | '' | Override colour |
 | `uv_scale` | number | 3.0 | Metres per UV tile |
+
+## `bake.*`
+
+### `bake.transfer`
+
+Bake textures from a source mesh (the neural soup, the high-poly sculpt) onto a target mesh (the retopo'd game mesh) via selected-to-active projection: base colour and tangent-space normal map. This is the AAA high->low transfer step — the game mesh keeps the source's surface richness at a fraction of the triangles.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `source` | string | None | Source mesh object (textured / high-poly) |
+| `target` | string | None | Target mesh object (retopo'd, with fresh UVs) |
+| `maps` | array | ['base_color', 'normal'] | Which maps to bake: base_color, normal, ao |
+| `size` | integer | 1024 | Bake resolution (square) |
+| `ray_distance` | number | 0.05 | Projection ray length in metres — raise if the bake misses recessed detail, lower if it picks up neighbouring parts |
+| `samples` | integer | 16 | Cycles samples per texel |
 
 ## `build.*`
 
@@ -392,6 +407,8 @@ Proportioned quadruped body (canine/equine/feline/generic) or hexapod (insect: s
 | `detail` | integer | 8 | Limb cross-section segments |
 | `location` | array | [0.0, 0.0, 0.0] | World position |
 | `skin` | string | '#7a6248' | Body colour |
+| `eyes` | none \| natural \| glow | 'natural' | Eye blobs: natural (dark), glow (emissive — the underworld signature, reads at any distance) |
+| `eye_color` | any | '#1c1c22' | Eye colour; glow reads best saturated (#39ff88 underworld, #ffb35a ember) |
 | `seed` | integer | 0 | Random seed |
 
 ### `char.creature_rig`
@@ -416,6 +433,8 @@ Give a char.humanoid head a readable face — brow ridge, nose wedge, chin — s
 | `name` | string | None | Body mesh (from char.humanoid) |
 | `height` | number | 0.0 | Character height; 0 measures the mesh bounds |
 | `build` | realistic \| heroic \| stylized \| chibi \| lithe | 'heroic' | Proportions — match the char.humanoid build |
+| `eyes` | none \| natural \| glow | 'natural' | Eye blobs: natural (dark), glow (emissive — underworld/monster signature, reads at any distance) |
+| `eye_color` | any | '#1c1c22' | Eye colour; glow eyes read best saturated (#39ff88 underworld, #ffb35a ember) |
 
 ### `char.gait`
 
@@ -545,6 +564,16 @@ Measure whether an asset's materials are actually distinguishable — the '8 mat
 | --- | --- | --- | --- |
 | `objects` | array | [] | Objects whose materials to measure (empty = every mesh) |
 | `min_delta_e` | number | 12.0 | Perceptual-separation floor in ΔE76. Below ~6 the difference is invisible in game; 12 is a safe bar for metal vs leather vs cloth |
+
+### `check.palette`
+
+Measure an asset against the game's art bible: every material's base colour is mapped to the nearest palette family in CIELAB and must land within tolerance (ΔE76). This is executable art direction — the difference between 'assets that look generated' and 'assets that look like they belong to one game'.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `objects` | array | [] | Objects whose materials to measure (empty = every mesh) |
+| `bible` | string | 'ashenward' | Art bible name (see ART_BIBLES) or a JSON list of {"name", "hex"} entries |
+| `tolerance` | number | 22.0 | Max distance to the nearest family in ΔE76 — 18 is strict, 26 is permissive |
 
 ### `check.silhouette`
 
@@ -1030,6 +1059,19 @@ Merge materials that render identically into one shared material. Composing a sc
 | `objects` | array | [] | Limit to these objects (empty = whole scene) |
 | `dry_run` | boolean | False | Report what would merge without changing anything |
 
+### `material.detail_normal`
+
+Generate a surface-detail normal map procedurally (cloth weave, hide scales, skin pores, wood grain) and wire it into the object's material. Bake passes only capture GEOMETRY normals, so shader bumps never survive export — this writes the relief into a real normal map, which is what makes cloth/skin/hide read as material instead of flat plastic at close range. Deterministic (seeded), glTF-safe (TEX_IMAGE + NORMAL_MAP only).
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `object` | string | None | Object to detail (must have UVs) |
+| `pattern` | weave \| scales \| pores \| grain | 'weave' | Surface class: weave=cloth, scales=hide/armour, pores=skin/leather, grain=wood |
+| `scale` | number | 24.0 | Pattern frequency across the texture |
+| `strength` | number | 0.6 | Relief intensity 0..1 |
+| `size` | integer | 512 | Texture size (square) |
+| `seed` | integer | 0 | Random seed |
+
 ### `material.face_assign`
 
 Give a subset of faces its own material — trim strips, emissive panels, painted details. Selected by world-space direction or height.
@@ -1123,6 +1165,32 @@ Bake a SEAMLESS PBR texture set and apply it repeating across a surface. This is
 | `out_dir` | string | 'textures' | Directory for the PNGs |
 | `reuse` | boolean | True | If this stem was already baked, assign the existing material instead of baking again. Bake once, apply to every stone surface in a building — same texture, one set of maps, one draw call |
 | `seed` | integer | 0 | Random seed |
+
+## `mesh.*`
+
+### `mesh.clean`
+
+Sweep a neural/scan mesh before retopo: delete floating islands below a size share of the main body, then Taubin-smooth the surface (smooth + counter-smooth, so it denoises without shrinking). Neural soup carries floaters and high-frequency noise that voxel retopo faithfully preserves — clean first or the spikes ship.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object to clean (modified in place) |
+| `island_min_share` | number | 0.02 | Drop disconnected islands smaller than this fraction of the largest island's face count (0.02 = keep anything at least 2% of the main body) |
+| `smooth_iterations` | integer | 2 | Laplacian rounds — 1-3 denoises neural output; 0 keeps the raw surface |
+| `smooth_factor` | number | 0.3 | Step size per round, capped at 0.35: a negative-volume counter-step (Taubin) was tried and SHREDDED voxel-quad meshes — plain small steps are the safe smooth |
+| `despike_iterations` | integer | 2 | Outlier-clamp passes — collapse verts sitting >threshold x the median edge length away from their neighbourhood median (the long thin spikes neural extraction leaves) |
+| `despike_threshold` | number | 4.0 | Spike cutoff as a multiple of the median edge length |
+
+### `mesh.retopo`
+
+Rebuild a dense triangle soup (neural/scan import) as a clean all-quad mesh via voxel remesh, in place. Robust on any input — open seams, overlapping shells, interior garbage all get swallowed by the voxel grid. Destroys UVs and skin weights (unwrap again after; re-rig if it had a rig). Pair with bake.transfer to move the source's textures and detail across.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Mesh object to retopologize (modified in place) |
+| `voxel_size` | number | 0.0 | Voxel edge in metres — 0 picks it from the bounds (~1/120 of the longest side). Smaller keeps more detail at more quads |
+| `adaptivity` | number | 0.02 | Quad adaptivity 0..0.2 — higher spends quads only where curvature demands |
+| `strip_rig` | boolean | True | Retopo destroys skin weights: unparent, drop armature modifiers, and apply transforms first (neural/scan inputs arrive unrigged anyway) |
 
 ## `meta.*`
 

--- a/docs/claims.toml
+++ b/docs/claims.toml
@@ -1,0 +1,93 @@
+# Public-claim consistency rules — the one source of truth for the numbers
+# the repository says about itself.
+#
+# Verification is this project's brand, and its own prose has drifted from the
+# code more than once (op counts, patch counts, release boundaries, a catalog
+# whose schema disagreed with the runtime). tools/ci/check_claims.py derives
+# the true values from the pinned artifacts listed here and fails CI when a
+# documented surface disagrees. Fix drift by editing the prose surface or
+# regenerating the artifact — never by hand-editing numbers to silence the
+# gate.
+#
+# Derived keys:
+#   bforge.ops         len(tools/bforge/catalog.json ops)   (regen: just bforge-catalog)
+#   bforge.namespaces  distinct namespaces in that catalog
+#   bforge.tests       test_* methods counted statically in tools/bforge/tests/test_*.py
+#   bforge.tests_blender  of those, the suites that boot a real Blender daemon
+#                      (module references find_blender / honors BFORGE_SKIP_LIVE)
+#   engine.patches     patch entries in engine/engine-lock.toml
+
+# A surface rule: every pattern must occur at least once in `file`, and every
+# number its capture group matches must equal the derived value of `key`.
+# `group` (default 1) says which capture group carries the key's number.
+# Write prose so the number appears inside one of these exact phrasings.
+
+[[surface]]
+file = "README.md"
+key = "bforge.ops"
+patterns = [
+  '(\d+) whitelisted, typed operations',
+  '(\d+) typed, whitelisted operations',
+  '(\d+) whitelisted, typed, deterministic operations',
+]
+
+[[surface]]
+file = "README.md"
+key = "bforge.tests"
+patterns = [
+  '(\d+) bforge tests, (\d+) in suites that start a real Blender daemon',
+  '(\d+) tests, (\d+) of them in suites that start a real Blender daemon',
+]
+
+[[surface]]
+file = "README.md"
+key = "bforge.tests_blender"
+group = 2
+patterns = [
+  '(\d+) bforge tests, (\d+) in suites that start a real Blender daemon',
+  '(\d+) tests, (\d+) of them in suites that start a real Blender daemon',
+]
+
+[[surface]]
+file = "README.md"
+key = "engine.patches"
+patterns = [
+  '(\d+) targeted integration patches',
+  '(\d+) checksummed patches',
+  '(\d+) targeted, checksummed patches',
+  'patch series 0001–0*(\d+)',
+]
+
+[[surface]]
+file = "tools/bforge/README.md"
+key = "bforge.ops"
+patterns = [
+  'the (\d+) operations, grouped by namespace',
+  '(\d+) ops across (\d+) namespaces',
+]
+
+[[surface]]
+file = "tools/bforge/README.md"
+key = "bforge.namespaces"
+group = 2
+patterns = [
+  '(\d+) ops across (\d+) namespaces',
+]
+
+# A forbidden claim: a phrase no surface may carry, because it is not
+# defensible. `files` is a repo-relative list; `phrase` is a literal string.
+
+[[forbidden]]
+files = ["README.md"]
+phrase = "only public Forward+"
+reason = "another public Godot Forward+ WebGPU patch stack exists (davtamay/Godot_WebGPU); absolute exclusivity claims are not defensible — claim the evidence and reproducibility instead"
+
+[[forbidden]]
+files = ["README.md"]
+phrase = "the only other public WebGPU effort"
+reason = "more than one other public WebGPU effort exists; name the specific project being compared instead"
+
+[[forbidden]]
+files = ["README.md", "docs/architecture/dependency-licenses.md", "docs/adr/0006-blender-master-asset-pipeline.md"]
+phrase = "Blender 5.2"
+reason = "the pinned and CI-verified Blender is 4.5 LTS (4.5.12); the bench installs it and every golden was produced with it"

--- a/engine/patches/README.md
+++ b/engine/patches/README.md
@@ -159,6 +159,175 @@ browser WebGPU template build. They apply to the official Godot commit in
     a layout against the SHADER, so the scanned declaration wins. Measured on a
     Tesla P40: Sint mismatches 4 -> 0, `GPUValidationError` 26 -> 18.
 
+23. `0023-webgpu-stage-correct-storage-buffers.patch` - keep fragment storage
+    buffers writable, and off the vertex stage. The WGSL post-pass demoted every
+    read_write storage buffer to read-only in BOTH stages; WebGPU only forbids a
+    writable storage buffer in the vertex stage, and the cluster builder is a
+    fragment shader whose entire job is to `atomicOr` into an SSBO, so the
+    demotion rewrote Tint's correct output into a module WGSL rejects outright
+    (atomics in `storage` must be read_write). Demote in the vertex stage only,
+    and never a buffer whose struct contains `atomic<>`; the read-only cache is
+    keyed by (set,binding) and filled once per stage, so read-write now wins over
+    whichever stage was scanned last; and a binding whose resolved type is
+    Storage no longer carries vertex visibility. Measured on a Tesla P40
+    (Chariot, Forward+): WGSL parse failures (atomics) 3 -> 0, ClusterRender
+    layout/pipeline 6 -> 0, read-write-in-vertex-visibility 2 -> 0,
+    `GPUValidationError` 18 -> 14.
+
+24. `0024-webgpu-textureload-identifier-boundary.patch` - match `textureLoad` on
+    a whole identifier, not a prefix. The read-only-storage-to-sampled conversion
+    adds a mip-level argument by searching for `"textureLoad(" + var_name`, and
+    SDFGI's preprocess shader declares both `src_light` and `src_light_aniso`, so
+    the prefix matched the longer name too and it received a second mip argument
+    - a four-argument `textureLoad` that invalidated SdfgiPreprocessShaderRD
+    variant 8. A rewrite for binding x may now only touch a call whose first
+    argument is exactly the identifier x, applied at both the shadow-texture and
+    direct-variable sites, which shared the hazard. Measured on a Tesla P40
+    (Chariot, Forward+): SDFGI WGSL parse failures 1 -> 0, cascading
+    invalid-module 1 -> 0, `GPUValidationError` 14 -> 6 (with 0025).
+
+25. `0025-webgpu-render-pass-needs-an-attachment.patch` - a render pass needs an
+    attachment, so stop claiming side-effects-only is supported. The driver
+    answered `SUPPORTS_FRAGMENT_SHADER_WITH_ONLY_SIDE_EFFECTS` true behind a
+    comment asserting WebGPU render passes work with no color attachments; WebGPU
+    requires at least one color or depth-stencil attachment and reports exactly
+    that ("No attachment was specified."). Godot already has the fallback for
+    APIs that cannot rasterize on side effects alone: answering false makes
+    `cluster_builder_rd.cpp` create a real color attachment and select the
+    `USE_ATTACHMENT` shader variant 0015 added, at the cost of one unused color
+    attachment on the cluster-build pass. Measured on a Tesla P40 (Chariot,
+    Forward+): attachmentless render-pass errors 2 -> 0, `GPUValidationError`
+    14 -> 6 (with 0024).
+
+26. `0026-scene-shader-subgroup-fallback.patch` - give the clustered scene
+    shader the no-subgroups path 0015 gave only the cluster builder.
+    `scene_forward_clustered.glsl` calls `subgroupMin`/`subgroupMax`/
+    `subgroupOr`/`subgroupBroadcastFirst` with no `#ifdef`, and its include
+    enables the subgroup extensions unconditionally, so the scene shader failed
+    translation ('subgroupOr' must only be called from subgroup uniform control
+    flow), no cluster builder was ever created, and `_render_scene` returned
+    early on `current_cluster_builder` null every frame - nothing drawn, and no
+    validation error to point at why. The reductions are a divergence
+    optimisation, not a correctness requirement, so the fallback is four identity
+    macros in `scene_forward_clustered_inc.glsl` behind `USE_SUBGROUPS`, which
+    `render_forward_clustered.cpp` now defines only when the device reports
+    ballot + arithmetic subgroup ops in the fragment stage - the same test
+    `cluster_builder_rd.cpp` already applies.
+
+27. `0027-webgpu-request-depth32float-stencil8.patch` - request the
+    `depth32float-stencil8` device feature. Forward+ allocates its depth-stencil
+    target as `D32_SFLOAT_S8_UINT`, which WebGPU exposes only behind that
+    optional feature, and using it without the feature enabled is not a
+    validation error - `createRenderPipeline` throws a `TypeError` that stops the
+    renderer outright, so nothing after it draws. The JS shell already filters an
+    optional-feature list against `adapter.features`, so this is one entry and
+    adapters without the feature are unaffected. Forward Mobile never requested
+    stencil alongside a 32-bit depth buffer, which is why the gap only surfaces
+    once Forward+ gets far enough to create its depth attachment.
+
+28. `0028-webgpu-depth-support-from-the-device.patch` - answer D32 depth support
+    from the device, not a table; 0027 is only half of the negotiation.
+    `texture_get_usages_supported_by_format()` reported a format supported
+    whenever its `WGPUTextureFormat` enum existed, so on an adapter without
+    `depth32float-stencil8` Godot still selects `D32_SFLOAT_S8_UINT`, never
+    reaches its own `D24_UNORM_S8_UINT` fallback, and texture creation fails with
+    no fallback left. The authority is now the created GPUDevice's enabled
+    feature set, mirroring the BC/ETC2/ASTC gating the same function already
+    applies, and the choice is reported once at device creation under
+    `--verbose`. NOT VERIFIED on hardware lacking the feature - the Tesla P40
+    exposes it, so the fallback branch has never executed here; recorded as
+    unmeasured in `docs/architecture/webgpu-runtime-status.md` rather than
+    claimed.
+
+29. `0029-webgpu-unused-color-targets-are-absent.patch` - an unused color target
+    is absent, not `rgba8unorm`. Unused fragment output locations were filled
+    with a placeholder `WGPUTextureFormat_RGBA8Unorm` plus a None write mask, but
+    masking writes does not make a target absent, and the render-pass path
+    already emitted a null view for the same slot, so pipeline and pass disagreed
+    on every Forward+ scene pipeline. An unused location now emits
+    `WGPUTextureFormat_Undefined`, with holes preserved in place rather than
+    compacted, because Godot reserves stable `@location()`s for optional outputs
+    such as separate specular and motion vectors. Measured on a Tesla P40
+    (Chariot, Forward+): attachment-state incompatibility 1018 -> 0, cascading
+    invalid CommandBuffer 1005 -> 0, `GPUValidationError` 9004 -> 4780 -
+    confirmed by pairing rather than by count (44 distinct pipeline/pass pairs,
+    zero mismatches). Still no frame; the remaining classes are unrelated to
+    attachments: sampler2DMS binding, comparison-sampler-as-non-comparison, and
+    two storage format-promotion mismatches.
+
+30. `0030-webgpu-view-format-follows-the-texture.patch` - a texture view must
+    follow the physical format, not the logical one. R8/RG8/R16/RG16 are not
+    WebGPU storage texel formats, so textures in them are promoted to 32-bit at
+    creation, but `texture_create_shared` and `texture_create_shared_from_slice`
+    took the view format straight from Godot, which supplies the LOGICAL format -
+    an r16float view of an r32float texture. An invalid view is not a local
+    failure: every bind group referencing it goes invalid, and so does the
+    command buffer holding those draws, which is why the 3D scene was black while
+    the separately-encoded 2D canvas kept presenting. `_view_format_for_texture`
+    promotes the requested format the same way the texture was promoted, and
+    passes genuine reinterpretations through unchanged for WebGPU to rule on
+    rather than inventing an answer. Measured on a Tesla P40 (headed
+    Chrome/WebGPU, Chariot, Forward+): distinct bind-group failure classes
+    4 -> 2, R16Float-view-of-R32Float 2 -> 0, [Invalid TextureView] cascades
+    2 -> 0. Still black; the next root failure in command order is the SSAO
+    interleave layout, addressed in 0032.
+
+31. `0031-webgpu-shared-view-physical-format-invariant.patch` - generalise the
+    0030 invariant, which was narrower than it claimed. "Promotes to the same
+    thing" admits reinterpretations the caller never declared, and promotion is
+    not the only physical transformation this driver performs: where
+    `float32-filterable` is unavailable, some logical float32 textures are
+    allocated as float16, and 0030 would have resolved a later shared view of one
+    back to float32 - recreating the exact class of invalid view it was written
+    to eliminate. `_resolve_shared_view_format()` states the rule in both
+    directions: a shared or sliced view of the same logical texture inherits the
+    physical format, whatever transformation produced it, and only a format
+    declared in the texture's viewFormats may differ - exactly one is declared,
+    the linear/sRGB counterpart. The format is also resolved before the WGTexture
+    wrapper is allocated (no leak on the error path), and `tex->format` is now
+    assigned in both paths. No measured change on the Tesla P40, and none
+    expected - it reports texture-formats-tier1 AND float32-filterable, so
+    neither transformation is exercised; the float32-to-float16 case is
+    UNVERIFIED on hardware, recorded as unmeasured exactly like the 0028
+    fallback.
+
+32. `0032-godot-ssao-interleave-r8-backport.patch` - match the SSAO interleave
+    storage image to its R8 AO target. `ssao_interleave.glsl` declares its
+    destination image `rgba8` while `ssao_allocate_buffers()` allocates RB_FINAL
+    as `R8_UNORM`, and WebGPU requires the layout's storage-texture format to
+    equal the bound texture's exactly. Not a missed promotion - the adapter
+    reports texture-formats-tier1, so r8unorm is natively valid for storage and
+    `_promote_storage_format` deliberately preserves it - and not the 0021/0029
+    placeholder defect, because the runtime WGSL faithfully reflects the shader.
+    The declaration itself is stale: upstream Godot already corrected it to
+    `layout(r8, ...)` in d9ea5c261eb6 (2026-05-06), so this is an unconditional
+    backport - the declaration was wrong on every backend - removable once the
+    engine pin moves to a Godot containing that commit. Measured on a Tesla P40
+    (headed Chrome/WebGPU, Chariot, Forward+): R8Unorm-vs-RGBA8Unorm bind-group
+    failures 1 -> 0, distinct bind-group failure classes 2 -> 1. Scene-bearing
+    submissions were still rejected at this point: `commandEncoder.finish` 6708
+    calls / 514 invalid, `queue.submit` 514 rejected, every rejected submission
+    carrying SceneForwardClusteredShaderRD and none carrying Sky/Tonemap/Canvas/
+    Blit.
+
+33. `0033-godot-volumetric-fog-remove-unused-shadow-sampler.patch` - remove the
+    dead `shadow_sampler` that was the last remaining bind-group failure.
+    `volumetric_fog_process.glsl` declares `sampler shadow_sampler` at binding 11
+    and never references it - every real shadow read builds its sampled image
+    from `linear_sampler` - so reflection's ShaderStage::None visibility and
+    filtering sampler type were the right description of a dead resource, while
+    `fog.cpp` nevertheless inserts the renderer's comparison-enabled sampler
+    there, and zero visibility does not exempt an entry from bind-group resource
+    validation. The resource is dead, so the declaration and its uniform block
+    are removed rather than described more accurately; bindings are explicitly
+    numbered, so 11 leaves a hole and WebGPU binding 22 simply ceases to exist.
+    Not a backport - current Godot master still carries the declaration, and
+    removal is a clean upstream-PR candidate because the resource is statically
+    unreachable. With it the failure count reaches 0: first verified Forward+
+    frame, 2026-07-28, Tesla P40, headed Chrome/WebGPU - 59 fps, 188 objects /
+    2,015,266 primitives, 0 rejected command buffers, 0 wasm traps; 0 invalid
+    `commandEncoder.finish` out of 10,842, 0 rejected `queue.submit`.
+
 The WebGPU implementation originated in `dwalter/godotwebgpu`. Studio
 Foundation owns the 4.7.1 port, scoped patch curation, preparation/build tooling,
 and validation. See `../../docs/architecture/webgpu-integration.md` for the
@@ -189,7 +358,7 @@ separately under `engine/toolchain/patches/`. It isolates Dawn's private
 `RefCounted` type from Godot's type of the same name and is independently
 checksum-locked in `engine-lock.toml`.
 
-As of 2026-07-24 the release/debug rebuild and the engine-owned browser WebGPU
-probe (active canvas context + 1.2% visual diff vs the WebGL baseline) both pass;
-the accepted templates are checksum-locked in
-`engine-lock.toml [artifacts.export_templates]`.
+The patch series is 0001-0033. The p0033 export templates render Forward+ with
+zero validation errors - first verified frame 2026-07-28 on an NVIDIA Tesla P40
+under headed Chrome/WebGPU. The accepted template hashes remain checksum-locked
+in `engine-lock.toml [artifacts.export_templates]`.

--- a/justfile
+++ b/justfile
@@ -381,6 +381,10 @@ ci-local:
 secret-scan:
     uv run --project tools python tools/ci/secret_scan.py
 
+# Fail when prose (README counts, public claims) drifts from the pinned artifacts
+check-claims:
+    uv run --project tools python tools/ci/check_claims.py
+
 sbom:
     {{PY}} tools/release/make_sbom.py
 

--- a/justfile
+++ b/justfile
@@ -231,6 +231,11 @@ bforge-gallery:
 bforge-catalog:
     uv run --project tools python tools/bforge/bforge/cli.py catalog --refresh --reference docs/bforge/OPS.md
 
+# Compile a Recipe IR document (ADR 0018): content hash -> cache -> gates -> proof capsule.
+#   just RECIPE=tools/bforge/examples/recipes/crate.json bforge-cook
+bforge-cook:
+    uv run --project tools python tools/bforge/bforge/cli.py cook "{{RECIPE}}"
+
 # ------------------------------------------------------------------ exports
 
 # WebGL2 Compatibility export — works with official installed templates

--- a/scripts/ci/run_all.py
+++ b/scripts/ci/run_all.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
-PR_RECIPES: tuple[str, ...] = ("test", "lint", "secret-scan")
+PR_RECIPES: tuple[str, ...] = ("test", "lint", "secret-scan", "check-claims")
 STAGE_RECIPES: dict[str, tuple[str, ...]] = {
     "pr": PR_RECIPES,
     "nightly": PR_RECIPES

--- a/tools/bforge/README.md
+++ b/tools/bforge/README.md
@@ -130,7 +130,7 @@ tools/bforge/
     daemon.py          JSON-line RPC loop
     registry.py        @op decorator: types, coercion, schema generation
     lib/               mesh, uvs, materials, scene-graph, finishing pass
-    ops/               the 130 operations, grouped by namespace
+    ops/               the 136 operations, grouped by namespace
   catalog.json       committed op snapshot (so tools/list needs no Blender)
   tests/             unit + live-integration + visual gallery
 ```
@@ -211,7 +211,7 @@ wrong" that no metric shows.
 
 ## What it can make
 
-130 ops across 19 namespaces. Full reference: [`docs/bforge/OPS.md`](../../docs/bforge/OPS.md).
+136 ops across 21 namespaces. Full reference: [`docs/bforge/OPS.md`](../../docs/bforge/OPS.md).
 
 - **`prop.*`** — crate, barrel, chest, sack, rock, crystal, tree, pillar, torch,
   fence, furniture, weapon, banner, debris

--- a/tools/bforge/bench.py
+++ b/tools/bforge/bench.py
@@ -70,29 +70,50 @@ def brief_crate(forge: Forge) -> dict:
 
 
 def brief_wolf(forge: Forge) -> dict:
-    forge.call("char.creature", name="bench_wolf", plan="canine", length=1.3,
-               shoulder=0.85, bulk=1.15, skin="#4a3c30", seed=13)
-    rig = forge.call("char.creature_rig", name="bench_wolf", plan="canine",
-                     length=1.3, shoulder=0.85)
+    forge.call(
+        "char.creature",
+        name="bench_wolf",
+        plan="canine",
+        length=1.3,
+        shoulder=0.85,
+        bulk=1.15,
+        skin="#4a3c30",
+        seed=13,
+    )
+    rig = forge.call(
+        "char.creature_rig", name="bench_wolf", plan="canine", length=1.3, shoulder=0.85
+    )
     forge.call("char.gait", rig=rig["armature"], speed=2.0)
-    return {"objects": ["bench_wolf", rig["armature"]],
-            "requires": {"skins_min": 1, "animations_min": 1, "vertex_color": True}}
+    return {
+        "objects": ["bench_wolf", rig["armature"]],
+        "requires": {"skins_min": 1, "animations_min": 1, "vertex_color": True},
+    }
 
 
 def brief_warden(forge: Forge) -> dict:
-    forge.call("char.humanoid", name="bench_warden", height=1.82, build="heroic",
-               skin="#b08a68", seed=3)
+    forge.call(
+        "char.humanoid", name="bench_warden", height=1.82, build="heroic", skin="#b08a68", seed=3
+    )
     forge.call("char.face", name="bench_warden", height=1.82)
     forge.call("char.hands", name="bench_warden", height=1.82)
     pieces = []
-    for piece, mat in (("cuirass", "bronze"), ("pteruges", "leather"),
-                       ("greaves", "bronze"), ("helmet", "bronze")):
-        pieces.append(forge.call("char.outfit", name="bench_warden", piece=piece,
-                                 height=1.82, material=mat)["object"])
+    for piece, mat in (
+        ("cuirass", "bronze"),
+        ("pteruges", "leather"),
+        ("greaves", "bronze"),
+        ("helmet", "bronze"),
+    ):
+        pieces.append(
+            forge.call("char.outfit", name="bench_warden", piece=piece, height=1.82, material=mat)[
+                "object"
+            ]
+        )
     rig = forge.call("char.rig", name="bench_warden", height=1.82, build="heroic")
     forge.call("char.gait", rig=rig["armature"], speed=1.4)
-    return {"objects": ["bench_warden", rig["armature"]] + pieces,
-            "requires": {"skins_min": 1, "animations_min": 1, "materials_min": 4}}
+    return {
+        "objects": ["bench_warden", rig["armature"]] + pieces,
+        "requires": {"skins_min": 1, "animations_min": 1, "materials_min": 4},
+    }
 
 
 def brief_camp(forge: Forge) -> dict:
@@ -102,10 +123,19 @@ def brief_camp(forge: Forge) -> dict:
 
 
 def brief_concept(forge: Forge, concept: Path) -> dict:
-    result = forge.call("image.to_mesh", path=str(concept), name="bench_medallion",
-                        target_height=1.0, depth=0.2, texture="none")
-    return {"objects": ["bench_medallion"],
-            "requires": {"meshes_min": 1}, "iou": result["silhouette_iou"]}
+    result = forge.call(
+        "image.to_mesh",
+        path=str(concept),
+        name="bench_medallion",
+        target_height=1.0,
+        depth=0.2,
+        texture="none",
+    )
+    return {
+        "objects": ["bench_medallion"],
+        "requires": {"meshes_min": 1},
+        "iou": result["silhouette_iou"],
+    }
 
 
 def brief_finishing(forge: Forge) -> dict:
@@ -114,8 +144,16 @@ def brief_finishing(forge: Forge) -> dict:
     unwrap -> transfer-bake -> gate. Determinism here is what makes the neural
     pipeline trustworthy.
     """
-    forge.call("char.creature", name="bench_soup_source", plan="canine", length=1.3,
-               shoulder=0.85, bulk=1.15, skin="#4a3c30", seed=13)
+    forge.call(
+        "char.creature",
+        name="bench_soup_source",
+        plan="canine",
+        length=1.3,
+        shoulder=0.85,
+        bulk=1.15,
+        skin="#4a3c30",
+        seed=13,
+    )
     soup_path = OUT_DIR / "out" / "bench_soup.glb"
     forge.call("export.gltf", out="bench_soup.glb", objects=["bench_soup_source"])
     forge.call("session.reset")
@@ -124,10 +162,19 @@ def brief_finishing(forge: Forge) -> dict:
     forge.call("build.subdivide", name="bench_finished", cuts=1)
     forge.call("mesh.retopo", name="bench_finished", voxel_size=0.025)
     forge.call("uv.unwrap", object="bench_finished", style="smart_packed")
-    forge.call("bake.transfer", source="soup_bench_soup_source", target="bench_finished",
-               maps=["base_color"], size=256, samples=4, ray_distance=0.08)
-    return {"objects": ["bench_finished"],
-            "requires": {"meshes_min": 1, "materials_min": 1, "textures_min": 1}}
+    forge.call(
+        "bake.transfer",
+        source="soup_bench_soup_source",
+        target="bench_finished",
+        maps=["base_color"],
+        size=256,
+        samples=4,
+        ray_distance=0.08,
+    )
+    return {
+        "objects": ["bench_finished"],
+        "requires": {"meshes_min": 1, "materials_min": 1, "textures_min": 1},
+    }
 
 
 BRIEFS = [
@@ -151,13 +198,16 @@ def verify(glb_path: Path, requires: dict) -> list[str]:
     if len(parsed.get("animations", [])) < requires.get("animations_min", 0):
         failures.append("no animations exported")
     if len(parsed.get("materials", [])) < requires.get("materials_min", 0):
-        failures.append(f"materials {len(parsed.get('materials', []))} < {requires['materials_min']}")
+        failures.append(
+            f"materials {len(parsed.get('materials', []))} < {requires['materials_min']}"
+        )
     if len(parsed.get("images", [])) < requires.get("textures_min", 0):
         failures.append("no baked textures exported")
     if requires.get("vertex_color"):
         has_vcol = any(
             "COLOR_0" in (prim.get("attributes") or {})
-            for mesh in meshes for prim in mesh.get("primitives", [])
+            for mesh in meshes
+            for prim in mesh.get("primitives", [])
         )
         if not has_vcol:
             failures.append("no COLOR_0 vertex colours exported")
@@ -174,7 +224,7 @@ def forensics(a: bytes, b: bytes) -> str:
     off = 20 + la
     bin_a = a[off + 8 :]
     bin_b = b[off + 8 :]
-    diffs = [i for i, (x, y) in enumerate(zip(bin_a, bin_b)) if x != y]
+    diffs = [i for i, (x, y) in enumerate(zip(bin_a, bin_b, strict=False)) if x != y]
     if not diffs:
         return "chunks equal but files differ (padding?)"
     first = diffs[0]
@@ -183,22 +233,30 @@ def forensics(a: bytes, b: bytes) -> str:
     fb = struct.unpack_from("<2f", bin_b, base)
     ia = struct.unpack_from("<2I", bin_a, base)
     ib = struct.unpack_from("<2I", bin_b, base)
-    return (f"BIN chunk: {len(diffs)} bytes differ from offset {first}; "
-            f"as floats {fa} vs {fb}; as uints {ia} vs {ib}")
+    return (
+        f"BIN chunk: {len(diffs)} bytes differ from offset {first}; "
+        f"as floats {fa} vs {fb}; as uints {ia} vs {ib}"
+    )
 
 
 def main() -> None:
     runs = int(sys.argv[1]) if len(sys.argv) > 1 else 1
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     concept = OUT_DIR / "_bench_concept.png"
-    _png_rgba(concept, 128, 128,
-              lambda x, y: (200, 30, 30, 255) if (x - 64) ** 2 + (y - 64) ** 2 < 40 ** 2
-              else (12, 12, 16, 255))
+    _png_rgba(
+        concept,
+        128,
+        128,
+        lambda x, y: (
+            (200, 30, 30, 255) if (x - 64) ** 2 + (y - 64) ** 2 < 40**2 else (12, 12, 16, 255)
+        ),
+    )
 
     report = {"bench": "bforge bench v2", "runs": [], "aggregates": {}}
     all_ok = True
-    with Forge(workdir=tempfile.mkdtemp(prefix="bforge_bench_"),
-               out_dir=str(OUT_DIR / "out")) as forge:
+    with Forge(
+        workdir=tempfile.mkdtemp(prefix="bforge_bench_"), out_dir=str(OUT_DIR / "out")
+    ) as forge:
         for title, brief_fn in BRIEFS:
             for iteration in range(runs):
                 hashes = []
@@ -213,8 +271,9 @@ def main() -> None:
                         built = brief_fn(forge, concept)
                     else:
                         built = brief_fn(forge)
-                    glb = forge.call("export.gltf", out=f"{built['objects'][0]}.glb",
-                                     objects=built["objects"])
+                    glb = forge.call(
+                        "export.gltf", out=f"{built['objects'][0]}.glb", objects=built["objects"]
+                    )
                     payload = Path(glb["path"]).read_bytes()
                     hashes.append(hashlib.sha256(payload).hexdigest())
                     export_bytes.append(payload)
@@ -229,7 +288,8 @@ def main() -> None:
                 deterministic = hashes[0] == hashes[1]
                 if not deterministic:
                     failures.append(
-                        f"nondeterministic export: {forensics(export_bytes[0], export_bytes[1])}")
+                        f"nondeterministic export: {forensics(export_bytes[0], export_bytes[1])}"
+                    )
                 ok = review["passed"] and not failures
                 all_ok = all_ok and ok
                 entry = {
@@ -249,10 +309,12 @@ def main() -> None:
                     entry["silhouette_iou"] = built["iou"]
                 report["runs"].append(entry)
                 mark = "ok " if ok else "FAIL"
-                print(f"  {mark} {title} #{iteration + 1}: {glb['triangles']} tris, "
-                      f"{seconds}s, gate {entry['gate']}, "
-                      f"{'deterministic' if deterministic else 'NONDETERMINISTIC'}"
-                      + (f" (iou {built['iou']})" if "iou" in built else ""))
+                print(
+                    f"  {mark} {title} #{iteration + 1}: {glb['triangles']} tris, "
+                    f"{seconds}s, gate {entry['gate']}, "
+                    f"{'deterministic' if deterministic else 'NONDETERMINISTIC'}"
+                    + (f" (iou {built['iou']})" if "iou" in built else "")
+                )
 
     total = len(report["runs"])
     passed = sum(1 for r in report["runs"] if r["ok"])
@@ -268,12 +330,17 @@ def main() -> None:
     }
     (OUT_DIR / "report.json").write_text(json.dumps(report, indent=2) + "\n")
 
-    summary = ["# bforge bench", "",
-               f"verdict: **{report['aggregates']['verdict'].upper()}** — "
-               f"{passed}/{total} runs green, "
-               f"{'all briefs byte-identical across regeneration' if deterministic_all else 'DETERMINISM FAILURE'} "
-               f"({report['aggregates']['total_triangles']} triangles total)", "",
-               "| brief | tris | gate | deterministic | structure |", "| --- | --- | --- | --- | --- |"]
+    summary = [
+        "# bforge bench",
+        "",
+        f"verdict: **{report['aggregates']['verdict'].upper()}** — "
+        f"{passed}/{total} runs green, "
+        f"{'all briefs byte-identical across regeneration' if deterministic_all else 'DETERMINISM FAILURE'} "
+        f"({report['aggregates']['total_triangles']} triangles total)",
+        "",
+        "| brief | tris | gate | deterministic | structure |",
+        "| --- | --- | --- | --- | --- |",
+    ]
     for r in report["runs"]:
         summary.append(
             f"| {r['brief']} | {r['triangles']} | {r['gate']} | "
@@ -281,22 +348,30 @@ def main() -> None:
             f"{'ok' if not r['structure_failures'] else ', '.join(r['structure_failures'])} |"
         )
     summary.append("")
-    summary.append("Every brief is forged twice from a reset session and the two GLB exports "
-                   "must hash identically (SHA-256 in report.json) — determinism is a checked "
-                   "property, not a slogan. Wall-clock seconds live in report.json "
-                   "(machine-dependent); this file carries only deterministic outputs and is "
-                   "what CI diffs.")
+    summary.append(
+        "Every brief is forged twice from a reset session and the two GLB exports "
+        "must hash identically (SHA-256 in report.json) — determinism is a checked "
+        "property, not a slogan. Wall-clock seconds live in report.json "
+        "(machine-dependent); this file carries only deterministic outputs and is "
+        "what CI diffs."
+    )
     summary.append("")
-    summary.append("Scope: programmatic op briefs over the persistent daemon — this bench proves "
-                   "the ops, gates, and export; natural-language brief evaluation is the "
-                   "BRIEF->BATTLE track (strategy/FRONTIER.md).")
+    summary.append(
+        "Scope: programmatic op briefs over the persistent daemon — this bench proves "
+        "the ops, gates, and export; natural-language brief evaluation is the "
+        "BRIEF->BATTLE track (strategy/FRONTIER.md)."
+    )
     summary.append("")
-    summary.append("Rerun: `uv run --project tools python tools/bforge/bench.py [runs]` — "
-                   "the numbers are produced by the runner, not by memory.")
+    summary.append(
+        "Rerun: `uv run --project tools python tools/bforge/bench.py [runs]` — "
+        "the numbers are produced by the runner, not by memory."
+    )
     (OUT_DIR / "SUMMARY.md").write_text("\n".join(summary) + "\n")
 
-    print(f"\nbench verdict: {report['aggregates']['verdict']} "
-          f"({passed}/{total} green, report -> {OUT_DIR})")
+    print(
+        f"\nbench verdict: {report['aggregates']['verdict']} "
+        f"({passed}/{total} green, report -> {OUT_DIR})"
+    )
     sys.exit(0 if all_ok else 1)
 
 

--- a/tools/bforge/bforge/cli.py
+++ b/tools/bforge/bforge/cli.py
@@ -227,6 +227,28 @@ def cmd_make(args) -> int:
         forge.stop()
 
 
+def cmd_cook(args) -> int:
+    """Compile a Recipe IR document: cache check -> worker -> gates -> proof."""
+    from bforge import recipe as recipe_mod
+
+    def factory() -> Forge:
+        return _forge(args)
+
+    try:
+        proof = recipe_mod.cook(
+            args.file,
+            cache_dir=args.cache_dir,
+            no_cache=args.no_cache,
+            forge_factory=factory,
+            allow_unpinned=args.allow_unpinned,
+        )
+    except recipe_mod.RecipeError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2), file=sys.stderr)
+        return 1
+    _emit(proof, True)
+    return 0
+
+
 def cmd_catalog(args) -> int:
     if args.refresh:
         forge = _forge(args)
@@ -345,6 +367,19 @@ def build_parser() -> argparse.ArgumentParser:
     make.add_argument("--prompt", default="", help="Recorded in the asset's provenance")
     make.add_argument("--timeout", type=float, default=900)
     make.set_defaults(func=cmd_make)
+
+    cook = sub.add_parser(
+        "cook", help="Compile a Recipe IR document (ADR 0017): cache, gates, proof capsule"
+    )
+    cook.add_argument("file", help="Path to the recipe JSON")
+    cook.add_argument("--cache-dir", default=None, help="Override the content-addressed cache root")
+    cook.add_argument("--no-cache", action="store_true", help="Rebuild even when a pass is cached")
+    cook.add_argument(
+        "--allow-unpinned",
+        action="store_true",
+        help="Permit a Blender other than blender-lock.toml's pin; results are never cached",
+    )
+    cook.set_defaults(func=cmd_cook)
 
     catalog = sub.add_parser("catalog", help="Show or regenerate the committed op catalog")
     catalog.add_argument("--refresh", action="store_true")

--- a/tools/bforge/bforge/recipe.py
+++ b/tools/bforge/bforge/recipe.py
@@ -1,0 +1,554 @@
+"""Asset Recipe IR v1 — declarative, content-hashed, proof-carrying builds.
+
+ADR 0018: an asset is declared, not performed. A recipe names its inputs,
+its op steps, and its requirements; the compiler canonicalizes and hashes
+them, consults a content-addressed cache, and only then pays for a Blender
+worker. Whatever happens, the run writes a proof capsule — recipe hash, tool
+identities, gate results, artifact hashes — so an asset is accepted because
+it carries evidence, not because an agent says it is finished.
+
+A cache hit returns the verified proof without constructing a Forge at all,
+so proof retrieval works on machines with no Blender installed. The cache key
+fingerprints the COMPILER, not just the recipe: the bforge source tree (so a
+dirty working tree is a different compiler), the committed catalog, the pinned
+Blender toolchain, and the canonicalization version. A hit is re-verified —
+every artifact is re-hashed against the proof before it is returned.
+
+Recipes are JSON because the tooling is deliberately stdlib-only (ADR 0013).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import secrets
+import shutil
+import time
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+
+RECIPE_VERSION = 1
+PROOF_VERSION = 1
+CANONICALIZATION = "bforge-json-c14n-v1"
+CACHE_SCHEMA = "bforge.recipe.v1"
+
+BFORGE_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CACHE = BFORGE_ROOT / "cache"
+
+_META_FILES = ("proof.json", "recipe.canonical.json")
+
+
+class RecipeError(Exception):
+    """A recipe is malformed, an input does not match its declared hash, or a
+    requirement/gate failed."""
+
+
+def _strict_loads(text: str, source: str):
+    """JSON with no NaN/Infinity — non-finite floats are not valid JSON and
+    must never silently enter a proof or a recipe."""
+
+    def reject(value):
+        raise RecipeError(f"{source}: non-finite constant {value!r} is not valid JSON")
+
+    try:
+        return json.loads(text, parse_constant=reject)
+    except json.JSONDecodeError as exc:
+        raise RecipeError(f"{source}: not valid JSON: {exc}") from exc
+
+
+def load_recipe(path: Path) -> dict:
+    recipe = _strict_loads(Path(path).read_text(encoding="utf-8"), str(path))
+    if not isinstance(recipe, dict):
+        raise RecipeError(f"{path}: a recipe is a JSON object")
+    version = recipe.get("recipe_version")
+    if version != RECIPE_VERSION:
+        raise RecipeError(f"{path}: unsupported recipe_version {version!r} (want {RECIPE_VERSION})")
+    asset_id = recipe.get("asset_id")
+    if not asset_id or not isinstance(asset_id, str):
+        raise RecipeError(f"{path}: asset_id is required")
+    steps = recipe.get("steps")
+    if not isinstance(steps, list) or not steps:
+        raise RecipeError(f"{path}: steps must be a non-empty list")
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict) or not isinstance(step.get("op"), str):
+            raise RecipeError(f"{path}: step {i} needs an op name")
+        if not isinstance(step.get("args", {}), dict):
+            raise RecipeError(f"{path}: step {i} args must be an object")
+    for key in ("inputs", "requirements", "export"):
+        if key in recipe and not isinstance(recipe[key], dict):
+            raise RecipeError(f"{path}: {key} must be an object")
+    return recipe
+
+
+def canonicalize(recipe: dict) -> bytes:
+    """Byte-stable form: the same recipe always hashes the same, regardless of
+    key order or whitespace in the source file."""
+    return json.dumps(recipe, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def hash_inputs(recipe: dict, base_dir: Path) -> dict[str, str]:
+    """Hash every declared input file. A declared sha256 is verified — recipes
+    treat their inputs as untrusted, so a silent substitution is a hard error."""
+    hashes: dict[str, str] = {}
+    for name, spec in sorted(recipe.get("inputs", {}).items()):
+        if not isinstance(spec, dict) or not spec.get("path"):
+            raise RecipeError(f"input {name!r} needs a path")
+        path = (base_dir / spec["path"]).resolve()
+        if not path.is_file():
+            raise RecipeError(f"input {name!r}: no such file: {path}")
+        actual = _sha256_file(path)
+        declared = spec.get("sha256")
+        if declared and declared != actual:
+            raise RecipeError(
+                f"input {name!r} hash mismatch: declared {declared}, actual {actual} "
+                "— the input changed; update the recipe deliberately"
+            )
+        hashes[name] = actual
+    return hashes
+
+
+def content_hash(recipe: dict, input_hashes: dict[str, str]) -> str:
+    """One hash covering the recipe document and the real bytes of its inputs."""
+    digest = hashlib.sha256()
+    digest.update(canonicalize(recipe))
+    for name, value in sorted(input_hashes.items()):
+        digest.update(f"{name}={value}\n".encode())
+    return digest.hexdigest()
+
+
+def compiler_fingerprint() -> dict:
+    """Fingerprint the COMPILER, so a cache entry is only reused by the same
+    implementation that produced it.
+
+    The tree hash covers every bforge client/runtime Python source — including
+    uncommitted edits, because a dirty working tree IS a different compiler.
+    A git commit alone could not say that. The pinned Blender identity comes
+    from blender-lock.toml (the archive hash CI verifies), and the catalog
+    hash pins the published op surface.
+    """
+    tree = hashlib.sha256()
+    sources = sorted(BFORGE_ROOT.glob("bforge/*.py")) + sorted(BFORGE_ROOT.glob("runtime/**/*.py"))
+    for path in sources:
+        if "__pycache__" in path.parts:
+            continue
+        tree.update(path.relative_to(BFORGE_ROOT).as_posix().encode())
+        tree.update(_sha256_file(path).encode())
+    blender: dict = {}
+    lock_path = BFORGE_ROOT / "blender-lock.toml"
+    if lock_path.is_file():
+        lock = tomllib.loads(lock_path.read_text(encoding="utf-8")).get("blender", {})
+        blender = {"version": lock.get("version"), "archive_sha256": lock.get("sha256")}
+    catalog_path = BFORGE_ROOT / "catalog.json"
+    return {
+        "bforge_tree_sha256": tree.hexdigest(),
+        "catalog_sha256": _sha256_file(catalog_path) if catalog_path.is_file() else None,
+        "blender": blender,
+        "python": platform.python_version(),
+    }
+
+
+def cache_key(
+    recipe: dict, input_hashes: dict[str, str], fingerprint: dict | None = None
+) -> tuple[str, dict]:
+    """The content address: recipe + inputs + compiler, canonicalized."""
+    envelope = {
+        "schema": CACHE_SCHEMA,
+        "canonicalization": CANONICALIZATION,
+        "recipe_sha256": content_hash(recipe, input_hashes),
+        "inputs": input_hashes,
+        "compiler": fingerprint if fingerprint is not None else compiler_fingerprint(),
+    }
+    return hashlib.sha256(canonicalize(envelope)).hexdigest(), envelope
+
+
+def _verify_cached_artifacts(proof: dict, out_dir: Path) -> bool:
+    """Artifact-level integrity: every recorded artifact exists, hashes match,
+    and the directory contains exactly the recorded set (no stale passengers)."""
+    artifacts = proof.get("artifacts", [])
+    if not artifacts:
+        return False
+    recorded: set[str] = set()
+    for artifact in artifacts:
+        rel = artifact.get("path", "")
+        # normalized, contained relative paths only
+        if not rel or rel.startswith("/") or rel.startswith("../") or "/../" in rel or "\\" in rel:
+            return False
+        recorded.add(rel)
+        path = out_dir / rel
+        if not path.is_file() or _sha256_file(path) != artifact.get("sha256"):
+            return False
+    on_disk = {
+        p.relative_to(out_dir).as_posix()
+        for p in out_dir.rglob("*")
+        if p.is_file() and p.name not in _META_FILES
+    }
+    return recorded == on_disk
+
+
+def verify_entry(proof: dict, out_dir: Path, expected: dict) -> bool:
+    """Full identity check for a cache entry: the proof must BE the answer to
+    THIS request, not merely a pass-stamped file with intact artifacts.
+
+    Checking only the artifacts named by a proof lets edited metadata (a
+    tampered toolchain or gate verdict) ride along — that is a chain of hashes
+    attached to an unverified claim, not a cryptographic chain.
+    """
+    if proof.get("proof_version") != PROOF_VERSION or proof.get("status") != "pass":
+        return False
+    for field in ("asset_id", "recipe_hash", "cache_key", "inputs"):
+        if proof.get(field) != expected[field]:
+            return False
+    if proof.get("cache", {}).get("envelope") != expected["envelope"]:
+        return False
+    canonical = out_dir / "recipe.canonical.json"
+    if not canonical.is_file() or canonical.read_bytes() != expected["canonical"]:
+        return False
+    # the toolchain record must match the pinned identity it claims
+    pinned = expected.get("pinned")
+    if pinned and proof.get("cache", {}).get("cacheable") is not False:
+        reported = proof.get("toolchain", {}).get("blender", "")
+        if not reported.startswith(pinned):
+            return False
+    # the recorded gates must be exactly the ones the requirements demand,
+    # with passing verdicts — a flipped or dropped verdict invalidates the entry
+    requirements = expected.get("requirements", {})
+    gates = proof.get("gates", {})
+    needs_check = any(
+        k in requirements
+        for k in ("max_triangles", "max_materials", "require_collision", "require_lods")
+    )
+    if needs_check and gates.get("check.asset", {}).get("ok") is not True:
+        return False
+    if not needs_check and "check.asset" in gates:
+        return False
+    if (
+        "platform" in requirements
+        and gates.get("gameready.budget", {}).get("within_budget") is not True
+    ):
+        return False
+    if "platform" not in requirements and "gameready.budget" in gates:
+        return False
+    return _verify_cached_artifacts(proof, out_dir)
+
+
+class _KeyLock:
+    """A per-content-address mkdir lock: one builder per key. Others wait, then
+    re-verify — the winner's entry may already satisfy them."""
+
+    def __init__(self, cache_root: Path, digest: str, timeout_s: float = 120.0):
+        self.lock_dir = cache_root / "locks" / f"{digest}.lock"
+        self.timeout_s = timeout_s
+
+    def __enter__(self):
+        self.lock_dir.parent.mkdir(parents=True, exist_ok=True)
+        waited = 0.0
+        while True:
+            try:
+                self.lock_dir.mkdir()
+                return self
+            except FileExistsError as exc:
+                if waited >= self.timeout_s:
+                    raise RecipeError(
+                        f"cache key locked by another build: {self.lock_dir}"
+                    ) from exc
+                time.sleep(0.25)
+                waited += 0.25
+
+    def __exit__(self, *_exc):
+        try:
+            self.lock_dir.rmdir()
+        except OSError:
+            pass
+
+
+def _run_gates(forge, requirements: dict) -> dict:
+    """Map recipe requirements onto the live gate ops. Only declared
+    requirements are checked — an absent requirement is not a silent default."""
+    gates: dict[str, dict] = {}
+    check_args: dict = {}
+    if "max_triangles" in requirements:
+        check_args["triangle_budget"] = int(requirements["max_triangles"])
+    if "max_materials" in requirements:
+        check_args["material_budget"] = int(requirements["max_materials"])
+    if requirements.get("require_collision"):
+        check_args["require_collision"] = True
+    if requirements.get("require_lods"):
+        check_args["require_lods"] = True
+    if check_args:
+        gates["check.asset"] = forge.call("check.asset", **check_args)
+    if "platform" in requirements:
+        gates["gameready.budget"] = forge.call(
+            "gameready.budget",
+            profile=requirements["platform"],
+            asset_class=requirements.get("asset_class", "prop"),
+        )
+    return gates
+
+
+def _gate_failures(gates: dict) -> list[str]:
+    """Fail closed: a gate result without its verdict field is a failure, not a pass."""
+    failures: list[str] = []
+    check = gates.get("check.asset")
+    if check is not None:
+        if "ok" not in check:
+            failures.append("check.asset: malformed result (no 'ok' verdict)")
+        elif not check["ok"]:
+            failures.append(f"check.asset: {check.get('errors', '?')} error(s)")
+    budget = gates.get("gameready.budget")
+    if budget is not None:
+        if "within_budget" not in budget:
+            failures.append("gameready.budget: malformed result (no 'within_budget' verdict)")
+        elif not budget["within_budget"]:
+            failures.append("gameready.budget: over budget")
+    return failures
+
+
+def _hash_artifacts(directory: Path) -> list[dict]:
+    artifacts = []
+    for path in sorted(directory.rglob("*")):
+        if path.is_file() and path.name not in ("proof.json", "recipe.canonical.json"):
+            artifacts.append(
+                {
+                    "path": path.relative_to(directory).as_posix(),
+                    "bytes": path.stat().st_size,
+                    "sha256": _sha256_file(path),
+                }
+            )
+    return artifacts
+
+
+def pinned_blender_version() -> str | None:
+    lock_path = BFORGE_ROOT / "blender-lock.toml"
+    if not lock_path.is_file():
+        return None
+    return tomllib.loads(lock_path.read_text(encoding="utf-8")).get("blender", {}).get("version")
+
+
+def _check_toolchain(reported: str, allow_unpinned: bool) -> None:
+    """The byte-identical claim holds only under the pinned Blender. A cache
+    miss must be built by the pinned toolchain — otherwise the content address
+    (which fingerprints the DECLARED toolchain) would store artifacts produced
+    by a different one."""
+    pinned = pinned_blender_version()
+    if not pinned or allow_unpinned:
+        return
+    if not reported.startswith(pinned):
+        raise RecipeError(
+            f"pinned toolchain violation: blender-lock.toml requires {pinned}, "
+            f"the daemon reports {reported!r}. Install the pinned Blender or pass "
+            "--allow-unpinned (results are then never cached)."
+        )
+
+
+def cook(
+    recipe_path,
+    cache_dir: Path | None = None,
+    no_cache: bool = False,
+    forge_factory=None,
+    allow_unpinned: bool = False,
+) -> dict:
+    """Compile a recipe into artifacts plus a proof capsule.
+
+    The cache is a content-addressed store: builds happen in a unique staging
+    directory, pass full verification, and are published by atomic rename
+    under a per-key lock. Accepted entries are immutable. Failures go to the
+    failure store; `--no-cache` and unpinned builds produce verified but
+    ephemeral packages that never touch the store.
+
+    `forge_factory` is called with no arguments only on a cache miss and must
+    return a started-or-startable Forge (kept injectable so a hit never needs
+    Blender and tests can fake the worker).
+    """
+    recipe_path = Path(recipe_path).resolve()
+    recipe = load_recipe(recipe_path)
+    input_hashes = hash_inputs(recipe, recipe_path.parent)
+    digest, envelope = cache_key(recipe, input_hashes)
+    cache_root = Path(cache_dir) if cache_dir else DEFAULT_CACHE
+    objects_dir = cache_root / "objects" / digest
+    canonical = canonicalize(recipe)
+    expected = {
+        "asset_id": recipe["asset_id"],
+        "recipe_hash": content_hash(recipe, input_hashes),
+        "cache_key": digest,
+        "inputs": input_hashes,
+        "envelope": envelope,
+        "canonical": canonical,
+        "requirements": recipe.get("requirements", {}),
+        "pinned": pinned_blender_version(),
+    }
+
+    if not no_cache and (objects_dir / "proof.json").is_file():
+        proof = _strict_loads(
+            (objects_dir / "proof.json").read_text(encoding="utf-8"), "proof.json"
+        )
+        if verify_entry(proof, objects_dir, expected):
+            proof["cache"]["hit"] = True
+            return proof
+        # unverifiable or tampered entries fall through to a rebuild
+
+    if forge_factory is None:
+        from bforge.client import Forge
+
+        forge_factory = Forge
+
+    staging = cache_root / "staging" / f"{digest}.{os.getpid()}.{secrets.token_hex(4)}"
+    proof: dict = {
+        "proof_version": PROOF_VERSION,
+        "asset_id": recipe["asset_id"],
+        "recipe_hash": expected["recipe_hash"],
+        "cache_key": digest,
+        "recipe_file": recipe_path.name,
+        "inputs": input_hashes,
+        "started_utc": datetime.now(UTC).isoformat(),
+        "status": "fail",
+    }
+
+    forge = None
+    cacheable = not no_cache
+    try:
+        forge = forge_factory()
+        info = forge.start()
+        reported_blender = info.get("blender", "unknown")
+        _check_toolchain(reported_blender, allow_unpinned)
+        pinned = pinned_blender_version()
+        cacheable = cacheable and (not pinned or reported_blender.startswith(pinned))
+        staging.mkdir(parents=True, exist_ok=False)
+        (staging / "recipe.canonical.json").write_bytes(canonical)
+        proof["cache"] = {"hit": False, "dir": str(objects_dir), "envelope": envelope}
+        if not cacheable:
+            proof["cache"]["cacheable"] = False
+            reason = f"unpinned Blender {reported_blender!r} (lock pins {pinned})"
+            proof["cache"]["reason"] = "forced rebuild" if no_cache and pinned else reason
+        blender_bin = getattr(forge, "blender", None)
+        proof["toolchain"] = {
+            "blender": reported_blender,
+            "blender_binary_sha256": (
+                _sha256_file(Path(blender_bin))
+                if blender_bin and Path(blender_bin).is_file()
+                else None
+            ),
+            "python": info.get("python", "unknown"),
+            "ops": info.get("ops", 0),
+        }
+        forge.call("session.reset")
+
+        steps = []
+        for step in recipe["steps"]:
+            started = time.time()
+            result = forge.call(
+                step["op"], _timeout=step.get("timeout", 900), **step.get("args", {})
+            )
+            steps.append(
+                {
+                    "op": step["op"],
+                    "ok": True,
+                    "ms": int((time.time() - started) * 1000),
+                    "result": result,
+                }
+            )
+        proof["steps"] = steps
+
+        requirements = recipe.get("requirements", {})
+        gates = _run_gates(forge, requirements)
+        proof["gates"] = gates
+        failures = _gate_failures(gates)
+
+        export_spec = recipe.get("export", {})
+        proof["export"] = forge.call(
+            "export.asset",
+            asset_id=recipe["asset_id"],
+            out_dir=str(staging),
+            engine=export_spec.get("engine", "godot"),
+            category=export_spec.get("category", "prop"),
+            ai_prompt=export_spec.get("ai_prompt", recipe.get("brief", "")),
+            contact_sheet=export_spec.get("contact_sheet", True),
+            strict=export_spec.get("strict", True),
+            _timeout=1200,
+        )
+
+        if failures:
+            proof["status"] = "fail"
+            proof["failures"] = failures
+        else:
+            proof["status"] = "pass"
+    except Exception as exc:  # proof of failure is still proof — record it
+        proof["status"] = "fail"
+        proof["failures"] = [f"{type(exc).__name__}: {exc}"]
+        if not staging.is_dir():
+            # toolchain violations never reach the store; re-raise bare
+            if forge is not None:
+                forge.stop()
+            raise
+    finally:
+        if forge is not None:
+            forge.stop()
+
+    if staging.is_dir():
+        proof["duration_s"] = round(
+            time.time() - datetime.fromisoformat(proof["started_utc"]).timestamp(), 3
+        )
+        proof["artifacts"] = _hash_artifacts(staging)
+        (staging / "proof.json").write_text(json.dumps(proof, indent=2) + "\n", encoding="utf-8")
+
+    if proof["status"] == "pass":
+        # verify the staged package before it can be published or returned
+        staged_proof = _strict_loads(
+            (staging / "proof.json").read_text(encoding="utf-8"), "staged proof"
+        )
+        if not verify_entry(staged_proof, staging, expected):
+            proof["status"] = "fail"
+            proof["failures"] = ["staged package failed self-verification"]
+            (staging / "proof.json").write_text(
+                json.dumps(proof, indent=2) + "\n", encoding="utf-8"
+            )
+
+    if proof["status"] != "pass":
+        failure_dir = (
+            cache_root / "failures" / f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}-{digest[:12]}"
+        )
+        if staging.is_dir():
+            failure_dir.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(staging), str(failure_dir))
+        raise RecipeError(
+            f"recipe {recipe_path.name} failed: {'; '.join(proof.get('failures', ['unknown']))} "
+            f"(proof: {failure_dir / 'proof.json'})"
+        )
+
+    if cacheable:
+        with _KeyLock(cache_root, digest):
+            objects_dir.parent.mkdir(parents=True, exist_ok=True)
+            if objects_dir.is_dir():
+                # another builder won the race; verify and reuse their entry
+                theirs = _strict_loads(
+                    (objects_dir / "proof.json").read_text(encoding="utf-8"), "proof.json"
+                )
+                if verify_entry(theirs, objects_dir, expected):
+                    shutil.rmtree(staging)
+                    theirs["cache"]["hit"] = True
+                    return theirs
+                shutil.move(
+                    str(objects_dir),
+                    str(
+                        cache_root
+                        / "failures"
+                        / f"corrupt-{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}-{digest[:12]}"
+                    ),
+                )
+            os.rename(staging, objects_dir)
+        proof["cache"]["dir"] = str(objects_dir)
+        return proof
+
+    proof["cache"]["dir"] = str(staging)  # ephemeral: verified, never published
+    proof["cache"]["ephemeral"] = True
+    return proof

--- a/tools/bforge/blender-lock.toml
+++ b/tools/bforge/blender-lock.toml
@@ -1,0 +1,16 @@
+# The pinned Blender toolchain for bforge.
+#
+# This is the version hosted CI installs, the byte-identical bench verifies
+# against, and the documentation quotes (docs/architecture/dependency-licenses.md,
+# ADR 0006). The engine lock checksums Godot patches and templates; this lock
+# gives the asset compiler the same treatment — CI verifies the archive hash
+# before extracting it.
+#
+# Byte-identical output is claimed under this pinned build, on the CI OS, only.
+
+[blender]
+version = "4.5.12"
+flavor = "LTS"
+archive = "blender-4.5.12-linux-x64.tar.xz"
+url = "https://download.blender.org/release/Blender4.5/blender-4.5.12-linux-x64.tar.xz"
+sha256 = "95e3a2dfedba3bd32ca54fc355eac6b15a11986954ccb02815a07535d0120a25"

--- a/tools/bforge/catalog.json
+++ b/tools/bforge/catalog.json
@@ -5084,6 +5084,50 @@
       }
     },
     {
+      "name": "mesh.clean",
+      "summary": "Sweep a neural/scan mesh before retopo: delete floating islands below a size share of the main body, then Taubin-smooth the surface (smooth + counter-smooth, so it denoises without shrinking). Neural soup carries floaters and high-frequency noise that voxel retopo faithfully preserves \u2014 clean first or the spikes ship.",
+      "tags": [
+        "mesh"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Mesh object to clean (modified in place)"
+          },
+          "island_min_share": {
+            "type": "number",
+            "description": "Drop disconnected islands smaller than this fraction of the largest island's face count (0.02 = keep anything at least 2% of the main body)",
+            "default": 0.02
+          },
+          "smooth_iterations": {
+            "type": "integer",
+            "description": "Laplacian rounds \u2014 1-3 denoises neural output; 0 keeps the raw surface",
+            "default": 2
+          },
+          "smooth_factor": {
+            "type": "number",
+            "description": "Step size per round, capped at 0.35: a negative-volume counter-step (Taubin) was tried and SHREDDED voxel-quad meshes \u2014 plain small steps are the safe smooth",
+            "default": 0.3
+          },
+          "despike_iterations": {
+            "type": "integer",
+            "description": "Outlier-clamp passes \u2014 collapse verts sitting >threshold x the median edge length away from their neighbourhood median (the long thin spikes neural extraction leaves)",
+            "default": 2
+          },
+          "despike_threshold": {
+            "type": "number",
+            "description": "Spike cutoff as a multiple of the median edge length",
+            "default": 4.0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "mesh.retopo",
       "summary": "Rebuild a dense triangle soup (neural/scan import) as a clean all-quad mesh via voxel remesh, in place. Robust on any input \u2014 open seams, overlapping shells, interior garbage all get swallowed by the voxel grid. Destroys UVs and skin weights (unwrap again after; re-rig if it had a rig). Pair with bake.transfer to move the source's textures and detail across.",
       "tags": [

--- a/tools/bforge/examples/bestiary.py
+++ b/tools/bforge/examples/bestiary.py
@@ -25,158 +25,273 @@ UNDERWORLD_GLOW = "#39ff88"
 
 ROSTER = [
     {
-        "id": "fallen_peltast", "family": "humanoid",
+        "id": "fallen_peltast",
+        "family": "humanoid",
         "brief": "Fallen peltast — a pale dead soldier with a scavenged iron shield, swarm fodder",
-        "height": 1.74, "build": "lithe", "skin": "#c9c2b0",
+        "height": 1.74,
+        "build": "lithe",
+        "skin": "#c9c2b0",
         "outfit": [("shield", "iron"), ("bracers", "leather")],
-        "wear": ["shield"], "seed": 61,
+        "wear": ["shield"],
+        "seed": 61,
     },
     {
-        "id": "tomb_breaker", "family": "humanoid",
+        "id": "tomb_breaker",
+        "family": "humanoid",
         "brief": "Tomb Breaker — massive dark-iron breaker that cracks gates and bones",
-        "height": 1.92, "build": "heroic", "skin": "#8a7a66",
+        "height": 1.92,
+        "build": "heroic",
+        "skin": "#8a7a66",
         "outfit": [("cuirass", "iron"), ("greaves", "iron"), ("helmet", "iron")],
-        "wear": ["cuirass", "helmet"], "seed": 67,
+        "wear": ["cuirass", "helmet"],
+        "seed": 67,
     },
     {
-        "id": "bone_oracle", "family": "humanoid",
+        "id": "bone_oracle",
+        "family": "humanoid",
         "brief": "Bone Oracle — robed caster reading the dead's debts, pale as candle wax",
-        "height": 1.78, "build": "lithe", "skin": "#cfc6b2",
+        "height": 1.78,
+        "build": "lithe",
+        "skin": "#cfc6b2",
         "outfit": [("robe", "cloth"), ("hood", "cloth")],
-        "robe_color": "#cfc6b2", "hood_color": "#191b1b",
-        "wear": [], "seed": 71,
+        "robe_color": "#cfc6b2",
+        "hood_color": "#191b1b",
+        "wear": [],
+        "seed": 71,
     },
     {
-        "id": "dread_strategos", "family": "humanoid",
+        "id": "dread_strategos",
+        "family": "humanoid",
         "brief": "Dread Strategos — bronze-cased dead general, crested, still giving orders",
-        "height": 1.9, "build": "heroic", "skin": "#9a8a72",
-        "outfit": [("cuirass", "bronze"), ("pteruges", "leather"), ("greaves", "bronze"),
-                   ("helmet", "bronze"), ("shield", "bronze")],
-        "wear": ["cuirass", "helmet", "shield"], "seed": 73,
+        "height": 1.9,
+        "build": "heroic",
+        "skin": "#9a8a72",
+        "outfit": [
+            ("cuirass", "bronze"),
+            ("pteruges", "leather"),
+            ("greaves", "bronze"),
+            ("helmet", "bronze"),
+            ("shield", "bronze"),
+        ],
+        "wear": ["cuirass", "helmet", "shield"],
+        "seed": 73,
     },
     {
-        "id": "stygian_warlock", "family": "humanoid",
+        "id": "stygian_warlock",
+        "family": "humanoid",
         "brief": "Stygian Warlock — river-green robed horror from the far bank",
-        "height": 1.84, "build": "realistic", "skin": "#7d8471",
+        "height": 1.84,
+        "build": "realistic",
+        "skin": "#7d8471",
         "outfit": [("robe", "cloth"), ("hood", "cloth")],
-        "robe_color": "#2e3b33", "hood_color": "#242f28",
-        "wear": [], "seed": 79,
+        "robe_color": "#2e3b33",
+        "hood_color": "#242f28",
+        "wear": [],
+        "seed": 79,
     },
     {
-        "id": "ash_stalker", "family": "humanoid",
+        "id": "ash_stalker",
+        "family": "humanoid",
         "brief": "Bone Stalker — gaunt ash-pale stalker in a burial shroud, fast and hungry",
-        "height": 1.92, "build": "lithe", "skin": "#a39c88",
+        "height": 1.92,
+        "build": "lithe",
+        "skin": "#a39c88",
         "outfit": [("hood", "cloth"), ("bracers", "leather")],
         "hood_color": "#191b1b",
-        "wear": [], "seed": 43,
+        "wear": [],
+        "seed": 43,
     },
     {
-        "id": "dire_hound", "family": "quadruped",
+        "id": "dire_hound",
+        "family": "quadruped",
         "brief": "Molossian Dire Hound — soot-dark underworld runner, all ribs and teeth",
-        "plan": "canine", "length": 1.75, "shoulder": 1.0, "bulk": 0.96,
-        "skin": "#24231f", "seed": 89,
+        "plan": "canine",
+        "length": 1.75,
+        "shoulder": 1.0,
+        "bulk": 0.96,
+        "skin": "#24231f",
+        "seed": 89,
     },
     {
-        "id": "carrion_scarab", "family": "insect",
+        "id": "carrion_scarab",
+        "family": "insect",
         "brief": "Carrion Scarab — dog-sized burial-beetle that eats what the war leaves",
-        "length": 1.0, "shoulder": 0.42, "bulk": 1.35, "skin": "#3a3026", "seed": 83,
+        "length": 1.0,
+        "shoulder": 0.42,
+        "bulk": 1.35,
+        "skin": "#3a3026",
+        "seed": 83,
     },
 ]
 
 
 def build_humanoid(forge: Forge, spec: dict, out_dir: Path) -> dict:
     name = spec["id"]
-    forge.call("char.humanoid", name=name, height=spec["height"], build=spec["build"],
-               skin=spec["skin"], seed=spec["seed"])
-    forge.call("char.face", name=name, height=spec["height"], build=spec["build"],
-               eyes="glow", eye_color=UNDERWORLD_GLOW)
+    forge.call(
+        "char.humanoid",
+        name=name,
+        height=spec["height"],
+        build=spec["build"],
+        skin=spec["skin"],
+        seed=spec["seed"],
+    )
+    forge.call(
+        "char.face",
+        name=name,
+        height=spec["height"],
+        build=spec["build"],
+        eyes="glow",
+        eye_color=UNDERWORLD_GLOW,
+    )
     forge.call("char.hands", name=name, height=spec["height"], build=spec["build"])
     pieces = []
     for piece, material in spec["outfit"]:
         kwargs = {}
         if f"{piece}_color" in spec:
             kwargs["color"] = spec[f"{piece}_color"]
-        result = forge.call("char.outfit", name=name, piece=piece,
-                            height=spec["height"], build=spec["build"],
-                            material=material, **kwargs)
+        result = forge.call(
+            "char.outfit",
+            name=name,
+            piece=piece,
+            height=spec["height"],
+            build=spec["build"],
+            material=material,
+            **kwargs,
+        )
         pieces.append(result["object"])
     for obj in pieces:
         leaf = obj.rsplit("_", 1)[-1]
         if leaf in spec["wear"]:
             forge.call("paint.fill", name=obj, color="#ffffff")
-            forge.call("paint.cavity", name=obj, color="#2c2118", mode="cavity",
-                       strength=0.55)
-            forge.call("paint.height", name=obj, low="#4a3a28", high="#ffffff",
-                       curve="smooth")
+            forge.call("paint.cavity", name=obj, color="#2c2118", mode="cavity", strength=0.55)
+            forge.call("paint.height", name=obj, low="#4a3a28", high="#ffffff", curve="smooth")
     # Surface richness on the metal: baked AO + roughness (the flat-color
     # ceiling breaker). 512 is plenty for RTS-distance armor.
     for obj in pieces:
         if obj.rsplit("_", 1)[-1] in spec["wear"]:
-            forge.call("material.bake_pbr", object=obj,
-                       maps=["base_color", "roughness", "ao"], size=512, samples=16)
+            forge.call(
+                "material.bake_pbr",
+                object=obj,
+                maps=["base_color", "roughness", "ao"],
+                size=512,
+                samples=16,
+            )
     # Surface relief that actually exports (bake passes only capture geometry
     # normals): cloth gets weave, bare skin gets pores.
     for obj in pieces:
         leaf = obj.rsplit("_", 1)[-1]
         if leaf in ("robe", "hood"):
-            forge.call("material.detail_normal", object=obj, pattern="weave",
-                       scale=64.0, strength=0.45, size=256, seed=spec["seed"] + 7)
+            forge.call(
+                "material.detail_normal",
+                object=obj,
+                pattern="weave",
+                scale=64.0,
+                strength=0.45,
+                size=256,
+                seed=spec["seed"] + 7,
+            )
     rig = forge.call("char.rig", name=name, height=spec["height"], build=spec["build"])
     for clip in ("idle", "walk", "attack", "death"):
         # Death is one-shot: looping it would snap the corpse back upright on
         # the final frame.
-        forge.call("char.animate", rig=rig["armature"], clip=clip, length=24,
-                   loop=clip != "death")
+        forge.call("char.animate", rig=rig["armature"], clip=clip, length=24, loop=clip != "death")
     objects = [name, rig["armature"]] + pieces
     review = forge.call("gameready.review", objects=objects)
     if not review["passed"]:
         raise SystemExit(f"{name} failed the gate: {review['findings']}")
-    result = forge.call("export.asset", asset_id=name, out_dir=str(out_dir),
-                        objects=objects, engine="threejs", category="character",
-                        ai_prompt=spec["brief"])
+    result = forge.call(
+        "export.asset",
+        asset_id=name,
+        out_dir=str(out_dir),
+        objects=objects,
+        engine="threejs",
+        category="character",
+        ai_prompt=spec["brief"],
+    )
     return {"id": name, "triangles": result["triangles"], "bytes": result["bytes"]}
 
 
 def build_quadruped(forge: Forge, spec: dict, out_dir: Path) -> dict:
     name = spec["id"]
     plan = spec.get("plan", "canine")
-    forge.call("char.creature", name=name, plan=plan, length=spec["length"],
-               shoulder=spec["shoulder"], bulk=spec["bulk"], skin=spec["skin"],
-               eyes="glow", eye_color=UNDERWORLD_GLOW, seed=spec["seed"])
-    rig = forge.call("char.creature_rig", name=name, plan=plan,
-                     length=spec["length"], shoulder=spec["shoulder"])
+    forge.call(
+        "char.creature",
+        name=name,
+        plan=plan,
+        length=spec["length"],
+        shoulder=spec["shoulder"],
+        bulk=spec["bulk"],
+        skin=spec["skin"],
+        eyes="glow",
+        eye_color=UNDERWORLD_GLOW,
+        seed=spec["seed"],
+    )
+    rig = forge.call(
+        "char.creature_rig", name=name, plan=plan, length=spec["length"], shoulder=spec["shoulder"]
+    )
     for clip in ("idle", "walk", "trot", "death"):
-        forge.call("char.animate", rig=rig["armature"], clip=clip, length=24,
-                   loop=clip != "death")
+        forge.call("char.animate", rig=rig["armature"], clip=clip, length=24, loop=clip != "death")
     objects = [name, rig["armature"]]
     review = forge.call("gameready.review", objects=objects)
     if not review["passed"]:
         raise SystemExit(f"{name} failed the gate: {review['findings']}")
-    result = forge.call("export.asset", asset_id=name, out_dir=str(out_dir),
-                        objects=objects, engine="threejs", category="character",
-                        ai_prompt=spec["brief"])
+    result = forge.call(
+        "export.asset",
+        asset_id=name,
+        out_dir=str(out_dir),
+        objects=objects,
+        engine="threejs",
+        category="character",
+        ai_prompt=spec["brief"],
+    )
     return {"id": name, "triangles": result["triangles"], "bytes": result["bytes"]}
 
 
 def build_insect(forge: Forge, spec: dict, out_dir: Path) -> dict:
     name = spec["id"]
-    forge.call("char.creature", name=name, plan="insect", length=spec["length"],
-               shoulder=spec["shoulder"], bulk=spec["bulk"], skin=spec["skin"],
-               eyes="glow", eye_color=UNDERWORLD_GLOW, seed=spec["seed"])
-    forge.call("material.detail_normal", object=name, pattern="scales",
-               scale=24.0, strength=0.55, size=256, seed=spec["seed"] + 13)
-    rig = forge.call("char.creature_rig", name=name, plan="insect",
-                     length=spec["length"], shoulder=spec["shoulder"])
+    forge.call(
+        "char.creature",
+        name=name,
+        plan="insect",
+        length=spec["length"],
+        shoulder=spec["shoulder"],
+        bulk=spec["bulk"],
+        skin=spec["skin"],
+        eyes="glow",
+        eye_color=UNDERWORLD_GLOW,
+        seed=spec["seed"],
+    )
+    forge.call(
+        "material.detail_normal",
+        object=name,
+        pattern="scales",
+        scale=24.0,
+        strength=0.55,
+        size=256,
+        seed=spec["seed"] + 13,
+    )
+    rig = forge.call(
+        "char.creature_rig",
+        name=name,
+        plan="insect",
+        length=spec["length"],
+        shoulder=spec["shoulder"],
+    )
     for clip in ("idle", "walk", "death"):
-        forge.call("char.animate", rig=rig["armature"], clip=clip, length=24,
-                   loop=clip != "death")
+        forge.call("char.animate", rig=rig["armature"], clip=clip, length=24, loop=clip != "death")
     objects = [name, rig["armature"]]
     review = forge.call("gameready.review", objects=objects)
     if not review["passed"]:
         raise SystemExit(f"{name} failed the gate: {review['findings']}")
-    result = forge.call("export.asset", asset_id=name, out_dir=str(out_dir),
-                        objects=objects, engine="threejs", category="character",
-                        ai_prompt=spec["brief"])
+    result = forge.call(
+        "export.asset",
+        asset_id=name,
+        out_dir=str(out_dir),
+        objects=objects,
+        engine="threejs",
+        category="character",
+        ai_prompt=spec["brief"],
+    )
     return {"id": name, "triangles": result["triangles"], "bytes": result["bytes"]}
 
 
@@ -192,8 +307,10 @@ def main() -> None:
                 report = build_quadruped(forge, spec, out_dir)
             else:
                 report = build_humanoid(forge, spec, out_dir)
-            print(f"{report['id']:18s} {report['triangles']:5d} tris  "
-                  f"{report['bytes'] / 1024:4.0f} KiB")
+            print(
+                f"{report['id']:18s} {report['triangles']:5d} tris  "
+                f"{report['bytes'] / 1024:4.0f} KiB"
+            )
     print(f"\nroster -> {out_dir}")
 
 

--- a/tools/bforge/examples/characters.py
+++ b/tools/bforge/examples/characters.py
@@ -27,7 +27,9 @@ CAST = [
     {
         "id": "settler",
         "brief": "First Fire settler — hide wrap, work-worn hands, no metal anywhere",
-        "height": 1.68, "build": "stylized", "skin": "#a8795a",
+        "height": 1.68,
+        "build": "stylized",
+        "skin": "#a8795a",
         "outfit": [("pteruges", "cloth"), ("bracers", "leather")],
         "wear_on": [],
         "seed": 11,
@@ -35,7 +37,9 @@ CAST = [
     {
         "id": "scout",
         "brief": "Hunter-scout — lean, leather bracers, cloth wrap, moves first",
-        "height": 1.74, "build": "lithe", "skin": "#8a6248",
+        "height": 1.74,
+        "build": "lithe",
+        "skin": "#8a6248",
         "outfit": [("pteruges", "cloth"), ("bracers", "leather")],
         "wear_on": [],
         "seed": 23,
@@ -43,18 +47,33 @@ CAST = [
     {
         "id": "warden",
         "brief": "Fortification-era bronze guard — cuirass, crested helmet, aspis on the forearm",
-        "height": 1.82, "build": "heroic", "skin": "#b08a68",
-        "outfit": [("cuirass", "bronze"), ("pteruges", "leather"), ("greaves", "bronze"),
-                   ("bracers", "leather"), ("helmet", "bronze"), ("shield", "bronze")],
+        "height": 1.82,
+        "build": "heroic",
+        "skin": "#b08a68",
+        "outfit": [
+            ("cuirass", "bronze"),
+            ("pteruges", "leather"),
+            ("greaves", "bronze"),
+            ("bracers", "leather"),
+            ("helmet", "bronze"),
+            ("shield", "bronze"),
+        ],
         "wear_on": ["cuirass", "helmet", "shield"],
         "seed": 3,
     },
     {
         "id": "raider",
         "brief": "Frontier raider — heavy, dark leather and scavenged iron, shield right",
-        "height": 1.86, "build": "realistic", "skin": "#96684e",
-        "outfit": [("cuirass", "iron"), ("pteruges", "leather"), ("bracers", "leather"),
-                   ("helmet", "iron"), ("shield", "iron")],
+        "height": 1.86,
+        "build": "realistic",
+        "skin": "#96684e",
+        "outfit": [
+            ("cuirass", "iron"),
+            ("pteruges", "leather"),
+            ("bracers", "leather"),
+            ("helmet", "iron"),
+            ("shield", "iron"),
+        ],
         "wear_on": ["cuirass", "helmet", "shield"],
         "seed": 41,
     },
@@ -66,28 +85,36 @@ def build_character(forge: Forge, spec: dict, out_dir: Path) -> dict:
     name = spec["id"]
     height = spec["height"]
 
-    forge.call("char.humanoid", name=name, height=height, build=spec["build"],
-               skin=spec["skin"], seed=spec["seed"])
+    forge.call(
+        "char.humanoid",
+        name=name,
+        height=height,
+        build=spec["build"],
+        skin=spec["skin"],
+        seed=spec["seed"],
+    )
     forge.call("char.face", name=name, height=height, build=spec["build"])
     forge.call("char.hands", name=name, height=height, build=spec["build"])
 
     pieces = []
     for piece, material in spec["outfit"]:
         result = forge.call(
-            "char.outfit", name=name, piece=piece, height=height,
-            build=spec["build"], material=material,
+            "char.outfit",
+            name=name,
+            piece=piece,
+            height=height,
+            build=spec["build"],
+            material=material,
             side="r" if spec["id"] == "raider" and piece == "shield" else "l",
         )
         pieces.append((result["object"], material))
 
     # Wear: grime in the cavities, dust at the hem — on METAL, where it reads.
-    for obj, material in pieces:
+    for obj, _material in pieces:
         if obj.rsplit("_", 1)[-1] in spec["wear_on"]:
             forge.call("paint.fill", name=obj, color="#ffffff")
-            forge.call("paint.cavity", name=obj, color="#3a2c1c",
-                       mode="cavity", strength=0.55)
-            forge.call("paint.height", name=obj, low="#5a4a34", high="#ffffff",
-                       curve="smooth")
+            forge.call("paint.cavity", name=obj, color="#3a2c1c", mode="cavity", strength=0.55)
+            forge.call("paint.height", name=obj, low="#5a4a34", high="#ffffff", curve="smooth")
 
     rig = forge.call("char.rig", name=name, height=height, build=spec["build"])
     for clip in ("idle", "walk"):
@@ -99,13 +126,21 @@ def build_character(forge: Forge, spec: dict, out_dir: Path) -> dict:
         raise SystemExit(f"{name} failed the quality gate: {review['findings']}")
 
     result = forge.call(
-        "export.asset", asset_id=name, out_dir=str(out_dir), objects=objects,
-        engine="threejs", category="character", ai_prompt=spec["brief"],
+        "export.asset",
+        asset_id=name,
+        out_dir=str(out_dir),
+        objects=objects,
+        engine="threejs",
+        category="character",
+        ai_prompt=spec["brief"],
     )
     separation = forge.call("check.materials", objects=objects)["max_delta_e"]
     return {
-        "id": name, "triangles": result["triangles"], "bytes": result["bytes"],
-        "max_delta_e": separation, "pieces": len(pieces),
+        "id": name,
+        "triangles": result["triangles"],
+        "bytes": result["bytes"],
+        "max_delta_e": separation,
+        "pieces": len(pieces),
     }
 
 

--- a/tools/bforge/examples/first_fire.py
+++ b/tools/bforge/examples/first_fire.py
@@ -27,42 +27,85 @@ def campfire(f: Forge, at):
         angle = i * 45.0
         x = at[0] + 0.45 * __import__("math").cos(__import__("math").radians(angle))
         y = at[1] + 0.45 * __import__("math").sin(__import__("math").radians(angle))
-        names.append(f.call("prop.rock", name=f"campfire_stone_{i}",
-                            location=[x, y, at[2]], size=[0.24, 0.22, 0.2],
-                            detail=1, seed=60 + i)["name"])
+        names.append(
+            f.call(
+                "prop.rock",
+                name=f"campfire_stone_{i}",
+                location=[x, y, at[2]],
+                size=[0.24, 0.22, 0.2],
+                detail=1,
+                seed=60 + i,
+            )["name"]
+        )
     for i in range(3):
-        names.append(f.call(
-            "build.cylinder", name=f"campfire_log_{i}", radius=0.045, depth=0.7,
-            segments=8, material="wood", color="#5d4426",
-            location=[at[0], at[1], at[2] + 0.28])["name"])
-        f.call("object.transform", name=f"campfire_log_{i}",
-               rotation=[62.0, 0.0, i * 120.0])
-    coals = f.call("build.cylinder", name="campfire_coals", radius=0.26,
-                   radius_top=0.2, depth=0.1, segments=12, material="stone",
-                   location=[at[0], at[1], at[2] + 0.05])["name"]
-    f.call("material.set", object=coals, preset="stone", name="m_embers",
-           color="#ff5a14", emission=4.5)
+        names.append(
+            f.call(
+                "build.cylinder",
+                name=f"campfire_log_{i}",
+                radius=0.045,
+                depth=0.7,
+                segments=8,
+                material="wood",
+                color="#5d4426",
+                location=[at[0], at[1], at[2] + 0.28],
+            )["name"]
+        )
+        f.call("object.transform", name=f"campfire_log_{i}", rotation=[62.0, 0.0, i * 120.0])
+    coals = f.call(
+        "build.cylinder",
+        name="campfire_coals",
+        radius=0.26,
+        radius_top=0.2,
+        depth=0.1,
+        segments=12,
+        material="stone",
+        location=[at[0], at[1], at[2] + 0.05],
+    )["name"]
+    f.call(
+        "material.set", object=coals, preset="stone", name="m_embers", color="#ff5a14", emission=4.5
+    )
     return names + [coals]
 
 
 def hide_tent(f: Forge, at):
     names = []
     # Ridge pole along X at the peak, one support pole at each end.
-    names.append(f.call(
-        "build.cylinder", name="tent_ridge", radius=0.035, depth=2.4,
-        segments=8, material="wood", color="#6a4e2c",
-        location=[at[0], at[1], at[2] + 1.55])["name"])
+    names.append(
+        f.call(
+            "build.cylinder",
+            name="tent_ridge",
+            radius=0.035,
+            depth=2.4,
+            segments=8,
+            material="wood",
+            color="#6a4e2c",
+            location=[at[0], at[1], at[2] + 1.55],
+        )["name"]
+    )
     f.call("object.transform", name="tent_ridge", rotation=[0.0, 90.0, 0.0])
     for side in (-1, 1):
-        names.append(f.call(
-            "build.cylinder", name=f"tent_pole_{side}", radius=0.035, depth=1.6,
-            segments=8, material="wood", color="#6a4e2c",
-            location=[at[0] + side * 1.1, at[1], at[2] + 0.8])["name"])
+        names.append(
+            f.call(
+                "build.cylinder",
+                name=f"tent_pole_{side}",
+                radius=0.035,
+                depth=1.6,
+                segments=8,
+                material="wood",
+                color="#6a4e2c",
+                location=[at[0] + side * 1.1, at[1], at[2] + 0.8],
+            )["name"]
+        )
     # Two sloped hide panels leaning on the ridge — the A in A-frame.
     for side, rot, yoff in (("a", 58.0, -0.72), ("b", -58.0, 0.72)):
-        panel = f.call("build.box", name=f"tent_hide_{side}", size=[2.3, 0.05, 1.9],
-                       material="cloth", color="#7a5a38",
-                       location=[at[0], at[1] + yoff, at[2] + 0.82])["name"]
+        panel = f.call(
+            "build.box",
+            name=f"tent_hide_{side}",
+            size=[2.3, 0.05, 1.9],
+            material="cloth",
+            color="#7a5a38",
+            location=[at[0], at[1] + yoff, at[2] + 0.82],
+        )["name"]
         f.call("object.transform", name=panel, rotation=[rot, 0.0, 0.0])
         f.call("paint.fill", name=panel, color="#c9b898")
         f.call("paint.cavity", name=panel, color="#4a3620", mode="cavity", strength=0.5)
@@ -74,61 +117,114 @@ def palisade(f: Forge, at):
     names = []
     for i in range(7):
         depth = 2.4 if i % 2 == 0 else 2.55
-        names.append(f.call(
-            "build.cylinder", name=f"palisade_log_{i}", radius=0.09, radius_top=0.0,
-            depth=depth, segments=10, material="wood", color="#6a4e2c",
-            location=[at[0] + (i - 3) * 0.19, at[1], at[2] + depth / 2.0])["name"])
+        names.append(
+            f.call(
+                "build.cylinder",
+                name=f"palisade_log_{i}",
+                radius=0.09,
+                radius_top=0.0,
+                depth=depth,
+                segments=10,
+                material="wood",
+                color="#6a4e2c",
+                location=[at[0] + (i - 3) * 0.19, at[1], at[2] + depth / 2.0],
+            )["name"]
+        )
     return names
 
 
 def storage_rack(f: Forge, at):
-    rack = f.call("prop.furniture", name="rack", kind="shelf",
-                  size=[1.4, 0.5, 1.2], location=list(at), seed=21)["name"]
-    sack_a = f.call("prop.sack", name="rack_sack_a",
-                    location=[at[0] - 0.3, at[1], at[2] + 0.75], seed=31)["name"]
-    sack_b = f.call("prop.sack", name="rack_sack_b",
-                    location=[at[0] + 0.32, at[1] - 0.05, at[2]], seed=47)["name"]
+    rack = f.call(
+        "prop.furniture",
+        name="rack",
+        kind="shelf",
+        size=[1.4, 0.5, 1.2],
+        location=list(at),
+        seed=21,
+    )["name"]
+    sack_a = f.call(
+        "prop.sack", name="rack_sack_a", location=[at[0] - 0.3, at[1], at[2] + 0.75], seed=31
+    )["name"]
+    sack_b = f.call(
+        "prop.sack", name="rack_sack_b", location=[at[0] + 0.32, at[1] - 0.05, at[2]], seed=47
+    )["name"]
     return [rack, sack_a, sack_b]
 
 
 def well(f: Forge, at):
     import math
+
     names = []
     stone_names = []
     for row in range(2):
         for i in range(9):
             angle = i * 40.0 + row * 20.0
-            stone_names.append(f.call(
-                "prop.rock", name=f"well_stone_{row}_{i}",
-                location=[at[0] + 0.62 * math.cos(math.radians(angle)),
-                          at[1] + 0.62 * math.sin(math.radians(angle)),
-                          at[2] + 0.14 + row * 0.24],
-                size=[0.3, 0.28, 0.24], detail=1, seed=100 + row * 10 + i)["name"])
+            stone_names.append(
+                f.call(
+                    "prop.rock",
+                    name=f"well_stone_{row}_{i}",
+                    location=[
+                        at[0] + 0.62 * math.cos(math.radians(angle)),
+                        at[1] + 0.62 * math.sin(math.radians(angle)),
+                        at[2] + 0.14 + row * 0.24,
+                    ],
+                    size=[0.3, 0.28, 0.24],
+                    detail=1,
+                    seed=100 + row * 10 + i,
+                )["name"]
+            )
     for side in (-1, 1):
-        names.append(f.call(
-            "build.cylinder", name=f"well_post_{side}", radius=0.05, depth=1.3,
-            segments=8, material="wood", color="#6a4e2c",
-            location=[at[0] + side * 0.62, at[1], at[2] + 0.65])["name"])
-    names.append(f.call(
-        "build.cylinder", name="well_bar", radius=0.045, depth=1.34, segments=8,
-        material="wood", color="#5d4426",
-        location=[at[0], at[1], at[2] + 1.28])["name"])
+        names.append(
+            f.call(
+                "build.cylinder",
+                name=f"well_post_{side}",
+                radius=0.05,
+                depth=1.3,
+                segments=8,
+                material="wood",
+                color="#6a4e2c",
+                location=[at[0] + side * 0.62, at[1], at[2] + 0.65],
+            )["name"]
+        )
+    names.append(
+        f.call(
+            "build.cylinder",
+            name="well_bar",
+            radius=0.045,
+            depth=1.34,
+            segments=8,
+            material="wood",
+            color="#5d4426",
+            location=[at[0], at[1], at[2] + 1.28],
+        )["name"]
+    )
     f.call("object.transform", name="well_bar", rotation=[0.0, 90.0, 0.0])
     # 18 stones + posts + bar would ship as 21 draw calls — join to two.
     f.call("object.join", names=stone_names, into="well_stones")
-    f.call("object.join", names=[n for n in names if "post" in n or "bar" in n],
-           into="well_frame")
+    f.call("object.join", names=[n for n in names if "post" in n or "bar" in n], into="well_frame")
     return ["well_stones", "well_frame"]
 
 
 def workbench(f: Forge, at):
-    bench = f.call("prop.furniture", name="workbench", kind="table",
-                   size=[1.4, 0.7, 0.8], location=list(at), seed=9)["name"]
-    axe = f.call("prop.weapon", name="bench_axe", kind="axe",
-                 location=[at[0] + 0.2, at[1], at[2] + 0.82], seed=5)["name"]
+    bench = f.call(
+        "prop.furniture",
+        name="workbench",
+        kind="table",
+        size=[1.4, 0.7, 0.8],
+        location=list(at),
+        seed=9,
+    )["name"]
+    axe = f.call(
+        "prop.weapon",
+        name="bench_axe",
+        kind="axe",
+        location=[at[0] + 0.2, at[1], at[2] + 0.82],
+        seed=5,
+    )["name"]
     f.call("object.transform", name="bench_axe", rotation=[0.0, 0.0, 78.0])
-    debris = f.call("prop.debris", name="bench_shavings",
-                    location=[at[0] - 0.4, at[1] + 0.3, at[2]], seed=12)["name"]
+    debris = f.call(
+        "prop.debris", name="bench_shavings", location=[at[0] - 0.4, at[1] + 0.3, at[2]], seed=12
+    )["name"]
     return [bench, axe, debris]
 
 
@@ -137,21 +233,35 @@ def firewood(f: Forge, at):
     rows = ((3, 0.07), (2, 0.21), (1, 0.35))
     for row, (count, z) in enumerate(rows):
         for i in range(count):
-            names.append(f.call(
-                "build.cylinder", name=f"firewood_{row}_{i}", radius=0.07,
-                depth=0.8, segments=10, material="wood", color="#6a4e2c",
-                location=[at[0] + (i - (count - 1) / 2.0) * 0.16, at[1], at[2] + z])["name"])
-            f.call("object.transform", name=f"firewood_{row}_{i}",
-                   rotation=[0.0, 90.0, 0.0])
+            names.append(
+                f.call(
+                    "build.cylinder",
+                    name=f"firewood_{row}_{i}",
+                    radius=0.07,
+                    depth=0.8,
+                    segments=10,
+                    material="wood",
+                    color="#6a4e2c",
+                    location=[at[0] + (i - (count - 1) / 2.0) * 0.16, at[1], at[2] + z],
+                )["name"]
+            )
+            f.call("object.transform", name=f"firewood_{row}_{i}", rotation=[0.0, 90.0, 0.0])
     return names
 
 
 def supply_stack(f: Forge, at):
     crate = f.call("prop.crate", name="supply_crate", location=list(at), seed=3)["name"]
-    barrel = f.call("prop.barrel", name="supply_barrel", height=0.9, bands=3,
-                    location=[at[0] + 0.85, at[1] + 0.2, at[2]], seed=7)["name"]
-    sack = f.call("prop.sack", name="supply_sack",
-                  location=[at[0] + 0.35, at[1] - 0.55, at[2]], seed=53)["name"]
+    barrel = f.call(
+        "prop.barrel",
+        name="supply_barrel",
+        height=0.9,
+        bands=3,
+        location=[at[0] + 0.85, at[1] + 0.2, at[2]],
+        seed=7,
+    )["name"]
+    sack = f.call(
+        "prop.sack", name="supply_sack", location=[at[0] + 0.35, at[1] - 0.55, at[2]], seed=53
+    )["name"]
     f.call("object.transform", name="supply_crate", rotation=[0.0, 0.0, 12.0])
     return [crate, barrel, sack]
 
@@ -182,8 +292,10 @@ def main() -> None:
             every_object.extend(names)
 
         conformance = forge.call("check.conformance", objects=every_object)
-        print(f"set conformance: {conformance['coherent']}/{len(conformance['objects'])} "
-              f"coherent, outliers: {conformance['outliers'] or 'none'}")
+        print(
+            f"set conformance: {conformance['coherent']}/{len(conformance['objects'])} "
+            f"coherent, outliers: {conformance['outliers'] or 'none'}"
+        )
 
         for asset_id, _builder, brief in ASSETS:
             names = per_asset[asset_id]
@@ -191,12 +303,18 @@ def main() -> None:
             if not review["passed"]:
                 raise SystemExit(f"{asset_id} failed the gate: {review['findings']}")
             result = forge.call(
-                "export.asset", asset_id=asset_id, out_dir=str(out_dir),
-                objects=names, engine="threejs", category="environment",
-                ai_prompt=brief, contact_sheet=True,
+                "export.asset",
+                asset_id=asset_id,
+                out_dir=str(out_dir),
+                objects=names,
+                engine="threejs",
+                category="environment",
+                ai_prompt=brief,
+                contact_sheet=True,
             )
-            print(f"{asset_id:14s} {result['triangles']:5d} tris  "
-                  f"{result['bytes'] / 1024:4.0f} KiB")
+            print(
+                f"{asset_id:14s} {result['triangles']:5d} tris  {result['bytes'] / 1024:4.0f} KiB"
+            )
     print(f"\npack -> {out_dir}")
 
 

--- a/tools/bforge/examples/neural_finish.py
+++ b/tools/bforge/examples/neural_finish.py
@@ -34,8 +34,11 @@ def main() -> None:
         forge.call("session.reset")
         imp = forge.call("session.import", path=str(source), prefix="src")
         imported = imp.get("objects") or []
-        meshes = [n for n in imported
-                  if not n.lower().endswith(("_rig", "_armature")) and "rig" not in n.lower()]
+        meshes = [
+            n
+            for n in imported
+            if not n.lower().endswith(("_rig", "_armature")) and "rig" not in n.lower()
+        ]
         if not meshes:
             raise SystemExit(f"no mesh found in {source.name}: {imported}")
         src = meshes[0]
@@ -48,19 +51,26 @@ def main() -> None:
 
         forge.call("uv.unwrap", object=asset_id, style="smart_packed")
         forge.call("uv.pack", object=asset_id, margin=0.01)
-        forge.call("bake.transfer", source=src, target=asset_id,
-                   maps=["base_color", "normal"], size=1024, samples=16,
-                   ray_distance=voxel * 4)
+        forge.call(
+            "bake.transfer",
+            source=src,
+            target=asset_id,
+            maps=["base_color", "normal"],
+            size=1024,
+            samples=16,
+            ray_distance=voxel * 4,
+        )
 
         if plan == "humanoid":
             rig = forge.call("char.rig", name=asset_id, height=0, build="realistic")
             clips = ("idle", "walk", "attack", "death")
         else:
-            rig = forge.call("char.creature_rig", name=asset_id, plan=plan,
-                             length=0, shoulder=0)
+            rig = forge.call("char.creature_rig", name=asset_id, plan=plan, length=0, shoulder=0)
             clips = ("idle", "walk", "trot") if plan != "insect" else ("idle", "walk")
-        print(f"rig: {rig['armature']} ({rig['bone_count']} bones, "
-              f"{rig['weighted_vertices']} weighted verts)")
+        print(
+            f"rig: {rig['armature']} ({rig['bone_count']} bones, "
+            f"{rig['weighted_vertices']} weighted verts)"
+        )
         for clip in clips:
             forge.call("char.animate", rig=rig["armature"], clip=clip, length=24)
 
@@ -68,11 +78,16 @@ def main() -> None:
         review = forge.call("gameready.review", objects=objects)
         if not review["passed"]:
             raise SystemExit(f"{asset_id} failed the gate: {review['findings']}")
-        result = forge.call("export.asset", asset_id=asset_id, out_dir=str(out_dir),
-                            objects=objects, engine="threejs", category="character",
-                            ai_prompt=f"neural-mesh finishing line: {source.name} -> game-ready")
-        print(f"{asset_id}: {result['triangles']} tris, {result['bytes'] // 1024} KiB "
-              f"-> {out_dir}")
+        result = forge.call(
+            "export.asset",
+            asset_id=asset_id,
+            out_dir=str(out_dir),
+            objects=objects,
+            engine="threejs",
+            category="character",
+            ai_prompt=f"neural-mesh finishing line: {source.name} -> game-ready",
+        )
+        print(f"{asset_id}: {result['triangles']} tris, {result['bytes'] // 1024} KiB -> {out_dir}")
 
 
 if __name__ == "__main__":

--- a/tools/bforge/examples/recipes/barrel.json
+++ b/tools/bforge/examples/recipes/barrel.json
@@ -1,0 +1,14 @@
+{
+  "recipe_version": 1,
+  "asset_id": "recipe_barrel",
+  "brief": "a small barrel, for the browser",
+  "steps": [
+    { "op": "prop.barrel", "args": { "name": "recipe_barrel", "seed": 11 } }
+  ],
+  "requirements": {
+    "max_triangles": 2000,
+    "platform": "browser_webgpu",
+    "asset_class": "prop"
+  },
+  "export": { "engine": "godot", "category": "prop" }
+}

--- a/tools/bforge/examples/recipes/crate.json
+++ b/tools/bforge/examples/recipes/crate.json
@@ -1,0 +1,16 @@
+{
+  "recipe_version": 1,
+  "asset_id": "recipe_crate",
+  "brief": "a sturdy one-metre supply crate with collision, for the browser",
+  "steps": [
+    { "op": "prop.crate", "args": { "name": "recipe_crate", "size": [1, 1, 1], "seed": 7 } },
+    { "op": "gameready.collision", "args": { "name": "recipe_crate", "mode": "convex" } }
+  ],
+  "requirements": {
+    "max_triangles": 2000,
+    "require_collision": true,
+    "platform": "browser_webgpu",
+    "asset_class": "prop"
+  },
+  "export": { "engine": "godot", "category": "prop" }
+}

--- a/tools/bforge/tests/skinning.py
+++ b/tools/bforge/tests/skinning.py
@@ -26,8 +26,13 @@ def posed_size(forge, location, pose=POSE):
     """Build, rig, pose and bake a figure at `location`; return size, bake, area."""
     forge.call("session.reset")
     forge.call(
-        "char.humanoid", name="f", height=HEIGHT, build="heroic",
-        bulk=1.25, detail=8, location=location,
+        "char.humanoid",
+        name="f",
+        height=HEIGHT,
+        build="heroic",
+        bulk=1.25,
+        detail=8,
+        location=location,
     )
     rig = forge.call("char.rig", name="f", height=HEIGHT, build="heroic")
     if pose:
@@ -57,7 +62,7 @@ def main():
         # armature-local bone positions, so every bone was displaced by exactly
         # the character's offset from the origin. A figure built on a vehicle
         # floor got its pelvis weighted to its shins.
-        drift = max(abs(a - b) for a, b in zip(at_origin, offset))
+        drift = max(abs(a - b) for a, b in zip(at_origin, offset, strict=True))
         if drift > 0.01:
             failures.append(
                 f"rigging depends on where the character stands: at origin {at_origin} "

--- a/tools/bforge/tests/test_char_outfit.py
+++ b/tools/bforge/tests/test_char_outfit.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+from bforge.client import DaemonError, Forge, find_blender  # noqa: E402
 
 FORGE: Forge | None = None
 TEMP: tempfile.TemporaryDirectory | None = None
@@ -82,17 +82,18 @@ class Outfit(ForgeCase):
         center_x = (info["bounds"]["min"][0] + info["bounds"]["max"][0]) / 2.0
         torso_r = 1.8 * 0.078 * 1.18  # heroic bulk
         self.assertGreater(
-            abs(center_x), torso_r,
+            abs(center_x),
+            torso_r,
             f"shield centre |x|={abs(center_x):.3f} is inside the torso silhouette "
             f"(torso_r={torso_r:.3f}) — the warden failure",
         )
 
     def test_materials_are_separated_by_construction(self):
         body = _humanoid()
-        FORGE.call("char.outfit", name=body, piece="cuirass", height=1.8)   # bronze
+        FORGE.call("char.outfit", name=body, piece="cuirass", height=1.8)  # bronze
         FORGE.call("char.outfit", name=body, piece="pteruges", height=1.8)  # leather
-        FORGE.call("char.outfit", name=body, piece="helmet", height=1.8)    # bronze
-        FORGE.call("char.outfit", name=body, piece="bracers", height=1.8)   # leather
+        FORGE.call("char.outfit", name=body, piece="helmet", height=1.8)  # bronze
+        FORGE.call("char.outfit", name=body, piece="bracers", height=1.8)  # leather
         result = FORGE.call("check.materials")
         errors = [f for f in result["findings"] if f["severity"] == "error"]
         self.assertEqual(errors, [], f"outfit defaults must pass the blob gate: {errors}")
@@ -105,9 +106,11 @@ class Outfit(ForgeCase):
         shield = FORGE.call("char.outfit", name=body, piece="shield", height=1.8)
         self.assertIn("head", helmet["follows"])
         self.assertIn("forearm_l", shield["follows"])
-        glb = FORGE.call("export.gltf", out="rigged.glb", objects=[rig["armature"], body,
-                                                                   helmet["object"],
-                                                                   shield["object"]])
+        glb = FORGE.call(
+            "export.gltf",
+            out="rigged.glb",
+            objects=[rig["armature"], body, helmet["object"], shield["object"]],
+        )
         parsed = read_glb_json(Path(glb["path"]))
         self.assertGreaterEqual(len(parsed.get("skins", [])), 1)
         # Bone-parented pieces export as children of their joint node.
@@ -116,8 +119,7 @@ class Outfit(ForgeCase):
         for index, node in enumerate(nodes):
             for child in node.get("children", []):
                 parent_of[child] = index
-        for piece_name, bone in ((helmet["object"], "head"),
-                                 (shield["object"], "forearm_l")):
+        for piece_name, bone in ((helmet["object"], "head"), (shield["object"], "forearm_l")):
             piece_idx = next(i for i, n in enumerate(nodes) if n.get("name") == piece_name)
             self.assertEqual(nodes[parent_of[piece_idx]].get("name"), bone)
 

--- a/tools/bforge/tests/test_creature.py
+++ b/tools/bforge/tests/test_creature.py
@@ -57,13 +57,13 @@ def read_glb_json(path: Path) -> dict:
 
 class Creature(ForgeCase):
     def test_body_builds_within_budget(self):
-        result = FORGE.call("char.creature", name="hound", length=1.3, shoulder=0.85,
-                            plan="canine", seed=5)
+        result = FORGE.call(
+            "char.creature", name="hound", length=1.3, shoulder=0.85, plan="canine", seed=5
+        )
         self.assertEqual(result["plan"], "canine")
         self.assertLess(result["triangles"], 6000)
         bounds = result["bounds"]["size"]
-        self.assertGreater(bounds[1], bounds[2] * 0.8,
-                           "a quadruped is longer than it is tall")
+        self.assertGreater(bounds[1], bounds[2] * 0.8, "a quadruped is longer than it is tall")
 
     def test_all_plans_build(self):
         for plan in ("equine", "feline", "generic"):
@@ -74,9 +74,21 @@ class Creature(ForgeCase):
         FORGE.call("char.creature", name="hound", length=1.3, shoulder=0.85, seed=5)
         rig = FORGE.call("char.creature_rig", name="hound", length=1.3, shoulder=0.85)
         bones = set(rig["bones"])
-        for expected in ("hips", "spine", "chest", "neck", "head", "tail_1", "tail_2",
-                         "front_upper_l", "front_lower_l", "front_paw_l",
-                         "rear_upper_r", "rear_lower_r", "rear_paw_r"):
+        for expected in (
+            "hips",
+            "spine",
+            "chest",
+            "neck",
+            "head",
+            "tail_1",
+            "tail_2",
+            "front_upper_l",
+            "front_lower_l",
+            "front_paw_l",
+            "rear_upper_r",
+            "rear_lower_r",
+            "rear_paw_r",
+        ):
             self.assertIn(expected, bones)
         self.assertEqual(rig["bone_count"], 19)
         self.assertGreater(rig["weighted_vertices"], 0)
@@ -87,8 +99,7 @@ class Creature(ForgeCase):
         for clip in ("walk", "trot", "gallop", "graze", "idle"):
             result = FORGE.call("char.animate", rig=rig["armature"], clip=clip, length=24)
             self.assertGreater(result["keyframes"], 10, f"{clip} produced no keys")
-        glb = FORGE.call("export.gltf", out="hound.glb",
-                         objects=[rig["armature"], "hound"])
+        glb = FORGE.call("export.gltf", out="hound.glb", objects=[rig["armature"], "hound"])
         parsed = read_glb_json(Path(glb["path"]))
         self.assertEqual(len(parsed.get("skins", [])), 1)
         self.assertEqual(len(parsed["skins"][0]["joints"]), 19)
@@ -125,38 +136,57 @@ class Creature(ForgeCase):
 
 class Hexapod(ForgeCase):
     def test_insect_body_and_rig(self):
-        result = FORGE.call("char.creature", name="scarab", plan="insect",
-                            length=0.9, shoulder=0.35, skin="#3d3226", seed=17)
+        result = FORGE.call(
+            "char.creature",
+            name="scarab",
+            plan="insect",
+            length=0.9,
+            shoulder=0.35,
+            skin="#3d3226",
+            seed=17,
+        )
         self.assertEqual(result["plan"], "insect")
         self.assertLess(result["triangles"], 8000)
-        rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
-                         length=0.9, shoulder=0.35)
+        rig = FORGE.call(
+            "char.creature_rig", name="scarab", plan="insect", length=0.9, shoulder=0.35
+        )
         bones = set(rig["bones"])
-        for expected in ("hips", "chest", "head",
-                         "front_upper_l", "mid_upper_l", "rear_upper_l",
-                         "mid_lower_r", "mid_paw_r", "rear_paw_l"):
+        for expected in (
+            "hips",
+            "chest",
+            "head",
+            "front_upper_l",
+            "mid_upper_l",
+            "rear_upper_l",
+            "mid_lower_r",
+            "mid_paw_r",
+            "rear_paw_l",
+        ):
             self.assertIn(expected, bones)
         self.assertEqual(rig["bone_count"], 21)
         self.assertGreater(rig["weighted_vertices"], 0)
 
     def test_tripod_walk_exports(self):
-        FORGE.call("char.creature", name="scarab", plan="insect",
-                   length=0.9, shoulder=0.35, seed=17)
-        rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
-                         length=0.9, shoulder=0.35)
+        FORGE.call(
+            "char.creature", name="scarab", plan="insect", length=0.9, shoulder=0.35, seed=17
+        )
+        rig = FORGE.call(
+            "char.creature_rig", name="scarab", plan="insect", length=0.9, shoulder=0.35
+        )
         walk = FORGE.call("char.animate", rig=rig["armature"], clip="walk", length=24)
         self.assertGreater(walk["keyframes"], 10)
-        glb = FORGE.call("export.gltf", out="scarab.glb",
-                         objects=[rig["armature"], "scarab"])
+        glb = FORGE.call("export.gltf", out="scarab.glb", objects=[rig["armature"], "scarab"])
         parsed = read_glb_json(Path(glb["path"]))
         self.assertEqual(len(parsed["skins"][0]["joints"]), 21)
         self.assertEqual(len(parsed.get("animations", [])), 1)
 
     def test_quadruped_gait_on_hexapod_is_a_helpful_error(self):
-        FORGE.call("char.creature", name="scarab", plan="insect",
-                   length=0.9, shoulder=0.35, seed=17)
-        rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
-                         length=0.9, shoulder=0.35)
+        FORGE.call(
+            "char.creature", name="scarab", plan="insect", length=0.9, shoulder=0.35, seed=17
+        )
+        rig = FORGE.call(
+            "char.creature_rig", name="scarab", plan="insect", length=0.9, shoulder=0.35
+        )
         with self.assertRaises(ForgeError) as ctx:
             FORGE.call("char.animate", rig=rig["armature"], clip="trot")
         self.assertIn("hexapod", str(ctx.exception))
@@ -164,10 +194,12 @@ class Hexapod(ForgeCase):
     def test_determinism(self):
         def build_once(out):
             FORGE.call("session.reset")
-            FORGE.call("char.creature", name="scarab", plan="insect",
-                       length=0.9, shoulder=0.35, seed=17)
-            rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
-                             length=0.9, shoulder=0.35)
+            FORGE.call(
+                "char.creature", name="scarab", plan="insect", length=0.9, shoulder=0.35, seed=17
+            )
+            rig = FORGE.call(
+                "char.creature_rig", name="scarab", plan="insect", length=0.9, shoulder=0.35
+            )
             FORGE.call("char.animate", rig=rig["armature"], clip="walk", length=24)
             return Path(FORGE.call("export.gltf", out=out)["path"]).read_bytes()
 

--- a/tools/bforge/tests/test_env_camp.py
+++ b/tools/bforge/tests/test_env_camp.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+from bforge.client import DaemonError, Forge, find_blender  # noqa: E402
 
 FORGE: Forge | None = None
 TEMP: tempfile.TemporaryDirectory | None = None
@@ -47,11 +47,19 @@ class ForgeCase(unittest.TestCase):
 
 class Camp(ForgeCase):
     def test_camp_builds_all_structures(self):
-        result = FORGE.call("env.camp", name="homeland", radius=8.0, shelters=5,
-                            well=True, racks=2, seed=42)
+        result = FORGE.call(
+            "env.camp", name="homeland", radius=8.0, shelters=5, well=True, racks=2, seed=42
+        )
         parts = {entry["part"] for entry in result["structures"]}
-        for expected in ("fire_stones", "fire_logs", "embers", "palisade",
-                         "well_stones", "well_frame", "ground"):
+        for expected in (
+            "fire_stones",
+            "fire_logs",
+            "embers",
+            "palisade",
+            "well_stones",
+            "well_frame",
+            "ground",
+        ):
             self.assertIn(expected, parts)
         hides = [p for p in parts if p.startswith("shelter_") and p.endswith("_hide")]
         self.assertEqual(len(hides), 5)
@@ -60,19 +68,26 @@ class Camp(ForgeCase):
 
     def test_gate_leaves_an_opening(self):
         """The palisade ring must skip the gate arc — the one way in."""
-        FORGE.call("env.camp", name="gated", radius=8.0, shelters=2, gate_angle=90.0,
-                   ground=False, seed=7)
+        FORGE.call(
+            "env.camp", name="gated", radius=8.0, shelters=2, gate_angle=90.0, ground=False, seed=7
+        )
         info = FORGE.call("object.inspect", name="gated_palisade")
         # At gate_angle=90 (+Y), no post may sit near (0, radius). Probe by
         # counting palisade triangles: a full ring has ~count*segments*2 tris;
         # the gate arc removes ~11 degrees * 2 of posts.
-        full = FORGE.call("env.camp", name="ungated", radius=8.0, shelters=2,
-                          palisade=True, gate_angle=999.0, ground=False, seed=7)
+        full = FORGE.call(
+            "env.camp",
+            name="ungated",
+            radius=8.0,
+            shelters=2,
+            palisade=True,
+            gate_angle=999.0,
+            ground=False,
+            seed=7,
+        )
         gated_tris = info["triangles"]
-        full_tris = next(e["triangles"] for e in full["structures"]
-                         if e["part"] == "palisade")
-        self.assertLess(gated_tris, full_tris,
-                        "the gate angle must remove posts from the ring")
+        full_tris = next(e["triangles"] for e in full["structures"] if e["part"] == "palisade")
+        self.assertLess(gated_tris, full_tris, "the gate angle must remove posts from the ring")
 
     def test_materials_are_separated(self):
         FORGE.call("env.camp", name="homeland", radius=8.0, shelters=3, seed=42)

--- a/tools/bforge/tests/test_forge.py
+++ b/tools/bforge/tests/test_forge.py
@@ -61,14 +61,34 @@ class Daemon(ForgeCase):
         self.assertGreaterEqual(FORGE.info["ops"], 80)
 
     def test_catalog_matches_the_committed_snapshot(self):
+        """Full-schema parity, not just op names.
+
+        The committed catalog drives MCP discovery, CLI help and the
+        OpenAI/Anthropic schema dumps without starting Blender, and the
+        runtime rejects unknown parameters — so a parameter that drifts
+        between registry and catalog makes an agent fail *because* it
+        followed the published schema. Comparing only op names let exactly
+        that happen once (mesh.retopo). Compare the complete entries.
+        """
         from bforge import schema as schema_mod
 
-        live = {op["name"] for op in FORGE.catalog()}
-        committed = {op["name"] for op in schema_mod.load_catalog()}
+        live = {op["name"]: op for op in FORGE.catalog()}
+        committed = {op["name"]: op for op in schema_mod.load_catalog()}
         self.assertEqual(
-            live,
-            committed,
+            set(live),
+            set(committed),
             "catalog.json is stale — run `bforge catalog --refresh`",
+        )
+        drifted = [
+            name
+            for name in sorted(live)
+            if json.dumps(live[name], sort_keys=True) != json.dumps(committed[name], sort_keys=True)
+        ]
+        self.assertEqual(
+            drifted,
+            [],
+            "catalog.json schemas drifted from the live registry for "
+            f"{drifted} — run `bforge catalog --refresh`",
         )
 
     def test_unknown_op_gives_a_helpful_error(self):

--- a/tools/bforge/tests/test_gait.py
+++ b/tools/bforge/tests/test_gait.py
@@ -68,8 +68,9 @@ class Humanoid(ForgeCase):
         self.assertEqual(fast["style"], "run")
         self.assertLess(slow["froude"], 0.55)
         self.assertGreater(fast["froude"], 0.55)
-        self.assertGreater(slow["frames"], fast["frames"],
-                           "a slower cadence means more frames per cycle")
+        self.assertGreater(
+            slow["frames"], fast["frames"], "a slower cadence means more frames per cycle"
+        )
 
     def test_explicit_style_and_cadence_math(self):
         rig = self._rig()
@@ -82,8 +83,7 @@ class Humanoid(ForgeCase):
     def test_gait_exports_as_animation(self):
         rig = self._rig()
         FORGE.call("char.gait", rig=rig["armature"], speed=1.4)
-        glb = FORGE.call("export.gltf", out="gait.glb",
-                         objects=[rig["armature"], "warden"])
+        glb = FORGE.call("export.gltf", out="gait.glb", objects=[rig["armature"], "warden"])
         parsed = read_glb_json(Path(glb["path"]))
         names = [a.get("name", "") for a in parsed.get("animations", [])]
         self.assertTrue(any("gait_walk" in n for n in names))
@@ -91,10 +91,10 @@ class Humanoid(ForgeCase):
 
 class Creature(ForgeCase):
     def test_quadruped_transitions_by_froude(self):
-        FORGE.call("char.creature", name="hound", plan="canine", length=1.3,
-                   shoulder=0.85, seed=5)
-        rig = FORGE.call("char.creature_rig", name="hound", plan="canine",
-                         length=1.3, shoulder=0.85)
+        FORGE.call("char.creature", name="hound", plan="canine", length=1.3, shoulder=0.85, seed=5)
+        rig = FORGE.call(
+            "char.creature_rig", name="hound", plan="canine", length=1.3, shoulder=0.85
+        )
         walk = FORGE.call("char.gait", rig=rig["armature"], speed=0.8)
         trot = FORGE.call("char.gait", rig=rig["armature"], speed=2.0)
         gallop = FORGE.call("char.gait", rig=rig["armature"], speed=5.0)
@@ -105,10 +105,12 @@ class Creature(ForgeCase):
         self.assertLess(trot["froude"], gallop["froude"])
 
     def test_hexapod_gets_tripod_gait(self):
-        FORGE.call("char.creature", name="scarab", plan="insect", length=0.9,
-                   shoulder=0.35, seed=17)
-        rig = FORGE.call("char.creature_rig", name="scarab", plan="insect",
-                         length=0.9, shoulder=0.35)
+        FORGE.call(
+            "char.creature", name="scarab", plan="insect", length=0.9, shoulder=0.35, seed=17
+        )
+        rig = FORGE.call(
+            "char.creature_rig", name="scarab", plan="insect", length=0.9, shoulder=0.35
+        )
         result = FORGE.call("char.gait", rig=rig["armature"], speed=0.4)
         self.assertEqual(result["family"], "hexapod")
         self.assertEqual(result["style"], "walk")
@@ -117,10 +119,12 @@ class Creature(ForgeCase):
     def test_determinism(self):
         def build_once(out):
             FORGE.call("session.reset")
-            FORGE.call("char.creature", name="hound", plan="canine", length=1.3,
-                       shoulder=0.85, seed=5)
-            rig = FORGE.call("char.creature_rig", name="hound", plan="canine",
-                             length=1.3, shoulder=0.85)
+            FORGE.call(
+                "char.creature", name="hound", plan="canine", length=1.3, shoulder=0.85, seed=5
+            )
+            rig = FORGE.call(
+                "char.creature_rig", name="hound", plan="canine", length=1.3, shoulder=0.85
+            )
             FORGE.call("char.gait", rig=rig["armature"], speed=2.0)
             return Path(FORGE.call("export.gltf", out=out)["path"]).read_bytes()
 

--- a/tools/bforge/tests/test_image.py
+++ b/tools/bforge/tests/test_image.py
@@ -51,12 +51,22 @@ def setUpModule():
     FORGE.start()
     # A red disc with alpha (clean segmentation), and a green triangle with no
     # alpha on a uniform backdrop (backdrop-distance segmentation).
-    _png_rgba(Path(TEMP.name) / "disc.png", 128, 128,
-              lambda x, y: (200, 30, 30, 255) if (x - 64) ** 2 + (y - 64) ** 2 < 40 ** 2
-              else (12, 12, 16, 255))
-    _png_rgba(Path(TEMP.name) / "tri.png", 128, 128,
-              lambda x, y: (30, 180, 60, 255) if y > 30 and abs(x - 64) < (y - 30) * 0.6
-              else (240, 240, 240, 255))
+    _png_rgba(
+        Path(TEMP.name) / "disc.png",
+        128,
+        128,
+        lambda x, y: (
+            (200, 30, 30, 255) if (x - 64) ** 2 + (y - 64) ** 2 < 40**2 else (12, 12, 16, 255)
+        ),
+    )
+    _png_rgba(
+        Path(TEMP.name) / "tri.png",
+        128,
+        128,
+        lambda x, y: (
+            (30, 180, 60, 255) if y > 30 and abs(x - 64) < (y - 30) * 0.6 else (240, 240, 240, 255)
+        ),
+    )
 
 
 def tearDownModule():
@@ -92,40 +102,57 @@ class Analyze(ForgeCase):
 
 class ToMesh(ForgeCase):
     def test_disc_extrudes_with_high_fidelity(self):
-        result = FORGE.call("image.to_mesh", path=str(Path(TEMP.name) / "disc.png"),
-                            name="medallion", target_height=1.0, depth=0.2,
-                            texture="project")
-        self.assertGreater(result["silhouette_iou"], 0.9,
-                           "the mesh silhouette must BE the picture's")
+        result = FORGE.call(
+            "image.to_mesh",
+            path=str(Path(TEMP.name) / "disc.png"),
+            name="medallion",
+            target_height=1.0,
+            depth=0.2,
+            texture="project",
+        )
+        self.assertGreater(
+            result["silhouette_iou"], 0.9, "the mesh silhouette must BE the picture's"
+        )
         self.assertGreater(result["triangles"], 50)
         self.assertLess(result["triangles"], 3000)
         self.assertAlmostEqual(result["bounds"]["size"][2], 1.0, delta=0.05)
         self.assertAlmostEqual(result["bounds"]["size"][1], 0.2, delta=0.1)
 
     def test_texture_variants_and_gate(self):
-        FORGE.call("image.to_mesh", path=str(Path(TEMP.name) / "disc.png"),
-                   name="flat", texture="none")
+        FORGE.call(
+            "image.to_mesh", path=str(Path(TEMP.name) / "disc.png"), name="flat", texture="none"
+        )
         review = FORGE.call("gameready.review", objects=["flat"])
         self.assertTrue(review["passed"], f"findings: {review['findings']}")
 
     def test_exports_cleanly(self):
         import json
         import struct as st
-        FORGE.call("image.to_mesh", path=str(Path(TEMP.name) / "disc.png"),
-                   name="medallion", texture="project")
+
+        FORGE.call(
+            "image.to_mesh",
+            path=str(Path(TEMP.name) / "disc.png"),
+            name="medallion",
+            texture="project",
+        )
         glb = FORGE.call("export.gltf", out="medallion.glb", objects=["medallion"])
         data = Path(glb["path"]).read_bytes()
         chunk_len, chunk_type = st.unpack_from("<I4s", data, 12)
-        parsed = json.loads(data[20:20 + chunk_len])
+        parsed = json.loads(data[20 : 20 + chunk_len])
         self.assertGreaterEqual(len(parsed["meshes"]), 1)
-        self.assertGreaterEqual(len(parsed.get("images", [])), 1,
-                                "projected texture must ship in the GLB")
+        self.assertGreaterEqual(
+            len(parsed.get("images", [])), 1, "projected texture must ship in the GLB"
+        )
 
     def test_determinism(self):
         def build_once(out):
             FORGE.call("session.reset")
-            FORGE.call("image.to_mesh", path=str(Path(TEMP.name) / "disc.png"),
-                       name="medallion", texture="none")
+            FORGE.call(
+                "image.to_mesh",
+                path=str(Path(TEMP.name) / "disc.png"),
+                name="medallion",
+                texture="none",
+            )
             return Path(FORGE.call("export.gltf", out=out)["path"]).read_bytes()
 
         self.assertEqual(build_once("img_a.glb"), build_once("img_b.glb"))

--- a/tools/bforge/tests/test_impostor.py
+++ b/tools/bforge/tests/test_impostor.py
@@ -123,11 +123,21 @@ class Impostor(ForgeCase):
     def test_identical_calls_produce_identical_output(self):
         self.forge.call("build.box", name="b", size=[1, 1, 1], bevel=0.0)
         first = self.forge.call(
-            "render.impostor", name="b", out="a.png", views=4, size=64, samples=8,
+            "render.impostor",
+            name="b",
+            out="a.png",
+            views=4,
+            size=64,
+            samples=8,
             _timeout=900,
         )
         second = self.forge.call(
-            "render.impostor", name="b", out="b.png", views=4, size=64, samples=8,
+            "render.impostor",
+            name="b",
+            out="b.png",
+            views=4,
+            size=64,
+            samples=8,
             _timeout=900,
         )
         self.assertEqual(

--- a/tools/bforge/tests/test_mcp.py
+++ b/tools/bforge/tests/test_mcp.py
@@ -26,7 +26,7 @@ class StubForge:
         self.fail_on = fail_on
         self.daemon_error_on = daemon_error_on
         self.process = None
-        self.info = {"blender": "5.2.0 LTS"}
+        self.info = {"blender": "4.5.12 LTS"}
         self.workdir = Path(".")
         self.out_dir = Path("out")
         self.restarted = False

--- a/tools/bforge/tests/test_morph.py
+++ b/tools/bforge/tests/test_morph.py
@@ -100,12 +100,14 @@ class Add(ForgeCase):
 
     def test_rules_actually_displace_different_verts(self):
         self.forge.call("build.box", name="b", size=[1, 1, 1])
-        dent = self.forge.call("morph.add", name="b", key="dent", rule="dent",
-                               amount=0.2, radius=2.0)
+        dent = self.forge.call(
+            "morph.add", name="b", key="dent", rule="dent", amount=0.2, radius=2.0
+        )
         self.forge.call("session.reset")
         self.forge.call("build.box", name="b", size=[1, 1, 1])
-        taper = self.forge.call("morph.add", name="b", key="taper", rule="taper",
-                                amount=0.5, radius=2.0)
+        taper = self.forge.call(
+            "morph.add", name="b", key="taper", rule="taper", amount=0.5, radius=2.0
+        )
         self.assertGreater(dent["vertices_moved"], 0)
         self.assertGreater(taper["vertices_moved"], 0)
 
@@ -148,8 +150,11 @@ class Animate(ForgeCase):
         self.forge.call("build.box", name="b", size=[1, 1, 1])
         self.forge.call("morph.add", name="b", key="dented", rule="dent", amount=0.2, radius=2.0)
         result = self.forge.call(
-            "morph.animate", name="b", key="dented",
-            frames=[1, 12, 24], values=[0.0, 1.0, 0.0],
+            "morph.animate",
+            name="b",
+            key="dented",
+            frames=[1, 12, 24],
+            values=[0.0, 1.0, 0.0],
         )
         self.assertEqual(result["keyframes"], 3)
         exported = self.forge.call("export.gltf", out="morph_anim.glb")
@@ -165,15 +170,15 @@ class Animate(ForgeCase):
         self.forge.call("build.box", name="b")
         self.forge.call("morph.add", name="b", key="dent", rule="dent")
         with self.assertRaises(ForgeError) as ctx:
-            self.forge.call("morph.animate", name="b", key="dent",
-                            frames=[1, 12], values=[0.0])
+            self.forge.call("morph.animate", name="b", key="dent", frames=[1, 12], values=[0.0])
         self.assertIn("same length", str(ctx.exception))
 
     def test_animate_requires_an_existing_key(self):
         self.forge.call("build.box", name="b")
         with self.assertRaises(ForgeError):
-            self.forge.call("morph.animate", name="b", key="ghost",
-                            frames=[1, 12], values=[0.0, 1.0])
+            self.forge.call(
+                "morph.animate", name="b", key="ghost", frames=[1, 12], values=[0.0, 1.0]
+            )
 
 
 if __name__ == "__main__":

--- a/tools/bforge/tests/test_paint.py
+++ b/tools/bforge/tests/test_paint.py
@@ -71,8 +71,14 @@ def read_glb(path: Path):
     return gltf, binary
 
 
-_COMPONENT = {5120: ("b", 1, None), 5121: ("B", 1, 255), 5122: ("h", 2, None),
-              5123: ("H", 2, 65535), 5125: ("I", 4, None), 5126: ("f", 4, None)}
+_COMPONENT = {
+    5120: ("b", 1, None),
+    5121: ("B", 1, 255),
+    5122: ("h", 2, None),
+    5123: ("H", 2, 65535),
+    5125: ("I", 4, None),
+    5126: ("f", 4, None),
+}
 _TYPE_LEN = {"SCALAR": 1, "VEC2": 2, "VEC3": 3, "VEC4": 4}
 
 
@@ -121,7 +127,8 @@ class Fill(ForgeCase):
         for channel in range(3):
             values = [c[channel] for c in colors]
             self.assertLessEqual(
-                max(values) - min(values), 0.02,
+                max(values) - min(values),
+                0.02,
                 "a flat fill must come back uniform",
             )
         # #8899aa is a cool grey: blue channel clearly above red.
@@ -146,7 +153,8 @@ class Height(ForgeCase):
         _gltf, colors = read_colors(Path(exported["path"]))
         luma = [0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2] for c in colors]
         self.assertGreater(
-            max(luma) - min(luma), 0.5,
+            max(luma) - min(luma),
+            0.5,
             f"a black-to-white gradient over 2 m must span most of the range: {min(luma):.3f}..{max(luma):.3f}",
         )
 
@@ -166,8 +174,9 @@ class Noise(ForgeCase):
     def test_noise_is_deterministic_for_a_seed(self):
         def bake(out):
             self.forge.call("build.plane", name="p", size=[4, 4], cuts=8)
-            self.forge.call("paint.noise", name="p", color_a="#000000", color_b="#ffffff",
-                            scale=2.0, seed=7)
+            self.forge.call(
+                "paint.noise", name="p", color_a="#000000", color_b="#ffffff", scale=2.0, seed=7
+            )
             exported = self.forge.call("export.gltf", out=out)
             _gltf, colors = read_colors(Path(exported["path"]))
             return colors
@@ -189,8 +198,9 @@ class Noise(ForgeCase):
 
     def test_noise_actually_varies_across_the_mesh(self):
         self.forge.call("build.plane", name="p", size=[4, 4], cuts=8)
-        self.forge.call("paint.noise", name="p", color_a="#000000", color_b="#ffffff",
-                        scale=2.0, seed=7)
+        self.forge.call(
+            "paint.noise", name="p", color_a="#000000", color_b="#ffffff", scale=2.0, seed=7
+        )
         exported = self.forge.call("export.gltf", out="noise_var.glb")
         _gltf, colors = read_colors(Path(exported["path"]))
         luma = {round(c[0], 2) for c in colors}
@@ -214,8 +224,7 @@ class Cavity(ForgeCase):
     def test_edge_mode_paints_convex_ridges_instead(self):
         self.forge.call("build.box", name="b", size=[1, 1, 1])
         cavity = self.forge.call("paint.cavity", name="b", color="#000000", mode="cavity")
-        edge = self.forge.call("paint.cavity", name="b", color="#ffffff", mode="edge",
-                               layer="wear")
+        edge = self.forge.call("paint.cavity", name="b", color="#ffffff", mode="edge", layer="wear")
         # A bevelled box has both concave-free flats and convex chamfer edges;
         # the two modes must not agree on zero.
         self.assertGreaterEqual(cavity["loops_painted"], 0)

--- a/tools/bforge/tests/test_quality_gate.py
+++ b/tools/bforge/tests/test_quality_gate.py
@@ -56,8 +56,14 @@ def _three_mud_materials(forge: Forge, name="blob"):
         (("#4a3828", "m_mud_a"), ("#4b3929", "m_mud_b"), ("#493827", "m_mud_c"))
     ):
         forge.call(
-            "material.set", object=name, preset="metal", name=mat_name, slot=slot,
-            color=brown, roughness=0.7, metallic=0.0,
+            "material.set",
+            object=name,
+            preset="metal",
+            name=mat_name,
+            slot=slot,
+            color=brown,
+            roughness=0.7,
+            metallic=0.0,
         )
     return name
 
@@ -79,12 +85,36 @@ class Materials(ForgeCase):
 
     def test_separated_materials_pass(self):
         FORGE.call("build.box", name="good", size=[1.0, 1.0, 1.0])
-        FORGE.call("material.set", object="good", preset="metal", name="m_red_cloth", slot=0,
-                   color="#8c1f1f", roughness=0.85, metallic=0.0)
-        FORGE.call("material.set", object="good", preset="metal", name="m_brass", slot=1,
-                   color="#c8b06a", roughness=0.3, metallic=1.0)
-        FORGE.call("material.set", object="good", preset="metal", name="m_slate", slot=2,
-                   color="#2a4a6a", roughness=0.6, metallic=0.0)
+        FORGE.call(
+            "material.set",
+            object="good",
+            preset="metal",
+            name="m_red_cloth",
+            slot=0,
+            color="#8c1f1f",
+            roughness=0.85,
+            metallic=0.0,
+        )
+        FORGE.call(
+            "material.set",
+            object="good",
+            preset="metal",
+            name="m_brass",
+            slot=1,
+            color="#c8b06a",
+            roughness=0.3,
+            metallic=1.0,
+        )
+        FORGE.call(
+            "material.set",
+            object="good",
+            preset="metal",
+            name="m_slate",
+            slot=2,
+            color="#2a4a6a",
+            roughness=0.6,
+            metallic=0.0,
+        )
         result = FORGE.call("check.materials", objects=["good"])
         self.assertTrue(result["separated"], f"unexpected findings: {result['findings']}")
         self.assertGreater(result["max_delta_e"], 12.0)
@@ -127,22 +157,27 @@ class ExportGate(ForgeCase):
         name = _three_mud_materials(FORGE)
         FORGE.call("uv.unwrap", object=name, style="smart_packed")
         with self.assertRaises(ForgeError) as ctx:
-            FORGE.call("export.asset", asset_id="mud_blob", objects=[name],
-                       contact_sheet=False)
+            FORGE.call("export.asset", asset_id="mud_blob", objects=[name], contact_sheet=False)
         self.assertIn("gameready.review", str(ctx.exception))
         self.assertIn("gate=false", str(ctx.exception))
 
     def test_gate_false_exports_anyway(self):
         name = _three_mud_materials(FORGE)
         FORGE.call("uv.unwrap", object=name, style="smart_packed")
-        result = FORGE.call("export.asset", asset_id="mud_blob_forced", objects=[name],
-                            contact_sheet=False, gate=False)
+        result = FORGE.call(
+            "export.asset",
+            asset_id="mud_blob_forced",
+            objects=[name],
+            contact_sheet=False,
+            gate=False,
+        )
         self.assertEqual(result["asset_id"], "mud_blob_forced")
 
     def test_gate_passes_a_clean_prop(self):
         FORGE.call("prop.barrel", name="barrel", height=1.1, bands=3, seed=7)
-        result = FORGE.call("export.asset", asset_id="barrel_gated", objects=["barrel"],
-                            contact_sheet=False)
+        result = FORGE.call(
+            "export.asset", asset_id="barrel_gated", objects=["barrel"], contact_sheet=False
+        )
         self.assertEqual(result["asset_id"], "barrel_gated")
 
 

--- a/tools/bforge/tests/test_recipe.py
+++ b/tools/bforge/tests/test_recipe.py
@@ -1,0 +1,329 @@
+"""Recipe IR (bforge cook) tests.
+
+Unit tests run anywhere; the live test boots a real Blender daemon through
+the compiler and proves the full path: recipe -> gates -> export -> proof,
+with a content-addressed cache hit on the second run and byte-identical
+artifacts on a forced rebuild.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, find_blender  # noqa: E402
+
+from bforge import recipe as recipe_mod  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[3]
+EXAMPLES = REPO / "tools" / "bforge" / "examples" / "recipes"
+
+
+def base_recipe() -> dict:
+    return {
+        "recipe_version": 1,
+        "asset_id": "widget",
+        "steps": [{"op": "build.box", "args": {"name": "widget", "size": [1, 1, 1]}}],
+        "requirements": {"max_triangles": 2000},
+        "export": {"engine": "godot", "category": "prop"},
+    }
+
+
+class FakeForge:
+    """A started-or-startable worker double; records calls, returns gates."""
+
+    instances: list[FakeForge] = []
+    gate_ok = True
+    budget_ok = True
+    reported_blender: str = ""  # set in setUp from the lock
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self.stopped = False
+        FakeForge.instances.append(self)
+
+    def start(self) -> dict:
+        return {"blender": FakeForge.reported_blender, "python": "fake", "ops": 136}
+
+    def stop(self):
+        self.stopped = True
+
+    def call(self, op, _timeout=None, **args):
+        self.calls.append((op, args))
+        if op == "check.asset":
+            return {"ok": FakeForge.gate_ok, "errors": 0 if FakeForge.gate_ok else 1}
+        if op == "gameready.budget":
+            if FakeForge.budget_ok is None:
+                return {"profile": "browser_webgpu"}  # malformed: no verdict
+            return {"within_budget": FakeForge.budget_ok}
+        if op == "export.asset":  # stand in for the artifact the daemon would write
+            out = Path(args["out_dir"]) / "pkg" / "widget.glb"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"glTF-fake-bytes")
+            return {"ok": True, "glb": str(out)}
+        return {"ok": True}
+
+
+class Canon(unittest.TestCase):
+    def test_canonicalize_ignores_key_order_and_whitespace(self):
+        a = json.loads(json.dumps(base_recipe(), indent=2))
+        b = json.loads(json.dumps(base_recipe()))
+        b["steps"][0]["args"] = dict(reversed(list(b["steps"][0]["args"].items())))
+        self.assertEqual(recipe_mod.canonicalize(a), recipe_mod.canonicalize(b))
+
+    def test_content_hash_tracks_step_args(self):
+        recipe = base_recipe()
+        changed = base_recipe()
+        changed["steps"][0]["args"]["size"] = [2, 1, 1]
+        self.assertNotEqual(
+            recipe_mod.content_hash(recipe, {}), recipe_mod.content_hash(changed, {})
+        )
+
+    def test_content_hash_covers_input_bytes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "in.bin"
+            path.write_bytes(b"v1")
+            recipe = base_recipe()
+            recipe["inputs"] = {"data": {"path": "in.bin"}}
+            first = recipe_mod.content_hash(recipe, recipe_mod.hash_inputs(recipe, Path(tmp)))
+            path.write_bytes(b"v2")
+            second = recipe_mod.content_hash(recipe, recipe_mod.hash_inputs(recipe, Path(tmp)))
+            self.assertNotEqual(first, second)
+
+
+class Validation(unittest.TestCase):
+    def write(self, tmp: str, recipe) -> Path:
+        path = Path(tmp) / "r.json"
+        path.write_text(json.dumps(recipe))
+        return path
+
+    def test_rejects_wrong_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            recipe = base_recipe()
+            recipe["recipe_version"] = 99
+            with self.assertRaises(recipe_mod.RecipeError):
+                recipe_mod.load_recipe(self.write(tmp, recipe))
+
+    def test_rejects_empty_steps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            recipe = base_recipe()
+            recipe["steps"] = []
+            with self.assertRaises(recipe_mod.RecipeError):
+                recipe_mod.load_recipe(self.write(tmp, recipe))
+
+    def test_input_hash_mismatch_is_a_hard_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "in.bin").write_bytes(b"actual")
+            recipe = base_recipe()
+            recipe["inputs"] = {"data": {"path": "in.bin", "sha256": "0" * 64}}
+            with self.assertRaises(recipe_mod.RecipeError):
+                recipe_mod.hash_inputs(recipe, Path(tmp))
+
+
+class CookFakeWorker(unittest.TestCase):
+    def setUp(self):
+        FakeForge.instances = []
+        FakeForge.gate_ok = True
+        FakeForge.budget_ok = True
+        FakeForge.reported_blender = recipe_mod.pinned_blender_version() or "unknown"
+
+    def cook(self, tmp: str, recipe: dict | None = None, **kwargs) -> dict:
+        path = Path(tmp) / "r.json"
+        if recipe is not None or not path.exists():
+            path.write_text(json.dumps(recipe if recipe is not None else base_recipe()))
+        return recipe_mod.cook(
+            path, cache_dir=Path(tmp) / "cache", forge_factory=FakeForge, **kwargs
+        )
+
+    def test_miss_runs_steps_gates_export_and_writes_proof(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            proof = self.cook(tmp)
+            self.assertEqual(proof["status"], "pass")
+            self.assertFalse(proof["cache"]["hit"])
+            ops = [op for op, _ in FakeForge.instances[0].calls]
+            self.assertEqual(ops[0], "session.reset")
+            self.assertIn("build.box", ops)
+            self.assertIn("check.asset", ops)  # from requirements.max_triangles
+            self.assertIn("export.asset", ops)
+            self.assertTrue(FakeForge.instances[0].stopped)
+            on_disk = json.loads((Path(proof["cache"]["dir"]) / "proof.json").read_text())
+            self.assertEqual(on_disk["recipe_hash"], proof["recipe_hash"])
+            self.assertTrue((Path(proof["cache"]["dir"]) / "recipe.canonical.json").is_file())
+
+    def test_hit_returns_proof_without_a_worker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = self.cook(tmp)
+            self.assertEqual(len(FakeForge.instances), 1)
+            second = self.cook(tmp)
+            self.assertTrue(second["cache"]["hit"])
+            self.assertEqual(len(FakeForge.instances), 1, "cache hit must not boot a worker")
+            self.assertEqual(first["recipe_hash"], second["recipe_hash"])
+
+    def test_no_cache_forces_rebuild(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.cook(tmp)
+            self.cook(tmp, no_cache=True)
+            self.assertEqual(len(FakeForge.instances), 2)
+
+    def test_gate_failure_raises_and_is_not_cached(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            FakeForge.gate_ok = False
+            with self.assertRaises(recipe_mod.RecipeError):
+                self.cook(tmp)
+            FakeForge.gate_ok = True
+            proof = self.cook(tmp)  # a failed proof must not satisfy the cache
+            self.assertEqual(proof["status"], "pass")
+            self.assertEqual(len(FakeForge.instances), 2)
+
+    def test_compiler_fingerprint_change_is_a_cache_miss(self):
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.cook(tmp)
+            self.assertEqual(len(FakeForge.instances), 1)
+            different = dict(recipe_mod.compiler_fingerprint(), python="0.0.0-different")
+            with mock.patch.object(recipe_mod, "compiler_fingerprint", return_value=different):
+                proof = self.cook(tmp)
+            self.assertEqual(
+                len(FakeForge.instances), 2, "a changed compiler must not reuse the cache"
+            )
+            self.assertFalse(proof["cache"]["hit"])
+
+    def test_tampered_artifact_invalidates_the_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            proof = self.cook(tmp)
+            artifact = Path(proof["cache"]["dir"]) / "pkg" / "widget.glb"
+            artifact.write_bytes(b"tampered")
+            self.cook(tmp)
+            self.assertEqual(
+                len(FakeForge.instances), 2, "a tampered artifact must force a rebuild"
+            )
+
+    def test_artifact_paths_are_relative_not_basenames(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            proof = self.cook(tmp)
+            paths = [a["path"] for a in proof["artifacts"]]
+            self.assertIn("pkg/widget.glb", paths)
+            self.assertNotIn("widget.glb", paths)
+
+    def test_over_budget_fails_closed(self):
+        recipe = base_recipe()
+        recipe["requirements"]["platform"] = "browser_webgpu"
+        with tempfile.TemporaryDirectory() as tmp:
+            FakeForge.budget_ok = False
+            with self.assertRaises(recipe_mod.RecipeError):
+                self.cook(tmp, recipe)
+            FakeForge.budget_ok = True
+            proof = self.cook(tmp, recipe)  # a budget failure must not satisfy the cache
+            self.assertEqual(proof["status"], "pass")
+
+    def test_malformed_budget_result_fails_closed(self):
+        recipe = base_recipe()
+        recipe["requirements"]["platform"] = "browser_webgpu"
+        with tempfile.TemporaryDirectory() as tmp:
+            FakeForge.budget_ok = None  # no within_budget verdict at all
+            with self.assertRaises(recipe_mod.RecipeError):
+                self.cook(tmp, recipe)
+
+    def test_unpinned_blender_is_rejected_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            FakeForge.reported_blender = "9.9.9"
+            with self.assertRaises(recipe_mod.RecipeError):
+                self.cook(tmp)
+            self.assertFalse(
+                any((Path(tmp) / "cache").rglob("proof.json")),
+                "an unpinned build must not write into the content-addressed store",
+            )
+
+    def test_allow_unpinned_diverts_and_never_caches(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            FakeForge.reported_blender = "9.9.9"
+            proof = self.cook(tmp, allow_unpinned=True)
+            self.assertEqual(proof["status"], "pass")
+            self.assertFalse(proof["cache"]["cacheable"])
+            self.assertTrue(proof["cache"]["ephemeral"])
+            self.assertIn("staging", proof["cache"]["dir"])
+            self.cook(tmp, allow_unpinned=True)
+            self.assertEqual(
+                len(FakeForge.instances), 2, "unpinned results must never be cache hits"
+            )
+
+    def test_proof_metadata_tamper_forces_rebuild_and_quarantine(self):
+        """Editing the proof's toolchain/gates/identity must invalidate the
+        entry — verifying only the artifacts a proof NAMES is not a chain."""
+        with tempfile.TemporaryDirectory() as tmp:
+            first = self.cook(tmp)
+            proof_path = Path(first["cache"]["dir"]) / "proof.json"
+            tampered = json.loads(proof_path.read_text())
+            tampered["toolchain"]["blender"] = "tampered-9.9.9"
+            proof_path.write_text(json.dumps(tampered, indent=2) + "\n")
+            second = self.cook(tmp)
+            self.assertEqual(len(FakeForge.instances), 2, "tampered metadata must force a rebuild")
+            self.assertEqual(second["toolchain"]["blender"], FakeForge.reported_blender)
+            quarantined = list((Path(tmp) / "cache" / "failures").glob("corrupt-*"))
+            self.assertTrue(quarantined, "the tampered entry must be quarantined, not reused")
+
+    def test_stale_file_in_the_store_invalidates_the_entry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = self.cook(tmp)
+            (Path(first["cache"]["dir"]) / "leftover.txt").write_text("from an older build")
+            self.cook(tmp)
+            self.assertEqual(
+                len(FakeForge.instances), 2, "an unrecorded file must invalidate the entry"
+            )
+
+    def test_strict_json_rejects_non_finite_constants(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            recipe = base_recipe()
+            text = json.dumps(recipe).replace('"max_triangles": 2000', '"max_triangles": NaN')
+            path = Path(tmp) / "r.json"
+            path.write_text(text)
+            with self.assertRaises(recipe_mod.RecipeError):
+                self.cook(tmp)
+
+
+BLENDER = None
+try:
+    if not os.environ.get("BFORGE_SKIP_LIVE"):
+        BLENDER = find_blender()
+except DaemonError:
+    BLENDER = None
+
+
+@unittest.skipIf(BLENDER is None, "Blender not available")
+class CookLive(unittest.TestCase):
+    def test_crate_recipe_end_to_end(self):
+        tmp = Path(tempfile.mkdtemp(prefix="bforge_recipe_"))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        cache = tmp / "cache"
+
+        def factory() -> Forge:
+            return Forge(workdir=str(tmp), out_dir=str(tmp / "out"))
+
+        recipe_path = EXAMPLES / "crate.json"
+        proof = recipe_mod.cook(recipe_path, cache_dir=cache, forge_factory=factory)
+        self.assertEqual(proof["status"], "pass")
+        self.assertTrue(proof["artifacts"], "export must produce hashed artifacts")
+        glb = next(a for a in proof["artifacts"] if a["path"].endswith(".glb"))
+
+        cached = recipe_mod.cook(recipe_path, cache_dir=cache, forge_factory=factory)
+        self.assertTrue(cached["cache"]["hit"])
+
+        rebuilt = recipe_mod.cook(
+            recipe_path, cache_dir=cache, no_cache=True, forge_factory=factory
+        )
+        glb_again = next(a for a in rebuilt["artifacts"] if a["path"].endswith(".glb"))
+        self.assertEqual(
+            glb["sha256"], glb_again["sha256"], "same recipe must rebuild byte-identical GLB"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bforge/tests/test_schema.py
+++ b/tools/bforge/tests/test_schema.py
@@ -117,6 +117,16 @@ class Dialects(unittest.TestCase):
         for op in self.ops:
             self.assertIn(f"`{op['name']}`", text)
 
+    def test_committed_ops_reference_matches_the_catalog(self):
+        """docs/bforge/OPS.md is generated; fail when it drifts from the catalog."""
+        reference = Path(__file__).resolve().parents[3] / "docs" / "bforge" / "OPS.md"
+        self.assertTrue(reference.is_file(), f"missing {reference}")
+        self.assertEqual(
+            reference.read_text(encoding="utf-8"),
+            schema_mod.markdown_reference(self.ops),
+            "OPS.md is stale — run `just bforge-catalog`",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/bforge/tests/test_style.py
+++ b/tools/bforge/tests/test_style.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+from bforge.client import DaemonError, Forge, find_blender  # noqa: E402
 
 FORGE: Forge | None = None
 TEMP: tempfile.TemporaryDirectory | None = None
@@ -50,8 +50,15 @@ class ForgeCase(unittest.TestCase):
 
 
 def _styled_box(name, color="#777777", uv_scale=1.0):
-    FORGE.call("build.box", name=name, size=[1.0, 1.0, 1.0],
-               material="metal", color=color, uv="box", uv_scale=uv_scale)
+    FORGE.call(
+        "build.box",
+        name=name,
+        size=[1.0, 1.0, 1.0],
+        material="metal",
+        color=color,
+        uv="box",
+        uv_scale=uv_scale,
+    )
     return name
 
 
@@ -60,8 +67,14 @@ class Style(ForgeCase):
         _styled_box("crate_a")
         result = FORGE.call("check.style")
         fp = result["objects"][0]
-        for key in ("palette", "texel_density", "hard_edge_ratio", "materials",
-                    "tris_per_m3", "uv_coverage"):
+        for key in (
+            "palette",
+            "texel_density",
+            "hard_edge_ratio",
+            "materials",
+            "tris_per_m3",
+            "uv_coverage",
+        ):
             self.assertIn(key, fp)
         self.assertEqual(fp["materials"], 1)
         self.assertGreater(fp["texel_density"], 0)
@@ -76,8 +89,9 @@ class Conformance(ForgeCase):
         result = FORGE.call("check.conformance")
         self.assertEqual(result["outliers"], [])
         for row in result["objects"]:
-            self.assertEqual(row["verdict"], "coherent",
-                             f"{row['object']} should be coherent: {row}")
+            self.assertEqual(
+                row["verdict"], "coherent", f"{row['object']} should be coherent: {row}"
+            )
 
     def test_palette_and_texel_drift_are_caught_and_named(self):
         _styled_box("a")
@@ -107,8 +121,9 @@ class Conformance(ForgeCase):
         FORGE.call("prop.crate", name="crate", seed=3)
         FORGE.call("prop.barrel", name="barrel", height=1.1, bands=3, seed=7)
         result = FORGE.call("check.conformance")
-        self.assertEqual(result["outliers"], [],
-                         f"stock props should look like one game: {result['objects']}")
+        self.assertEqual(
+            result["outliers"], [], f"stock props should look like one game: {result['objects']}"
+        )
 
 
 if __name__ == "__main__":

--- a/tools/ci/check_claims.py
+++ b/tools/ci/check_claims.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Fail CI when the repository's prose disagrees with its artifacts.
+
+Verification is this project's brand; its public numbers have drifted from the
+code more than once (op counts, patch counts, release boundaries, a committed
+catalog whose schema disagreed with the live registry). This script is the
+gate: it derives the true values from the pinned artifacts — the bforge
+catalog, the bforge test tree, and the engine lock — and checks the rules in
+docs/claims.toml against the prose surfaces that quote them.
+
+Stdlib only, so the hosted policy job can run it with a bare interpreter.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+RULES_REL = Path("docs") / "claims.toml"
+
+
+def _count_bforge_tests(tests_dir: Path) -> tuple[int, int]:
+    """(total, blender-backed) test methods.
+
+    A suite counts as Blender-backed when it resolves a Blender binary or
+    honors BFORGE_SKIP_LIVE — i.e. it boots (or would boot) the daemon.
+    """
+    total = backed = 0
+    for path in sorted(tests_dir.glob("test_*.py")):
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text, filename=str(path))
+        n = sum(
+            1
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+        )
+        total += n
+        if "find_blender" in text or "BFORGE_SKIP_LIVE" in text:
+            backed += n
+    return total, backed
+
+
+def derive_values(repo: Path) -> dict[str, int]:
+    catalog = json.loads((repo / "tools" / "bforge" / "catalog.json").read_text(encoding="utf-8"))
+    ops = catalog["ops"]
+    lock = tomllib.loads((repo / "engine" / "engine-lock.toml").read_text(encoding="utf-8"))
+    tests_total, tests_backed = _count_bforge_tests(repo / "tools" / "bforge" / "tests")
+    return {
+        "bforge.ops": len(ops),
+        "bforge.namespaces": len({op["name"].split(".")[0] for op in ops}),
+        "bforge.tests": tests_total,
+        "bforge.tests_blender": tests_backed,
+        "engine.patches": len(lock["patches"]["series"]),
+    }
+
+
+def check(repo: Path = REPO) -> list[str]:
+    """Return a list of human-readable violations; empty means consistent."""
+    rules = tomllib.loads((repo / RULES_REL).read_text(encoding="utf-8"))
+    derived = derive_values(repo)
+    problems: list[str] = []
+
+    for surface in rules.get("surface", []):
+        key = surface["key"]
+        if key not in derived:
+            problems.append(f"claims.toml: unknown derived key {key!r}")
+            continue
+        expected = derived[key]
+        group = int(surface.get("group", 1))
+        path = repo / surface["file"]
+        text = path.read_text(encoding="utf-8") if path.is_file() else None
+        if text is None:
+            problems.append(f"{surface['file']}: missing surface file")
+            continue
+        for pattern in surface["patterns"]:
+            matches = list(re.finditer(pattern, text))
+            if not matches:
+                problems.append(
+                    f"{surface['file']}: pattern not found: {pattern!r} "
+                    f"(expected {key}={expected} to be stated this way)"
+                )
+                continue
+            for match in matches:
+                found = int(match.group(group))
+                if found != expected:
+                    problems.append(
+                        f"{surface['file']}: claims {found} but {key} is {expected} "
+                        f"(matched {match.group(0)!r})"
+                    )
+
+    for rule in rules.get("forbidden", []):
+        for rel in rule["files"]:
+            path = repo / rel
+            if not path.is_file():
+                problems.append(f"{rel}: missing surface file (forbidden-claim rule)")
+                continue
+            if rule["phrase"] in path.read_text(encoding="utf-8"):
+                problems.append(f"{rel}: forbidden claim {rule['phrase']!r} — {rule['reason']}")
+
+    return problems
+
+
+def main() -> int:
+    problems = check()
+    if problems:
+        print("claim check FAILED — prose disagrees with the pinned artifacts:")
+        for problem in problems:
+            print(f"  - {problem}")
+        print("rules: docs/claims.toml (fix the prose or regenerate the artifact)")
+        return 1
+    derived = derive_values(REPO)
+    summary = ", ".join(f"{key}={value}" for key, value in sorted(derived.items()))
+    print(f"claim check OK ({summary})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/godot/qa_capture.py
+++ b/tools/godot/qa_capture.py
@@ -41,18 +41,25 @@ RUNNER = "res://addons/studio_core/tools/qa_capture.gd"
 
 def godot_args(project: Path, method: str, renderer: str, user_args: list[str]) -> list[str]:
     return [
-        "--path", str(project),
-        "--rendering-method", method,
-        "--rendering-driver", renderer,
-        "--script", RUNNER,
-        "--", *user_args,
+        "--path",
+        str(project),
+        "--rendering-method",
+        method,
+        "--rendering-driver",
+        renderer,
+        "--script",
+        RUNNER,
+        "--",
+        *user_args,
     ]
 
 
 def list_shots(project: Path, method: str, renderer: str, driver: str, timeout: int) -> list[str]:
     code, output = rg.run_godot(
         godot_args(project, method, renderer, [f"--driver={driver}", "--list"]),
-        project, timeout, isolate_user_data=True,
+        project,
+        timeout,
+        isolate_user_data=True,
     )
     if code != 0:
         print(output, file=sys.stderr)
@@ -68,21 +75,28 @@ def list_shots(project: Path, method: str, renderer: str, driver: str, timeout: 
 def out_dir_of(project: Path, out_arg: str) -> Path:
     if not out_arg.startswith("res://"):
         raise SystemExit("--out must be a res:// path (it is resolved inside the project)")
-    return project / out_arg[len("res://"):]
+    return project / out_arg[len("res://") :]
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--game", default="templates/godot-game")
-    parser.add_argument("--driver", default="res://tests/qa_shots.gd",
-                        help="game-side shot declaration script")
+    parser.add_argument(
+        "--driver", default="res://tests/qa_shots.gd", help="game-side shot declaration script"
+    )
     parser.add_argument("--out", default="res://build/qa")
     parser.add_argument("--shots", default="", help="comma-separated subset of shot names")
     parser.add_argument("--devices", default="", help="comma-separated subset of device presets")
-    parser.add_argument("--method", default="gl_compatibility",
-                        help="rendering method (gl_compatibility works without a GPU)")
-    parser.add_argument("--renderer", default="",
-                        help="rendering driver (default: opengl3_angle on Windows, opengl3 elsewhere)")
+    parser.add_argument(
+        "--method",
+        default="gl_compatibility",
+        help="rendering method (gl_compatibility works without a GPU)",
+    )
+    parser.add_argument(
+        "--renderer",
+        default="",
+        help="rendering driver (default: opengl3_angle on Windows, opengl3 elsewhere)",
+    )
     parser.add_argument("--list", action="store_true", help="list the game's shots and exit")
     parser.add_argument("--json", action="store_true", help="print the merged report as JSON")
     parser.add_argument("--warn-only", action="store_true")
@@ -134,7 +148,9 @@ def main() -> int:
         try:
             code, output = rg.run_godot(
                 godot_args(project, args.method, renderer, user_args),
-                project, args.timeout, isolate_user_data=True,
+                project,
+                args.timeout,
+                isolate_user_data=True,
             )
         except SystemExit as exc:
             # run_godot raises on a hard timeout. One wedged shot may not
@@ -146,8 +162,10 @@ def main() -> int:
             continue
         print(output)
         if "[qa] runner alive" not in output:
-            print(f"[{name}] runner marker missing — parse error in an addon or the driver?",
-                  file=sys.stderr)
+            print(
+                f"[{name}] runner marker missing — parse error in an addon or the driver?",
+                file=sys.stderr,
+            )
             return 2
         if "nothing to run" in output:
             # Device filter excluded every job of this shot; not a failure.
@@ -155,8 +173,10 @@ def main() -> int:
         if not report_path.exists():
             # The runner writes the report even when findings fail the run, so
             # a missing report means the process died mid-shot.
-            print(f"[{name}] godot exited {code} without a report — counting as a crash",
-                  file=sys.stderr)
+            print(
+                f"[{name}] godot exited {code} without a report — counting as a crash",
+                file=sys.stderr,
+            )
             merged["crashed"].append({"shot": name, "exit_code": code})
             merged["tool_failures"] += 1
             worst = max(worst, 2)
@@ -179,8 +199,10 @@ def main() -> int:
     if args.json:
         print(json.dumps(merged, indent=2))
     stills = len(merged["results"])
-    print(f"[qa] sweep: {stills} still(s), {merged['findings']} finding(s), "
-          f"{merged['tool_failures']} tool failure(s) -> {report_path}")
+    print(
+        f"[qa] sweep: {stills} still(s), {merged['findings']} finding(s), "
+        f"{merged['tool_failures']} tool failure(s) -> {report_path}"
+    )
     return worst
 
 

--- a/tools/godot/run_godot.py
+++ b/tools/godot/run_godot.py
@@ -145,9 +145,15 @@ def stage_budget(project: Path, profile: str, scene: str, frames: int, timeout: 
         return 2
     code, output = run_godot(
         [
-            "--headless", "--path", str(project),
-            "--script", "res://addons/studio_core/tools/audit_scene_budget.gd",
-            "--", f"--scene={target}", f"--profile={profile}", f"--frames={frames}",
+            "--headless",
+            "--path",
+            str(project),
+            "--script",
+            "res://addons/studio_core/tools/audit_scene_budget.gd",
+            "--",
+            f"--scene={target}",
+            f"--profile={profile}",
+            f"--frames={frames}",
         ],
         project,
         timeout,
@@ -162,14 +168,20 @@ def main() -> int:
     parser.add_argument("--game", default="templates/godot-game")
     parser.add_argument("--import-only", action="store_true")
     parser.add_argument("--tests", action="store_true")
-    parser.add_argument("--budget", action="store_true",
-                        help="audit the main scene against its render profile budgets")
-    parser.add_argument("--profile", default="browser_webgpu",
-                        help="render profile to apply and audit against")
-    parser.add_argument("--scene", default="",
-                        help="scene to audit (defaults to the project's main scene)")
-    parser.add_argument("--frames", type=int, default=30,
-                        help="frames to let the scene build before measuring")
+    parser.add_argument(
+        "--budget",
+        action="store_true",
+        help="audit the main scene against its render profile budgets",
+    )
+    parser.add_argument(
+        "--profile", default="browser_webgpu", help="render profile to apply and audit against"
+    )
+    parser.add_argument(
+        "--scene", default="", help="scene to audit (defaults to the project's main scene)"
+    )
+    parser.add_argument(
+        "--frames", type=int, default=30, help="frames to let the scene build before measuring"
+    )
     parser.add_argument("--timeout", type=int, default=300)
     args = parser.parse_args()
 

--- a/tools/studio-mcp/tests/test_ci_tools.py
+++ b/tools/studio-mcp/tests/test_ci_tools.py
@@ -42,7 +42,7 @@ class CiRunnerTests(unittest.TestCase):
             return 0
 
         self.assertEqual(self.run_silently("pr", runner), 0)
-        self.assertEqual(called, ["test", "lint", "secret-scan"])
+        self.assertEqual(called, ["test", "lint", "secret-scan", "check-claims"])
 
     def test_nightly_extends_pr_with_slow_gates(self) -> None:
         called: list[str] = []
@@ -58,6 +58,7 @@ class CiRunnerTests(unittest.TestCase):
                 "test",
                 "lint",
                 "secret-scan",
+                "check-claims",
                 "test-generated",
                 "test-db",
                 "release-validate",
@@ -189,6 +190,62 @@ jobs:
 """
         )
         self.assertTrue(any("not pinned to a full commit" in item for item in problems))
+
+
+check_claims = load_script("studio_ci_check_claims", REPO / "tools" / "ci" / "check_claims.py")
+
+
+class CheckClaimsTests(unittest.TestCase):
+    def make_repo(self, root: Path) -> Path:
+        """A minimal synthetic repo with one op, one test, one patch."""
+        (root / "tools" / "bforge" / "tests").mkdir(parents=True)
+        (root / "engine").mkdir(parents=True)
+        (root / "docs").mkdir(parents=True)
+        (root / "tools" / "bforge" / "catalog.json").write_text(
+            '{"version": 1, "ops": [{"name": "build.box", "summary": "s",'
+            ' "inputSchema": {"type": "object", "properties": {}}}]}'
+        )
+        (root / "tools" / "bforge" / "tests" / "test_x.py").write_text(
+            "def test_one():\n    pass\n"
+        )
+        (root / "engine" / "engine-lock.toml").write_text(
+            '[patches]\nseries = [{ file = "patches/0001-x.patch", sha256 = "ab" }]\n'
+        )
+        (root / "docs" / "claims.toml").write_text(
+            '[[surface]]\nfile = "README.md"\nkey = "bforge.ops"\n'
+            'patterns = ["(\\\\d+) whitelisted operations"]\n'
+            '[[forbidden]]\nfiles = ["README.md"]\n'
+            'phrase = "only public"\nreason = "absolute claims are not defensible"\n'
+        )
+        return root
+
+    def test_derives_values_from_the_real_artifacts(self) -> None:
+        derived = check_claims.derive_values(REPO)
+        self.assertGreaterEqual(derived["bforge.ops"], 80)
+        self.assertGreaterEqual(derived["bforge.tests"], 80)
+        self.assertGreaterEqual(derived["engine.patches"], 1)
+        self.assertGreaterEqual(derived["bforge.namespaces"], 10)
+
+    def test_green_when_prose_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = self.make_repo(Path(temp_dir))
+            (root / "README.md").write_text("1 whitelisted operations, honestly.\n")
+            self.assertEqual(check_claims.check(root), [])
+
+    def test_flags_a_number_that_drifted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = self.make_repo(Path(temp_dir))
+            (root / "README.md").write_text("9 whitelisted operations, aspirationally.\n")
+            problems = check_claims.check(root)
+            self.assertTrue(any("claims 9" in problem for problem in problems))
+
+    def test_flags_a_missing_pattern_and_a_forbidden_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = self.make_repo(Path(temp_dir))
+            (root / "README.md").write_text("the only public implementation\n")
+            problems = check_claims.check(root)
+            self.assertTrue(any("pattern not found" in problem for problem in problems))
+            self.assertTrue(any("forbidden claim" in problem for problem in problems))
 
 
 if __name__ == "__main__":

--- a/tools/studio-mcp/tests/test_ci_tools.py
+++ b/tools/studio-mcp/tests/test_ci_tools.py
@@ -226,6 +226,9 @@ class CheckClaimsTests(unittest.TestCase):
         self.assertGreaterEqual(derived["engine.patches"], 1)
         self.assertGreaterEqual(derived["bforge.namespaces"], 10)
 
+    def test_the_repository_s_own_surfaces_are_consistent(self) -> None:
+        self.assertEqual(check_claims.check(REPO), [])
+
     def test_green_when_prose_matches(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = self.make_repo(Path(temp_dir))

--- a/tools/verification/verify_renderer.py
+++ b/tools/verification/verify_renderer.py
@@ -59,9 +59,10 @@ def _preconditions(renderer: str) -> list[str]:
         )
     if not shutil.which("node"):
         problems.append("node is not on PATH (needed for the browser probe)")
-    if not (BROWSER_DIR / "node_modules" / "playwright").is_dir() and not (
-        BROWSER_DIR / "node_modules" / "playwright-core"
-    ).is_dir():
+    if (
+        not (BROWSER_DIR / "node_modules" / "playwright").is_dir()
+        and not (BROWSER_DIR / "node_modules" / "playwright-core").is_dir()
+    ):
         problems.append(f"playwright is not installed — run `npm ci` in {BROWSER_DIR}")
     if not senv.find_godot():
         problems.append("Godot editor binary not found (set GODOT_BIN, or run `just doctor`)")
@@ -77,11 +78,17 @@ def _preconditions(renderer: str) -> list[str]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("--game", default="games/chariot")
     parser.add_argument("--renderer", default="forward_plus", choices=["forward_plus", "mobile"])
-    parser.add_argument("--seconds", type=int, default=45, help="observation window; cold start alone can take ~20s")
-    parser.add_argument("--out", default="verification/renderer", help="directory for the evidence file")
+    parser.add_argument(
+        "--seconds", type=int, default=45, help="observation window; cold start alone can take ~20s"
+    )
+    parser.add_argument(
+        "--out", default="verification/renderer", help="directory for the evidence file"
+    )
     parser.add_argument("--skip-export", action="store_true", help="reuse an existing export")
     args = parser.parse_args()
 
@@ -107,7 +114,9 @@ def main() -> int:
         evidence["verdict"] = "inconclusive"
         evidence["verdict_reason"] = "preconditions not met"
         evidence["preconditions_missing"] = problems
-        (out_dir / f"{label}.json").write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        (out_dir / f"{label}.json").write_text(
+            json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
+        )
         print("cannot verify — preconditions not met:")
         for p in problems:
             print(f"  - {p}")
@@ -116,8 +125,9 @@ def main() -> int:
     # Which patch series produced the templates being tested. Without this a
     # result cannot be attributed to a build.
     try:
-        from studio_tools.provenance import series_from_lock, series_id  # noqa: PLC0415
         import tomllib  # noqa: PLC0415
+
+        from studio_tools.provenance import series_from_lock, series_id  # noqa: PLC0415
 
         with (REPO / "engine" / "engine-lock.toml").open("rb") as fh:
             evidence["series_id"] = series_id(*series_from_lock(tomllib.load(fh)))
@@ -131,21 +141,33 @@ def main() -> int:
     if not args.skip_export:
         print(f"[verify] exporting {args.game} with --rendering-method {args.renderer}")
         rc = subprocess.call(
-            [sys.executable, str(REPO / "tools" / "godot" / "export_game.py"),
-             "--game", args.game, "--preset", "web-webgpu", "--rendering-method", args.renderer],
+            [
+                sys.executable,
+                str(REPO / "tools" / "godot" / "export_game.py"),
+                "--game",
+                args.game,
+                "--preset",
+                "web-webgpu",
+                "--rendering-method",
+                args.renderer,
+            ],
             cwd=REPO,
         )
         if rc != 0:
             evidence["verdict"] = "inconclusive"
             evidence["verdict_reason"] = f"export failed (exit {rc})"
-            (out_dir / f"{label}.json").write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+            (out_dir / f"{label}.json").write_text(
+                json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
+            )
             print("[verify] export failed — nothing to measure")
             return 3
 
     if not (export_dir / "index.html").is_file():
         evidence["verdict"] = "inconclusive"
         evidence["verdict_reason"] = f"no export at {export_dir}"
-        (out_dir / f"{label}.json").write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        (out_dir / f"{label}.json").write_text(
+            json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
+        )
         return 3
 
     port = _free_port()
@@ -153,14 +175,25 @@ def main() -> int:
     print(f"[verify] serving {export_dir} on {url}")
     server = subprocess.Popen(
         [sys.executable, "-m", "http.server", str(port), "--bind", "127.0.0.1"],
-        cwd=export_dir, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        cwd=export_dir,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
     try:
         time.sleep(1.5)
         probe_out = out_dir / "probe"
-        probe_cmd = ["node", str(BROWSER_DIR / "render-probe.mjs"),
-                     "--url", url, "--out", str(probe_out), "--label", label,
-                     "--seconds", str(args.seconds)]
+        probe_cmd = [
+            "node",
+            str(BROWSER_DIR / "render-probe.mjs"),
+            "--url",
+            url,
+            "--out",
+            str(probe_out),
+            "--label",
+            label,
+            "--seconds",
+            str(args.seconds),
+        ]
         # A virtual display where one exists; the probe rejects software adapters
         # itself, so a wrong choice here degrades to "inconclusive", never a pass.
         if shutil.which("xvfb-run"):
@@ -177,14 +210,23 @@ def main() -> int:
         # The binding trace is what distinguishes "renders" from "renders and is
         # actually valid", so a clean frame with rejected command buffers cannot
         # be reported as clean.
-        trace_cmd = ["node", str(BROWSER_DIR / "binding-trace.mjs"),
-                     "--url", url, "--seconds", str(min(args.seconds, 35)), "--max", "3", "--json"]
+        trace_cmd = [
+            "node",
+            str(BROWSER_DIR / "binding-trace.mjs"),
+            "--url",
+            url,
+            "--seconds",
+            str(min(args.seconds, 35)),
+            "--max",
+            "3",
+            "--json",
+        ]
         if shutil.which("xvfb-run"):
             trace_cmd = ["xvfb-run", "-a", *trace_cmd]
         print("[verify] tracing bind groups and command-buffer validity")
         trace = subprocess.run(trace_cmd, cwd=BROWSER_DIR, capture_output=True, text=True)
         try:
-            evidence["bindings"] = json.loads(trace.stdout[trace.stdout.index("{"):])
+            evidence["bindings"] = json.loads(trace.stdout[trace.stdout.index("{") :])
         except (ValueError, json.JSONDecodeError):
             evidence["bindings"] = None
             evidence["notes"].append("NOTE binding trace produced no parsable output")
@@ -195,7 +237,7 @@ def main() -> int:
     evidence["verdict"] = probe.get("verdict", "inconclusive")
     evidence["verdict_reason"] = probe.get("verdict_reason", "probe produced no report")
 
-    cb = ((evidence.get("bindings") or {}).get("command_buffers") or {})
+    cb = (evidence.get("bindings") or {}).get("command_buffers") or {}
     evidence["summary"] = {
         "verdict": evidence["verdict"],
         "renderer_reported": (probe.get("engine_counters") or {}).get("renderer"),
@@ -205,7 +247,7 @@ def main() -> int:
         "adapter_is_fallback": (probe.get("adapter") or {}).get("isFallbackAdapter"),
         "canvas_dominant_colour_fraction": (probe.get("canvas") or {}).get("dominantColorFraction"),
         "gpu_validation_errors": probe.get("gpu_validation_errors"),
-        "bind_group_failure_classes": len(((evidence.get("bindings") or {}).get("counts") or {})),
+        "bind_group_failure_classes": len((evidence.get("bindings") or {}).get("counts") or {}),
         "command_buffers_invalid": cb.get("finish_failed"),
         "submissions_rejected": cb.get("submit_failed"),
     }


### PR DESCRIPTION
## What this does

Five commits, each passing its own gates, turning the external review's central criticism (the repo's prose drifted from its artifacts) into enforceable architecture — and landing the first Milestone-1 increment of ADR 0018 (BRIEF→BATTLE).

1. **`ci: enforce prose/artifact claim consistency and full-schema catalog parity`** — `docs/claims.toml` + `tools/ci/check_claims.py` derive op/namespace/test/patch counts from the pinned artifacts and fail CI when a documented surface disagrees; absolute-exclusivity claims ("only public Forward+ …") are rejected outright. The catalog parity test now compares **full schemas** against the live registry, not just op names (the hole that let `mesh.retopo` advertise params the runtime rejected). OPS.md gets a freshness gate. The refresh exposed real drift: the committed catalog was **missing `mesh.clean` entirely** (135 committed vs 136 live).
2. **`bforge: Recipe IR v1 — content-addressed compiles with proof capsules`** — `bforge cook`: canonicalize → hash inputs+params → content-addressed cache → Blender worker → requirement gates → strict export → proof capsule. **The cache key fingerprints the compiler, not just the recipe**: the bforge source tree (a dirty working tree is a different compiler — a git commit cannot say that), the committed catalog, the pinned Blender toolchain, and the canonicalization version. A cache hit re-hashes every artifact against the proof before returning it; tampered or stale entries fall through to a rebuild. Cache hit returns the verified proof **without booting Blender**.
3. **`docs: reconcile bforge, Blender, and WebGPU status with current evidence`** — 136 ops, 195 tests (156 in suites that start a real Blender daemon), 33 patches, Blender 4.5.12 LTS; exclusivity claims removed; the p0014-era "What this download is not" paragraph (contradicting the p0033 release) rewritten; patches 0023–0033 documented from their commit bodies. ADR renumbered to 0018 — **ADR 0017 is the open peer-runtime proposal (PR #50)** and nothing here treats it as accepted.
4. **`ci: hash-pin the Blender toolchain and run the complete bforge suite`** — `tools/bforge/blender-lock.toml` pins Blender 4.5.12 LTS by URL + SHA-256 (`95e3a2dfedba3bd32ca54fc355eac6b15a11986954ccb02815a07535d0120a25`), verified before extraction in CI (same treatment as the engine lock). The hosted bench job now runs the **entire** 195-test bforge suite — a test count the public gate does not run is not a claim, it is a hope.
5. **`style: normalize the Python lint surface`** — purely mechanical ruff format + latent B905/B007/F401/I001 findings. No behavior change; safe to skim.

## The claims gate caught 14 violations on first run

```
README.md: claims 130 but bforge.ops is 136 (×3 phrasings)
README.md: claims 174 but bforge.tests is 193→195 (×3)
README.md: claims 29 but engine.patches is 33 (×2)
tools/bforge/README.md: claims 130/19 (ops/namespaces)
README.md: forbidden claim 'only public Forward+'
README.md: forbidden claim 'the only other public WebGPU effort'
```

## The cache-key envelope

```json
{
  "schema": "bforge.recipe.v1",
  "canonicalization": "bforge-json-c14n-v1",
  "recipe_sha256": "sha256(canonical recipe + input hashes)",
  "inputs": {"name": "sha256", …},
  "compiler": {
    "bforge_tree_sha256": "hash over every client+runtime .py (dirty tree = different compiler)",
    "catalog_sha256": "…",
    "blender": {"version": "4.5.12", "archive_sha256": "95e3a2df…"},
    "python": "3.12.x"
  }
}
```
`cache_key = sha256(canonical(envelope))`. Regression tests: a changed compiler fingerprint forces a miss; a tampered cached artifact forces a rebuild; a failed proof never satisfies the cache.

## Acceptance (clean worktree, from origin/main)

- 195 bforge tests OK against real Blender 4.5.12 (incl. the live recipe cook: cache hit, forced rebuild byte-identical)
- studio-mcp (incl. claims-gate tests) / infra / asset-pipeline / engine-scripts / provenance / verification suites OK
- `check_claims.py`, `secret_scan.py`, `validate_workflows.py`, `check_fixtures.py` OK
- `ruff check` + `ruff format --check` green on all 94 lint-surface files

## Known limitations / not in this PR

- The GitHub Pages evidence site (p0014-era) is updated separately on the `gh-pages` branch.
- The cache key pins the *declared* toolchain from `blender-lock.toml`; overriding `BLENDER_BIN` to a different local Blender is possible and voids the byte-identical claim (CI enforces the pinned archive).
- Recipe IR v1 recipes declare their steps explicitly; synthesis from natural-language briefs is the benchmark track, not this PR.

## M2.1 hardening (second review round)

- **Fail-closed gates (merge blocker fixed).** `gameready.budget` returns `within_budget`, but the gate check read `ok` — an over-budget result passed. Gate evaluation now fails closed: a missing verdict field is a failure. Regression tests: over-budget fails and is not cached; a malformed budget result (no verdict) fails.
- **Relative artifact paths.** Artifacts record `path.relative_to(cache_root)`, so structured package directories can't collide by basename.
- **Pinned-toolchain enforcement.** Cache misses must be built by the Blender pinned in `blender-lock.toml`; a mismatched daemon is a hard error. `--allow-unpinned` diverts output to `<key>.unpinned/` and never caches it. Tests cover rejection and diversion.

## M2.2 contract-integrity pass (third review round)

- **Cache hits now validate the proof's identity, not just the artifacts it names.** A hit recomputes and compares asset_id, recipe hash, cache key, inputs, the complete compiler envelope, the canonical recipe file, the recorded gate set and verdicts, and the pinned toolchain identity — plus the exact artifact set (a stale passenger file invalidates the entry). Regressions: metadata tamper → rebuild + quarantine; stale file → rebuild; NaN in JSON → hard error.
- **Atomic publication.** Builds run in a unique staging dir, self-verify, and publish by rename under a per-key lock. Accepted entries are immutable; failures go to a separate failure store; `--no-cache` and unpinned builds produce verified-but-ephemeral packages that never touch the store.
- **Toolchain identity.** Proofs record the Blender binary's SHA-256 alongside the reported version; the byte-identical claim is scoped to CI's hash-verified archive.
