### PR TITLE
worldc: worlds compile to world proof capsules

### DIFF
--- a/docs/specs/world-ir-v0.1.md
+++ b/docs/specs/world-ir-v0.1.md
@@ -121,3 +121,34 @@ evidence — but it never satisfies a cache.
   runtime adapters (Godot/Babylon), replay hashes — milestone M3.
 - Geometry synthesis from semantics alone.
 - Multiple entities per document, world graphs, streaming groups.
+
+## Worlds (v0.1, landed)
+
+A **world document** (`world_ir: "0.1"`, `world`, `entities`, `scenario`,
+optional `expect_navigation`) compiles to a world proof capsule:
+
+```text
+worldc compile-world fortress_world.json
+  → entity proof for every entity (shared documents share proofs)
+  → the scenario replay, bound to exactly these entities and their compiled
+     simulation contracts (name set, plus each inline contract must hash to
+     the contract the world's document compiles to, or the world fails)
+  → expect_navigation outcomes checked against the deterministic result
+  → world-cache/<key>/world_proof.json
+```
+
+The world cache key covers the canonical world document, every entity proof's
+SHA-256, the replay's canonical SHA-256, and the worldc compiler fingerprint.
+Simulation semantics enter a world only through worldc.sim_contract — the
+integer-only compiled contract (milli-unit storage, affordances, integer
+parameters) that both kernels consume and the replay pins by hash.
+The capsule carries resolvable entity-proof URIs and hashes, the replay
+fingerprint, the final state hash, and every check result. Publication is
+atomic (staging + rename under a per-key lock); failures go to the failure
+store as evidence.
+
+The example — `tools/worldc/examples/fortress_world.json` — is the fortress
+battle: two gate instances from one entity document; the scenario unlocks,
+opens, and destroys the main gate while the side gate stays locked, and the
+world proof asserts `gate_main` no longer blocks navigation while `gate_side`
+still does.

--- a/justfile
+++ b/justfile
@@ -243,6 +243,11 @@ bforge-cook:
 worldc-compile:
     uv run --project tools python tools/worldc/worldc.py compile "{{ENTITY}}"
 
+# Compile a whole world (entities + deterministic scenario) to a world proof capsule.
+#   just WORLD=tools/worldc/examples/fortress_world.json worldc-world
+worldc-world:
+    uv run --project tools python tools/worldc/worldc.py compile-world "{{WORLD}}"
+
 # Run a deterministic replay (spec: docs/specs/sim-replay-v0.1.md); exits non-zero on golden mismatch.
 #   just REPLAY=tools/sim/replays/gate_open_destroy.json sim-replay
 sim-replay:

--- a/tools/worldc/examples/fortress_battle.json
+++ b/tools/worldc/examples/fortress_battle.json
@@ -1,0 +1,142 @@
+{
+  "sim_replay": "0.1",
+  "seed": 0,
+  "ticks": 20,
+  "comment": "the fortress battle: the main gate is unlocked, opened, and battered to destruction while the side gate stays locked shut",
+  "entities": {
+    "gate_main": {
+      "contract": {
+        "sim_contract": "0.1",
+        "source_world_ir_sha256": "59f7fbb7ce22dc55bf76030fe9c84f46a3af6c239ceb85c6f2438d8e2fc509fa",
+        "entity": "fortress_gate",
+        "state": {
+          "openness": {
+            "storage": "milli_i64"
+          },
+          "locked": {
+            "storage": "bool"
+          },
+          "health": {
+            "storage": "i64"
+          },
+          "destroyed": {
+            "storage": "bool"
+          }
+        },
+        "affordances": [
+          "open",
+          "close",
+          "lock",
+          "unlock",
+          "attack",
+          "repair"
+        ],
+        "parameters": {
+          "open_rate_milli": 250,
+          "max_health": 100,
+          "navigation": {
+            "blocks_below": [
+              {
+                "var": "openness",
+                "threshold_milli": 700
+              }
+            ],
+            "never_blocks_when_destroyed": true
+          }
+        }
+      },
+      "contract_sha256": "5f744f0c342fd4cd535756c974f7497537d497a880dcfc9559ef0ca4667a7ce5"
+    },
+    "gate_side": {
+      "contract": {
+        "sim_contract": "0.1",
+        "source_world_ir_sha256": "59f7fbb7ce22dc55bf76030fe9c84f46a3af6c239ceb85c6f2438d8e2fc509fa",
+        "entity": "fortress_gate",
+        "state": {
+          "openness": {
+            "storage": "milli_i64"
+          },
+          "locked": {
+            "storage": "bool"
+          },
+          "health": {
+            "storage": "i64"
+          },
+          "destroyed": {
+            "storage": "bool"
+          }
+        },
+        "affordances": [
+          "open",
+          "close",
+          "lock",
+          "unlock",
+          "attack",
+          "repair"
+        ],
+        "parameters": {
+          "open_rate_milli": 250,
+          "max_health": 100,
+          "navigation": {
+            "blocks_below": [
+              {
+                "var": "openness",
+                "threshold_milli": 700
+              }
+            ],
+            "never_blocks_when_destroyed": true
+          }
+        }
+      },
+      "contract_sha256": "5f744f0c342fd4cd535756c974f7497537d497a880dcfc9559ef0ca4667a7ce5"
+    }
+  },
+  "initial": {
+    "gate_main": {
+      "health": 100,
+      "locked": true
+    },
+    "gate_side": {
+      "health": 100,
+      "locked": true
+    }
+  },
+  "events": [
+    [
+      0,
+      "gate_side",
+      "open",
+      null
+    ],
+    [
+      1,
+      "gate_main",
+      "unlock",
+      null
+    ],
+    [
+      2,
+      "gate_main",
+      "open",
+      null
+    ],
+    [
+      5,
+      "gate_main",
+      "attack",
+      40
+    ],
+    [
+      8,
+      "gate_main",
+      "attack",
+      40
+    ],
+    [
+      11,
+      "gate_main",
+      "attack",
+      40
+    ]
+  ]
+}

--- a/tools/worldc/examples/fortress_world.json
+++ b/tools/worldc/examples/fortress_world.json
@@ -1,0 +1,14 @@
+{
+  "world_ir": "0.1",
+  "world": "fortress",
+  "brief": "a fortress with a main gate and a side gate; the battle scenario must breach the main gate while the side gate holds",
+  "entities": {
+    "gate_main": { "doc": "fortress_gate.json" },
+    "gate_side": { "doc": "fortress_gate.json" }
+  },
+  "scenario": "fortress_battle.json",
+  "expect_navigation": {
+    "gate_main": false,
+    "gate_side": true
+  }
+}

--- a/tools/worldc/tests/test_world.py
+++ b/tools/worldc/tests/test_world.py
@@ -1,0 +1,135 @@
+"""worldc world-compilation tests — validation, scenario binding, world proof.
+
+The live test compiles the fortress_world example end to end: two gate
+entities through bforge (entity proofs), the battle scenario through the
+deterministic kernel, and one world proof capsule binding both by hash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "bforge"))
+
+from bforge.client import DaemonError, Forge, find_blender  # noqa: E402
+
+import worldc  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[3]
+EXAMPLES = REPO / "tools" / "worldc" / "examples"
+WORLD = EXAMPLES / "fortress_world.json"
+
+
+def base_world() -> dict:
+    return {
+        "world_ir": "0.1",
+        "world": "arena_test",
+        "entities": {
+            "gate_a": {"doc": "fortress_gate.json"},
+            "gate_b": {"doc": "fortress_gate.json"},
+        },
+        "scenario": "fortress_battle.json",
+    }
+
+
+class WorldValidation(unittest.TestCase):
+    def _load(self, doc: dict):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(doc, fh)
+            return fh.name
+
+    def check_error(self, doc: dict):
+        with self.assertRaises(worldc.WorldIRError):
+            worldc.load_world(self._load(doc))
+
+    def test_valid_document_passes(self):
+        doc = worldc.load_world(self._load(base_world()))
+        self.assertEqual(doc["world"], "arena_test")
+
+    def test_unknown_top_level_field(self):
+        doc = base_world()
+        doc["mood"] = "grim"
+        self.check_error(doc)
+
+    def test_entities_must_be_nonempty(self):
+        doc = base_world()
+        doc["entities"] = {}
+        self.check_error(doc)
+
+    def test_entity_entry_needs_a_doc_path(self):
+        doc = base_world()
+        doc["entities"]["gate_a"] = "fortress_gate.json"
+        self.check_error(doc)
+
+    def test_scenario_required(self):
+        doc = base_world()
+        del doc["scenario"]
+        self.check_error(doc)
+
+    def test_expect_navigation_must_reference_known_entities(self):
+        doc = base_world()
+        doc["expect_navigation"] = {"gate_ghost": False}
+        self.check_error(doc)
+
+    def test_version_gate(self):
+        doc = base_world()
+        doc["world_ir"] = "9.9"
+        self.check_error(doc)
+
+
+BLENDER = None
+try:
+    if not os.environ.get("BFORGE_SKIP_LIVE"):
+        BLENDER = find_blender()
+except DaemonError:
+    BLENDER = None
+
+
+@unittest.skipIf(BLENDER is None, "Blender not available")
+class WorldLive(unittest.TestCase):
+    def test_fortress_world_compiles_to_a_passing_world_proof(self):
+        tmp = Path(tempfile.mkdtemp(prefix="worldc_world_"))
+        self.addCleanup(shutil.rmtree, tmp, True)
+
+        def factory() -> Forge:
+            return Forge(workdir=str(tmp), out_dir=str(tmp / "out"))
+
+        proof = worldc.compile_world(WORLD, cache_dir=tmp / "cache", forge_factory=factory)
+        self.assertEqual(proof["status"], "pass")
+
+        # both gate instances compiled (same doc -> one shared entity proof)
+        self.assertEqual(
+            proof["entities"]["gate_main"]["entity_cache_key"],
+            proof["entities"]["gate_side"]["entity_cache_key"],
+        )
+        # the scenario ran and the battle came out as ordered
+        self.assertFalse(proof["scenario"]["navigation"]["gate_main"])
+        self.assertTrue(proof["scenario"]["navigation"]["gate_side"])
+        self.assertEqual(len(proof["scenario"]["state_hash"]), 64)
+
+        # every reference in the proof resolves from its own directory
+        world_dir = Path(proof["cache"]["dir"])
+        self.assertTrue((world_dir / "world_proof.json").is_file())
+        for ref in proof["entities"].values():
+            resolved = (world_dir / ref["entity_proof_uri"]).resolve()
+            self.assertTrue(resolved.is_file(), f"entity proof URI resolves: {resolved}")
+            self.assertEqual(
+                ref["entity_proof_sha256"],
+                hashlib.sha256(resolved.read_bytes()).hexdigest(),
+            )
+
+        # a second compile reuses everything (still pass, same key)
+        again = worldc.compile_world(WORLD, cache_dir=tmp / "cache", forge_factory=factory)
+        self.assertEqual(again["world_cache_key"], proof["world_cache_key"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/worldc/worldc.py
+++ b/tools/worldc/worldc.py
@@ -530,6 +530,195 @@ def compile_entity(
     return proof
 
 
+# -------------------------------------------------------------------- worlds
+
+WORLD_SCHEMA = "studio.world.v0.1"
+WORLD_KEYS = {
+    "world_ir",
+    "world",
+    "brief",
+    "entities",
+    "scenario",
+    "expect_navigation",
+    "extensions",
+}
+
+
+def load_world(path: Path) -> dict:
+    try:
+        doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WorldIRError(f"{path}: not valid JSON: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise WorldIRError(f"{path}: a world is a JSON object")
+    source = str(path)
+    unknown = sorted(set(doc) - WORLD_KEYS)
+    if unknown:
+        raise WorldIRError(f"{source}: unknown top-level fields {unknown}")
+    if doc.get("world_ir") != WORLD_IR_VERSION:
+        raise WorldIRError(
+            f"{source}: unsupported world_ir {doc.get('world_ir')!r} (want {WORLD_IR_VERSION})"
+        )
+    if not isinstance(doc.get("world"), str) or not IDENTIFIER.match(doc["world"]):
+        raise WorldIRError(f"{source}: world must be a snake_case identifier")
+    entities = doc.get("entities")
+    if not isinstance(entities, dict) or not entities:
+        raise WorldIRError(f"{source}: entities must be a non-empty object")
+    for name, entry in entities.items():
+        if not IDENTIFIER.match(name):
+            raise WorldIRError(f"{source}: bad entity name {name!r}")
+        if not isinstance(entry, dict) or not isinstance(entry.get("doc"), str):
+            raise WorldIRError(f"{source}: entity {name!r} needs an object with a doc path")
+    if not isinstance(doc.get("scenario"), str):
+        raise WorldIRError(f"{source}: scenario (a replay path) is required")
+    expect_nav = doc.get("expect_navigation", {})
+    if not isinstance(expect_nav, dict) or any(
+        k not in entities or not isinstance(v, bool) for k, v in expect_nav.items()
+    ):
+        raise WorldIRError(f"{source}: expect_navigation maps entity names to booleans")
+    return doc
+
+
+def compile_world(
+    world_path,
+    cache_dir: Path | None = None,
+    no_cache: bool = False,
+    forge_factory=None,
+) -> dict:
+    """Compile a world: entity proofs for every entity, then the scenario
+    replay, then one world proof capsule binding both by hash."""
+    world_path = Path(world_path).resolve()
+    doc = load_world(world_path)
+    world_name = doc["world"]
+
+    cache_root = Path(cache_dir) if cache_dir else WORLDC_ROOT / "cache"
+    world_cache = cache_root / "world-cache"
+
+    # 1. entity proofs (each into the entity store; shared docs share proofs)
+    entity_proofs: dict[str, dict] = {}
+    entity_docs: dict[str, dict] = {}
+    for name, entry in doc["entities"].items():
+        entity_doc_path = (world_path.parent / entry["doc"]).resolve()
+        entity_docs[name] = load_entity(entity_doc_path)
+        entity_proofs[name] = compile_entity(
+            entity_doc_path, cache_dir=cache_root, no_cache=no_cache, forge_factory=forge_factory
+        )
+
+    # 2. the scenario replay must name exactly this world's entities, and its
+    #    inline contracts must be the ones these documents compile to
+    replay_path = (world_path.parent / doc["scenario"]).resolve()
+    sim_mod = _sim_kernel()
+    replay = sim_mod.load_replay(replay_path)  # format validation
+    replay_entities = replay.get("entities", {})
+    if set(replay_entities) != set(doc["entities"]):
+        raise WorldIRError(
+            f"{world_path}: scenario entities {sorted(replay_entities)} do not match "
+            f"the world's {sorted(doc['entities'])}"
+        )
+    for name, rent in replay_entities.items():
+        compiled = sim_contract(entity_docs[name], source=str(world_path))
+        compiled_sha = hashlib.sha256(recipe_mod.canonicalize(compiled)).hexdigest()
+        inline_sha = hashlib.sha256(recipe_mod.canonicalize(rent["contract"])).hexdigest()
+        if inline_sha != compiled_sha or rent["contract_sha256"] != compiled_sha:
+            raise WorldIRError(
+                f"{world_path}: scenario's contract for {name} does not match the "
+                f"world's document ({rent['contract_sha256'][:12]}… vs {compiled_sha[:12]}…)"
+            )
+
+    # 3. run the scenario deterministically (self-contained replay)
+    result = sim_mod.run_replay(replay_path)
+
+    # 4. world-level checks
+    checks: list[dict] = []
+    for name, proof in entity_proofs.items():
+        checks.append(
+            {
+                "check": f"entity proof passes: {name}",
+                "ok": proof["status"] == "pass",
+                "detail": f"entity-cache key {proof['entity_cache_key'][:12]}…",
+            }
+        )
+    for name, expected in doc.get("expect_navigation", {}).items():
+        actual = result["navigation"][name]
+        checks.append(
+            {
+                "check": f"navigation outcome: {name} blocks == {expected}",
+                "ok": actual is expected,
+                "detail": f"blocks_navigation == {actual}",
+            }
+        )
+    failures = [c["check"] for c in checks if not c["ok"]]
+
+    # 5. one world proof capsule
+    replay_sha = hashlib.sha256(recipe_mod.canonicalize(replay)).hexdigest()
+    entity_refs = {}
+    for name, proof in entity_proofs.items():
+        proof_file = Path(proof["cache"]["dir"]) / "entity_proof.json"
+        entity_refs[name] = {
+            "entity_cache_key": proof["entity_cache_key"],
+            "entity_proof_sha256": hashlib.sha256(proof_file.read_bytes()).hexdigest(),
+        }
+    envelope = {
+        "schema": WORLD_SCHEMA,
+        "canonicalization": CANONICALIZATION,
+        "world_doc_sha256": hashlib.sha256(recipe_mod.canonicalize(doc)).hexdigest(),
+        "entity_proofs": {name: ref["entity_proof_sha256"] for name, ref in entity_refs.items()},
+        "replay_sha256": replay_sha,
+        "worldc_compiler": worldc_fingerprint(),
+    }
+    key = hashlib.sha256(recipe_mod.canonicalize(envelope)).hexdigest()
+    world_dir = world_cache / key
+    for name, proof in entity_proofs.items():
+        proof_file = Path(proof["cache"]["dir"]) / "entity_proof.json"
+        entity_refs[name]["entity_proof_uri"] = os.path.relpath(proof_file, start=world_dir)
+
+    proof = {
+        "proof_version": PROOF_VERSION,
+        "schema": WORLD_SCHEMA,
+        "world": world_name,
+        "world_cache_key": key,
+        "entities": entity_refs,
+        "scenario": {
+            "replay": doc["scenario"],
+            "replay_sha256": replay_sha,
+            "state_hash": result["state_hash"],
+            "navigation": result["navigation"],
+            "fingerprints": result["fingerprints"],
+        },
+        "worldc_compiler": envelope["worldc_compiler"],
+        "checks": checks,
+        "status": "pass" if not failures else "fail",
+    }
+
+    staging = world_cache / "staging" / f"{key}.{os.getpid()}.{secrets.token_hex(4)}"
+    staging.mkdir(parents=True, exist_ok=False)
+    (staging / "world_proof.json").write_text(json.dumps(proof, indent=2) + "\n", encoding="utf-8")
+    if failures:
+        failure_dir = (
+            world_cache / "failures" / f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%S')}-{key[:12]}"
+        )
+        failure_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(staging), str(failure_dir))
+        raise WorldIRError(
+            f"{world_name}: world contract broken — {failures} "
+            f"(proof: {failure_dir / 'world_proof.json'})"
+        )
+    with recipe_mod._KeyLock(world_cache, key):
+        if not world_dir.is_dir():
+            os.rename(staging, world_dir)
+        else:
+            shutil.rmtree(staging)
+    proof["cache"] = {"hit": False, "dir": str(world_dir)}
+    return proof
+
+
+def _sim_kernel():
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sim"))
+    import kernel
+
+    return kernel
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(prog="worldc", description=__doc__.split("\n")[1])
     sub = parser.add_subparsers(dest="command", required=True)
@@ -537,14 +726,27 @@ def main(argv=None) -> int:
     comp.add_argument("file")
     comp.add_argument("--cache-dir", default=None)
     comp.add_argument("--no-cache", action="store_true")
+    world = sub.add_parser(
+        "compile-world", help="Compile a world document (entities + scenario) to a world proof"
+    )
+    world.add_argument("file")
+    world.add_argument("--cache-dir", default=None)
+    world.add_argument("--no-cache", action="store_true")
     args = parser.parse_args(argv)
 
     try:
-        proof = compile_entity(
-            args.file,
-            cache_dir=args.cache_dir,
-            no_cache=args.no_cache,
-        )
+        if args.command == "compile-world":
+            proof = compile_world(
+                args.file,
+                cache_dir=args.cache_dir,
+                no_cache=args.no_cache,
+            )
+        else:
+            proof = compile_entity(
+                args.file,
+                cache_dir=args.cache_dir,
+                no_cache=args.no_cache,
+            )
     except (WorldIRError, recipe_mod.RecipeError) as exc:
         print(json.dumps({"error": str(exc)}, indent=2), file=sys.stderr)
         return 1


### PR DESCRIPTION
Stacked on #83 (feat/sim-rust-parity). Base moves up as the stack merges.

## What this does

The world-level capstone of the current arc: a **world document compiles to a world proof capsule**.

```
fortress_world.json (entities + scenario + expected navigation)
  → entity proof per entity (content-addressed layers below; shared docs share proofs)
  → scenario replay bound to exactly these entities/documents
       (name set + per-entity doc_sha256 — a scenario naming other documents fails)
  → deterministic kernel run
  → expect_navigation checked against the result
  → world-cache/<key>/world_proof.json
```

The example is the **fortress battle**: two gate instances from one entity document; the scenario unlocks, opens, and destroys the main gate while the side gate stays locked — and the world proof asserts `gate_main` no longer blocks navigation while `gate_side` still does. That is "the gate opens without intersecting the wall, and the wall still blocks" as a machine-checkable contract.

- The world cache key covers the canonical world document, every entity proof's SHA-256, the replay's canonical SHA-256, and the worldc compiler fingerprint.
- The capsule carries resolvable entity-proof URIs + hashes, the replay fingerprint, the final state hash, and every check result.
- Atomic publication (staging + rename under per-key lock); failures go to the failure store as evidence.
- CLI: `worldc compile-world`; just: `worldc-world`.

## Acceptance

- worldc suite: 32 tests OK (validation + entity cache + live entity compile + live world compile)
- bforge full suite OK; sim suite OK; claims gate OK; ruff clean

## Deferred

Multi-system reducers (movement/combat/economy), runtime adapters observing sim snapshots, streaming groups and world graphs.
