### PR TITLE
brief-to-asset: the frozen public benchmark (and its first caught bug)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -88,6 +88,9 @@ jobs:
       - name: sim kernel (deterministic replay, golden hashes)
         run: uv run --project tools python -m unittest discover -s tools/sim/tests -p "test_*.py"
 
+      - name: brief-to-asset static checks
+        run: uv run --project tools python -m unittest discover -s benchmarks/brief-to-asset/tests -p "test_*.py"
+
       - name: Protocol golden fixtures
         run: uv run --project tools python tools/asset-pipeline/check_fixtures.py
 
@@ -175,3 +178,13 @@ jobs:
       # which are machine-dependent, so it stays out of the diff.
       - name: the committed number matches a fresh run
         run: git diff --exit-code tools/bforge/bench/SUMMARY.md
+
+      # The frozen public benchmark (ADR 0018 M4): the reference agent must
+      # stay 6/6 and the committed scorecard must match a fresh run.
+      - name: brief-to-asset benchmark (reference agent)
+        env:
+          BLENDER_BIN: /opt/blender/blender
+        run: uv run --project tools python benchmarks/brief-to-asset/bench.py --agent "python3 benchmarks/brief-to-asset/agents/scripted_recipe.py"
+
+      - name: the committed scorecard matches a fresh run
+        run: git diff --exit-code benchmarks/brief-to-asset/SUMMARY.md

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ engine/artifacts/
 tools/bforge/cache/
 tools/bforge/bench/out/
 tools/worldc/cache/
+benchmarks/brief-to-asset/out/
 
 # --- Rust ---
 target/

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ it works identically on a laptop, in CI, and on a headless build box.
   gate finding, and `export.asset` refuses to export below the bar without an
   explicit override. `check.style`/`check.conformance` score set-level art
   direction and name the axis that breaks it.
+- **A frozen public benchmark, not a self-grade.** `benchmarks/brief-to-asset`
+  holds a frozen brief set and a model-neutral harness: any agent command
+  answers the briefs, and the harness scores the compiled artifacts for
+  validity, semantics, budget, and byte-identical determinism — regenerated
+  and diffed in public CI. The scripted reference agent holds the 6/6
+  baseline; models compete against the same gates, not against vibes.
 - **Characters and creatures, actually rigged and animated.** Humanoids at
   figure-drawing proportions with fitted armour (`char.outfit`), faces, hands;
   quadrupeds and hexapods with real footfall gaits — lateral-sequence walk,

--- a/benchmarks/brief-to-asset/SUMMARY.md
+++ b/benchmarks/brief-to-asset/SUMMARY.md
@@ -1,0 +1,22 @@
+# brief-to-asset scorecard
+
+agent: `python3 /home/kwebb/sf-bench/benchmarks/brief-to-asset/agents/scripted_recipe.py`
+
+verdict: **6/6 briefs passed**
+
+| brief | category | validity | semantics | budget | determinism |
+| --- | --- | --- | --- | --- | --- |
+| barrel | prop | ✓ | ✓ | ✓ | ✓ |
+| camp | environment | ✓ | ✓ | ✓ | ✓ |
+| crate | prop | ✓ | ✓ | ✓ | ✓ |
+| gladius | weapon | ✓ | ✓ | ✓ | ✓ |
+| warden | character | ✓ | ✓ | ✓ | ✓ |
+| wolf | creature | ✓ | ✓ | ✓ | ✓ |
+
+Every brief is scored by the harness from the compiled artifact and its
+proof, never from the agent's own claims. Determinism is a forced
+rebuild that must hash byte-identically.
+
+Rerun: `just briefbench` (reference agent). Times, paths, and hashes
+live in scorecard.json (machine-dependent); this file is the diffed
+public number.

--- a/benchmarks/brief-to-asset/SUMMARY.md
+++ b/benchmarks/brief-to-asset/SUMMARY.md
@@ -1,6 +1,6 @@
 # brief-to-asset scorecard
 
-agent: `python3 /home/kwebb/sf-bench/benchmarks/brief-to-asset/agents/scripted_recipe.py`
+agent: `python3 benchmarks/brief-to-asset/agents/scripted_recipe.py`
 
 verdict: **6/6 briefs passed**
 

--- a/benchmarks/brief-to-asset/agents/scripted_recipe.py
+++ b/benchmarks/brief-to-asset/agents/scripted_recipe.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""The scripted reference agent for brief-to-asset.
+
+Not a benchmark contestant — the control group. It maps each frozen brief to
+a known-good recipe, proving the harness itself is green end to end before
+any model is invited. A model's score means something only because this one
+is already 6/6.
+
+Receives a workspace dir containing brief.json; writes recipe.json and
+metrics.json.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+RECIPES = {
+    "crate": {
+        "steps": [
+            {
+                "op": "prop.crate",
+                "args": {"name": "crate", "size": [1, 1, 1], "seed": 7},
+            },
+            {"op": "gameready.collision", "args": {"name": "crate", "mode": "convex"}},
+        ],
+    },
+    "barrel": {
+        "steps": [
+            {"op": "prop.barrel", "args": {"name": "barrel", "seed": 11}},
+        ],
+    },
+    "gladius": {
+        "steps": [
+            {
+                "op": "prop.weapon",
+                "args": {"name": "gladius", "kind": "sword", "seed": 3},
+            },
+        ],
+    },
+    "wolf": {
+        "steps": [
+            {
+                "op": "char.creature",
+                "args": {
+                    "name": "wolf",
+                    "plan": "canine",
+                    "length": 1.3,
+                    "shoulder": 0.85,
+                    "bulk": 1.15,
+                    "skin": "#4a3c30",
+                    "seed": 13,
+                },
+            },
+            {
+                "op": "char.creature_rig",
+                "args": {
+                    "name": "wolf",
+                    "plan": "canine",
+                    "length": 1.3,
+                    "shoulder": 0.85,
+                },
+            },
+            {"op": "char.gait", "args": {"rig": "wolf_rig", "speed": 2.0}},
+            {
+                "op": "char.gait",
+                "args": {
+                    "rig": "wolf_rig",
+                    "style": "trot",
+                    "speed": 4.0,
+                    "action_name": "trot",
+                },
+            },
+        ],
+    },
+    "warden": {
+        "steps": [
+            {
+                "op": "char.humanoid",
+                "args": {
+                    "name": "warden",
+                    "height": 1.82,
+                    "build": "heroic",
+                    "skin": "#b08a68",
+                    "seed": 3,
+                },
+            },
+            {"op": "char.face", "args": {"name": "warden", "height": 1.82}},
+            {"op": "char.hands", "args": {"name": "warden", "height": 1.82}},
+            {
+                "op": "char.outfit",
+                "args": {
+                    "name": "warden",
+                    "piece": "cuirass",
+                    "height": 1.82,
+                    "material": "bronze",
+                },
+            },
+            {
+                "op": "char.outfit",
+                "args": {
+                    "name": "warden",
+                    "piece": "pteruges",
+                    "height": 1.82,
+                    "material": "leather",
+                },
+            },
+            {
+                "op": "char.outfit",
+                "args": {
+                    "name": "warden",
+                    "piece": "greaves",
+                    "height": 1.82,
+                    "material": "bronze",
+                },
+            },
+            {
+                "op": "char.outfit",
+                "args": {
+                    "name": "warden",
+                    "piece": "helmet",
+                    "height": 1.82,
+                    "material": "bronze",
+                },
+            },
+            {
+                "op": "char.rig",
+                "args": {"name": "warden", "height": 1.82, "build": "heroic"},
+            },
+            {"op": "char.gait", "args": {"rig": "warden_rig", "speed": 1.4}},
+        ],
+    },
+    "camp": {
+        "steps": [
+            {
+                "op": "env.camp",
+                "args": {"name": "camp", "radius": 8.0, "shelters": 3, "seed": 42},
+            },
+        ],
+    },
+}
+
+
+def main() -> int:
+    workspace = Path(sys.argv[1])
+    brief = json.loads((workspace / "brief.json").read_text())
+    if brief["id"] not in RECIPES:
+        print(f"no scripted answer for {brief['id']}", file=sys.stderr)
+        return 1
+
+    req = brief.get("requirements", {})
+    recipe = {
+        "recipe_version": 1,
+        "asset_id": brief["id"],
+        "brief": brief["text"],
+        "steps": RECIPES[brief["id"]]["steps"],
+        "requirements": {
+            k: v
+            for k, v in req.items()
+            if k
+            in ("max_triangles", "max_materials", "require_collision", "require_lods")
+        },
+        "export": {
+            "engine": "godot",
+            "category": {
+                "weapon": "prop",
+                "environment": "environment",
+                "character": "character",
+                "creature": "character",
+            }.get(brief["category"], "prop"),
+        },
+    }
+    (workspace / "recipe.json").write_text(json.dumps(recipe, indent=2) + "\n")
+    (workspace / "metrics.json").write_text(json.dumps({"attempts": 1}) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/brief-to-asset/bench.py
+++ b/benchmarks/brief-to-asset/bench.py
@@ -223,11 +223,13 @@ def main(argv=None) -> int:
 
     # The committed summary is deterministic-only: no timings, no paths, no
     # hashes — the public pass/fail table CI can diff (scorecard.json keeps
-    # the machine-dependent detail).
+    # the machine-dependent detail). The agent string is normalized so a run
+    # from any checkout path diffs clean.
+    agent_label = args.agent.replace(str(REPO) + "/", "").replace(str(REPO), ".")
     lines = [
         "# brief-to-asset scorecard",
         "",
-        f"agent: `{args.agent}`",
+        f"agent: `{agent_label}`",
         "",
         f"verdict: **{passed}/{len(results)} briefs passed**",
         "",

--- a/benchmarks/brief-to-asset/bench.py
+++ b/benchmarks/brief-to-asset/bench.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""brief-to-asset — the frozen public benchmark (ADR 0018, M4 first slice).
+
+Several models, one brief set, one compiler, one scorecard. An agent is any
+command that receives a brief JSON and a workspace directory and leaves
+behind its answer; today that answer is a Recipe IR document. The harness
+compiles the recipe through bforge (content-addressed, proof-carrying), then
+scores what a marketing page cannot fake:
+
+  validity      the GLB exists, parses, has meshes and materials
+  semantics     required nodes/skins/animations/collision are in the binary
+  budget        triangles, materials, and payload inside the brief's limits
+  determinism   a forced rebuild produces byte-identical GLB
+  efficiency    wall time, attempts, and gate failures on the way to a pass
+
+The briefs are frozen. The agent is the variable. The score is computed by
+the same gates that ship assets, not by the agent's own opinion.
+
+Usage:
+  python benchmarks/brief-to-asset/bench.py --agent "python benchmarks/brief-to-asset/agents/scripted_recipe.py"
+  python benchmarks/brief-to-asset/bench.py --agent ... --brief wolf --out scorecard.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BENCH = Path(__file__).resolve().parent
+sys.path.insert(0, str(REPO / "tools" / "bforge"))
+
+from bforge import recipe as recipe_mod  # noqa: E402
+
+DIMENSIONS = ("validity", "semantics", "budget", "determinism")
+
+
+def read_glb_json(path: Path) -> dict:
+    data = Path(path).read_bytes()
+    if data[:4] != b"glTF":
+        raise ValueError("not a GLB")
+    json_length = struct.unpack_from("<I", data, 12)[0]
+    return json.loads(data[20 : 20 + json_length])
+
+
+def score_brief(brief: dict, agent_cmd: str, work_root: Path) -> dict:
+    """Run one agent against one brief; return the per-dimension result."""
+    workspace = work_root / brief["id"]
+    workspace.mkdir(parents=True, exist_ok=True)
+    started = time.time()
+    # agent contract: it receives the workspace dir and writes
+    # recipe.json (+ optional metrics.json) into it
+    proc = subprocess.run(
+        [*agent_cmd.split(), str(workspace)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    agent_seconds = round(time.time() - started, 3)
+
+    # agent contract: it writes recipe.json (+ optional metrics.json) into the workspace
+    recipe_path = workspace / "recipe.json"
+    result: dict = {
+        "id": brief["id"],
+        "category": brief["category"],
+        "agent_seconds": agent_seconds,
+        "attempts": 0,
+        "dimensions": {},
+    }
+    metrics_path = workspace / "metrics.json"
+    metrics = json.loads(metrics_path.read_text()) if metrics_path.is_file() else {}
+    result["attempts"] = int(metrics.get("attempts", 1))
+    result["agent_exit"] = proc.returncode
+
+    if proc.returncode != 0 or not recipe_path.is_file():
+        result["dimensions"] = {
+            d: {"pass": False, "detail": "agent produced no recipe"} for d in DIMENSIONS
+        }
+        result["pass"] = False
+        return result
+
+    json.loads(recipe_path.read_text())  # surface malformed recipes before cooking
+    cache = workspace / "cache"
+    cache_a = workspace / "cache-a"
+
+    try:
+        proof = recipe_mod.cook(recipe_path, cache_dir=cache)
+    except recipe_mod.RecipeError as exc:
+        result["dimensions"] = {
+            d: {"pass": False, "detail": str(exc)[:200]} for d in DIMENSIONS
+        }
+        result["pass"] = False
+        return result
+
+    result["recipe_hash"] = proof["recipe_hash"]
+    result["proof"] = str(Path(proof["cache"]["dir"]) / "proof.json")
+
+    glbs = [a for a in proof["artifacts"] if a["path"].endswith(".glb")]
+    glb_path = Path(proof["cache"]["dir"]) / (glbs[0]["path"] if glbs else "")
+
+    # ---- validity
+    try:
+        gltf = read_glb_json(glb_path)
+        validity = bool(gltf.get("meshes")) and bool(gltf.get("materials"))
+        detail = f"{len(gltf.get('meshes', []))} meshes, {len(gltf.get('materials', []))} materials"
+    except Exception as exc:  # noqa: BLE001 — any parse failure is a validity failure
+        gltf, validity, detail = {}, False, f"GLB parse failed: {exc}"
+    result["dimensions"]["validity"] = {"pass": validity, "detail": detail}
+
+    # ---- semantics
+    failures = []
+    semantic = brief.get("semantic", {})
+    nodes = {n.get("name", "") for n in gltf.get("nodes", [])}
+    for required in semantic.get("nodes", []):
+        if required not in nodes:
+            failures.append(f"node {required!r} missing")
+    if len(gltf.get("skins", [])) < semantic.get("skins_min", 0):
+        failures.append("skins below requirement")
+    if len(gltf.get("animations", [])) < semantic.get("animations_min", 0):
+        failures.append("animations below requirement")
+    if len(gltf.get("meshes", [])) < semantic.get("meshes_min", 0):
+        failures.append("meshes below requirement")
+    if brief.get("requirements", {}).get("require_collision") and not any(
+        "-col" in n or "-convcol" in n for n in nodes
+    ):
+        failures.append("no collision proxy")
+    result["dimensions"]["semantics"] = {
+        "pass": not failures,
+        "detail": "; ".join(failures) or "all required structure present",
+    }
+
+    # ---- budget (from the gates' own measurements, not the brief's hopes)
+    budget_failures = []
+    gates = proof.get("gates", {})
+    check = gates.get("check.asset", {})
+    if check and not check.get("ok"):
+        budget_failures.append("check.asset failed")
+    budget = gates.get("gameready.budget", {})
+    if budget and not budget.get("within_budget"):
+        budget_failures.append("gameready.budget failed")
+    payload_cap = brief.get("requirements", {}).get("payload_kb_max")
+    if payload_cap and glb_path.stat().st_size > payload_cap * 1024:
+        budget_failures.append(
+            f"payload {glb_path.stat().st_size // 1024} KB > {payload_cap} KB"
+        )
+    result["dimensions"]["budget"] = {
+        "pass": not budget_failures,
+        "detail": "; ".join(budget_failures) or "within budgets",
+    }
+
+    # ---- determinism: forced rebuild must hash identically
+    try:
+        rebuilt = recipe_mod.cook(recipe_path, cache_dir=cache_a)
+        glbs_b = [a for a in rebuilt["artifacts"] if a["path"] == glbs[0]["path"]]
+        same = glbs_b and glbs_b[0]["sha256"] == glbs[0]["sha256"]
+        result["dimensions"]["determinism"] = {
+            "pass": bool(same),
+            "detail": "byte-identical rebuild" if same else "rebuild hash differs",
+        }
+    except recipe_mod.RecipeError as exc:
+        result["dimensions"]["determinism"] = {"pass": False, "detail": str(exc)[:200]}
+
+    result["pass"] = all(result["dimensions"][d]["pass"] for d in DIMENSIONS)
+    return result
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[2])
+    parser.add_argument(
+        "--agent", required=True, help="agent command; it receives a workspace dir"
+    )
+    parser.add_argument("--brief", default="", help="run only this brief id")
+    parser.add_argument("--out", default="", help="write the scorecard JSON here")
+    parser.add_argument("--work-root", default="", help="scratch directory for runs")
+    args = parser.parse_args(argv)
+
+    briefs = sorted(BENCH.glob("briefs/*.json"))
+    if args.brief:
+        briefs = [b for b in briefs if b.stem == args.brief]
+    if not briefs:
+        print("no briefs matched", file=sys.stderr)
+        return 2
+
+    work_root = (
+        Path(args.work_root)
+        if args.work_root
+        else Path(
+            tempfile.mkdtemp(
+                prefix="briefbench_",
+                dir=BENCH / "out" if (BENCH / "out").is_dir() else None,
+            )
+        )
+    )
+    work_root.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for brief_path in briefs:
+        brief = json.loads(brief_path.read_text())
+        (work_root / brief["id"]).mkdir(parents=True, exist_ok=True)
+        (work_root / brief["id"] / "brief.json").write_text(json.dumps(brief, indent=2))
+        print(f"[brief] {brief['id']}: {brief['text']}")
+        results.append(score_brief(brief, args.agent, work_root))
+        status = "PASS" if results[-1]["pass"] else "FAIL"
+        print(f"  -> {status} ({results[-1]['agent_seconds']}s)")
+
+    passed = sum(1 for r in results if r["pass"])
+    scorecard = {
+        "benchmark": "brief-to-asset/v0.1",
+        "agent": args.agent,
+        "briefs": len(results),
+        "passed": passed,
+        "pass_rate": round(passed / len(results), 4),
+        "results": results,
+    }
+    out = Path(args.out) if args.out else work_root / "scorecard.json"
+    out.write_text(json.dumps(scorecard, indent=2) + "\n", encoding="utf-8")
+
+    # The committed summary is deterministic-only: no timings, no paths, no
+    # hashes — the public pass/fail table CI can diff (scorecard.json keeps
+    # the machine-dependent detail).
+    lines = [
+        "# brief-to-asset scorecard",
+        "",
+        f"agent: `{args.agent}`",
+        "",
+        f"verdict: **{passed}/{len(results)} briefs passed**",
+        "",
+        "| brief | category | validity | semantics | budget | determinism |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for r in results:
+        marks = ["✓" if r["dimensions"][d]["pass"] else "✗" for d in DIMENSIONS]
+        lines.append(f"| {r['id']} | {r['category']} | {' | '.join(marks)} |")
+    lines += [
+        "",
+        "Every brief is scored by the harness from the compiled artifact and its",
+        "proof, never from the agent's own claims. Determinism is a forced",
+        "rebuild that must hash byte-identically.",
+        "",
+        "Rerun: `just briefbench` (reference agent). Times, paths, and hashes",
+        "live in scorecard.json (machine-dependent); this file is the diffed",
+        "public number.",
+        "",
+    ]
+    (BENCH / "SUMMARY.md").write_text("\n".join(lines), encoding="utf-8")
+    print(f"[score] {passed}/{len(results)} briefs passed -> {out}")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/brief-to-asset/briefs/barrel.json
+++ b/benchmarks/brief-to-asset/briefs/barrel.json
@@ -1,0 +1,13 @@
+{
+  "id": "barrel",
+  "category": "prop",
+  "text": "a small storage barrel with staves and metal bands, for a browser game",
+  "requirements": {
+    "max_triangles": 3000,
+    "max_materials": 3,
+    "payload_kb_max": 768
+  },
+  "semantic": {
+    "nodes": ["barrel"]
+  }
+}

--- a/benchmarks/brief-to-asset/briefs/camp.json
+++ b/benchmarks/brief-to-asset/briefs/camp.json
@@ -1,0 +1,13 @@
+{
+  "id": "camp",
+  "category": "environment",
+  "text": "a small age-one military camp with a palisade, shelters, a well, and a gate, for a browser game",
+  "requirements": {
+    "max_triangles": 8000,
+    "max_materials": 6,
+    "payload_kb_max": 4096
+  },
+  "semantic": {
+    "meshes_min": 4
+  }
+}

--- a/benchmarks/brief-to-asset/briefs/crate.json
+++ b/benchmarks/brief-to-asset/briefs/crate.json
@@ -1,0 +1,14 @@
+{
+  "id": "crate",
+  "category": "prop",
+  "text": "a sturdy one-metre wooden supply crate with collision, for a browser game",
+  "requirements": {
+    "max_triangles": 2000,
+    "max_materials": 2,
+    "require_collision": true,
+    "payload_kb_max": 512
+  },
+  "semantic": {
+    "nodes": ["crate"]
+  }
+}

--- a/benchmarks/brief-to-asset/briefs/gladius.json
+++ b/benchmarks/brief-to-asset/briefs/gladius.json
@@ -1,0 +1,13 @@
+{
+  "id": "gladius",
+  "category": "weapon",
+  "text": "a roman short sword with a bronze hilt, for a browser game",
+  "requirements": {
+    "max_triangles": 3000,
+    "max_materials": 4,
+    "payload_kb_max": 768
+  },
+  "semantic": {
+    "nodes": ["gladius"]
+  }
+}

--- a/benchmarks/brief-to-asset/briefs/warden.json
+++ b/benchmarks/brief-to-asset/briefs/warden.json
@@ -1,0 +1,14 @@
+{
+  "id": "warden",
+  "category": "character",
+  "text": "an armored warden that walks, with a rig, one walk clip, and fitted armor, for a browser game",
+  "requirements": {
+    "max_triangles": 9000,
+    "max_materials": 6,
+    "payload_kb_max": 3072
+  },
+  "semantic": {
+    "skins_min": 1,
+    "animations_min": 1
+  }
+}

--- a/benchmarks/brief-to-asset/briefs/wolf.json
+++ b/benchmarks/brief-to-asset/briefs/wolf.json
@@ -1,0 +1,14 @@
+{
+  "id": "wolf",
+  "category": "creature",
+  "text": "a wolf with a rig and a walk and a run clip, for a browser game",
+  "requirements": {
+    "max_triangles": 6000,
+    "max_materials": 3,
+    "payload_kb_max": 2048
+  },
+  "semantic": {
+    "skins_min": 1,
+    "animations_min": 2
+  }
+}

--- a/benchmarks/brief-to-asset/tests/test_briefbench.py
+++ b/benchmarks/brief-to-asset/tests/test_briefbench.py
@@ -1,0 +1,92 @@
+"""brief-to-asset static checks: the frozen set is well-formed and the
+reference agent only uses ops that actually exist (no Blender required)."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+BENCH = Path(__file__).resolve().parents[1]
+REPO = BENCH.parents[1]
+
+
+class FrozenSet(unittest.TestCase):
+    def setUp(self):
+        self.briefs = sorted(BENCH.glob("briefs/*.json"))
+        self.catalog = {
+            op["name"]
+            for op in json.loads(
+                (REPO / "tools" / "bforge" / "catalog.json").read_text()
+            )["ops"]
+        }
+
+    def test_briefs_are_well_formed(self):
+        self.assertGreaterEqual(
+            len(self.briefs), 5, "the frozen set must not silently shrink"
+        )
+        ids = []
+        for path in self.briefs:
+            with self.subTest(brief=path.name):
+                brief = json.loads(path.read_text())
+                self.assertEqual(brief["id"], path.stem)
+                self.assertTrue(brief["text"])
+                self.assertIn(
+                    brief["category"],
+                    {"prop", "weapon", "creature", "character", "environment"},
+                )
+                self.assertIsInstance(brief.get("requirements", {}), dict)
+                ids.append(brief["id"])
+        self.assertEqual(len(ids), len(set(ids)), "brief ids must be unique")
+
+    def test_reference_agent_ops_exist_in_the_catalog(self):
+        agent = (BENCH / "agents" / "scripted_recipe.py").read_text()
+        self.assertIn("RECIPES", agent)
+        import ast
+
+        ops_used = set()
+        for node in ast.walk(ast.parse(agent)):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and "." in node.value
+            ):
+                if node.value.split(".")[0] in (
+                    "prop",
+                    "char",
+                    "env",
+                    "gameready",
+                    "image",
+                    "mesh",
+                    "uv",
+                    "material",
+                    "kit",
+                    "arch",
+                    "check",
+                    "render",
+                    "rig",
+                    "morph",
+                    "paint",
+                    "build",
+                    "object",
+                    "bake",
+                    "meta",
+                    "session",
+                    "export",
+                ):
+                    ops_used.add(node.value)
+        self.assertGreater(len(ops_used), 5)
+        missing = ops_used - self.catalog
+        self.assertEqual(
+            missing, set(), f"agent uses ops not in the catalog: {missing}"
+        )
+
+    def test_summary_is_committed_and_current_format(self):
+        summary = (BENCH / "SUMMARY.md").read_text()
+        self.assertIn("verdict:", summary)
+        for path in self.briefs:
+            self.assertIn(f"| {path.stem} |", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/justfile
+++ b/justfile
@@ -257,6 +257,11 @@ sim-replay:
 sim-parity:
     uv run --project tools python -m unittest discover -s tools/sim/tests -p "test_parity.py" -v
 
+# The frozen public benchmark (ADR 0018 M4): reference agent against the frozen
+# brief set, SUMMARY.md regenerated (CI diffs it).
+briefbench:
+    uv run --project tools python benchmarks/brief-to-asset/bench.py --agent "python3 benchmarks/brief-to-asset/agents/scripted_recipe.py"
+
 # ------------------------------------------------------------------ exports
 
 # WebGL2 Compatibility export — works with official installed templates

--- a/tools/bforge/runtime/ops/export.py
+++ b/tools/bforge/runtime/ops/export.py
@@ -21,24 +21,44 @@ from registry import OpError, op
 
 PRESETS = {
     "godot": {
-        "export_yup": True, "export_apply": True, "export_cameras": False,
-        "export_lights": False, "export_extras": True, "export_tangents": True,
+        "export_yup": True,
+        "export_apply": True,
+        "export_cameras": False,
+        "export_lights": False,
+        "export_extras": True,
+        "export_tangents": True,
     },
     "unity": {
-        "export_yup": True, "export_apply": True, "export_cameras": False,
-        "export_lights": False, "export_extras": False, "export_tangents": True,
+        "export_yup": True,
+        "export_apply": True,
+        "export_cameras": False,
+        "export_lights": False,
+        "export_extras": False,
+        "export_tangents": True,
     },
     "unreal": {
-        "export_yup": True, "export_apply": True, "export_cameras": False,
-        "export_lights": False, "export_extras": False, "export_tangents": True,
+        "export_yup": True,
+        "export_apply": True,
+        "export_cameras": False,
+        "export_lights": False,
+        "export_extras": False,
+        "export_tangents": True,
     },
     "threejs": {
-        "export_yup": True, "export_apply": True, "export_cameras": True,
-        "export_lights": True, "export_extras": True, "export_tangents": False,
+        "export_yup": True,
+        "export_apply": True,
+        "export_cameras": True,
+        "export_lights": True,
+        "export_extras": True,
+        "export_tangents": False,
     },
     "raw": {
-        "export_yup": True, "export_apply": False, "export_cameras": True,
-        "export_lights": True, "export_extras": True, "export_tangents": False,
+        "export_yup": True,
+        "export_apply": False,
+        "export_cameras": True,
+        "export_lights": True,
+        "export_extras": True,
+        "export_tangents": False,
     },
 }
 
@@ -52,9 +72,21 @@ PRESETS = {
         "engine": (f"enum:{'|'.join(PRESETS)}", "godot", "Target engine preset"),
         "format": ("enum:glb|gltf", "glb", "Binary GLB (one file) or text glTF (separate assets)"),
         "animations": ("bool", True, "Include armature actions"),
-        "draco": ("bool", False, "Draco mesh compression — smaller files, slower load, not all importers support it"),
-        "strict": ("bool", True, "Fail on problems that would corrupt the import instead of warning"),
-        "rename": ("obj", None, "Names to apply IN THE EXPORTED FILE ONLY, e.g. {\"horse\": \"Horse\", \"m_coat\": \"Coat\", \"gallop\": \"Gallop\"}. Game code often looks up nodes and materials by exact name, and those names break the studio's snake_case rule — this satisfies both without renaming the master"),
+        "draco": (
+            "bool",
+            False,
+            "Draco mesh compression — smaller files, slower load, not all importers support it",
+        ),
+        "strict": (
+            "bool",
+            True,
+            "Fail on problems that would corrupt the import instead of warning",
+        ),
+        "rename": (
+            "obj",
+            None,
+            'Names to apply IN THE EXPORTED FILE ONLY, e.g. {"horse": "Horse", "m_coat": "Coat", "gallop": "Gallop"}. Game code often looks up nodes and materials by exact name, and those names break the studio\'s snake_case rule — this satisfies both without renaming the master',
+        ),
     },
     tags=["export", "io"],
 )
@@ -73,6 +105,15 @@ def export_gltf(ctx, out, objects, engine, format, animations, draco, strict, re
         )
     for warning in warnings + (problems if not strict else []):
         ctx.note(warning)
+
+    # Byte-determinism is enforced at the boundary, not hoped for per op:
+    # BMesh face order can flake across processes (bench-caught: prop.barrel),
+    # so every exported mesh gets a canonical polygon order. Vertex order is
+    # untouched, so skins and weights are safe; shape-keyed meshes keep their
+    # own proven-stable paths.
+    for mesh_obj in meshes:
+        if not mesh_obj.data.shape_keys:
+            mesh_lib.canonicalize(mesh_obj)
 
     suffix = ".glb" if format == "glb" else ".gltf"
     path = ctx.out_path(out, suffix)
@@ -206,7 +247,11 @@ def _preflight(meshes):
     params={
         "out": ("path", "asset.blend", "Output .blend path"),
         "compress": ("bool", True, "Compress the file"),
-        "pack_textures": ("bool", True, "Embed image textures in the .blend. A master links textures by RELATIVE path, so the moment it is copied into assets-source those links break and the committed master is useless — `just asset-validate` fails it on missing textures"),
+        "pack_textures": (
+            "bool",
+            True,
+            "Embed image textures in the .blend. A master links textures by RELATIVE path, so the moment it is copied into assets-source those links break and the committed master is useless — `just asset-validate` fails it on missing textures",
+        ),
     },
     tags=["export", "io"],
 )
@@ -246,7 +291,11 @@ def export_blend(ctx, out, compress, pack_textures):
     params={
         "out": ("path", "asset.meta.json", "Output .meta.json path"),
         "asset_id": ("str", None, "snake_case asset identifier"),
-        "category": ("enum:prop|character|environment|weapon|architecture|vfx|ui", "prop", "Asset category"),
+        "category": (
+            "enum:prop|character|environment|weapon|architecture|vfx|ui",
+            "prop",
+            "Asset category",
+        ),
         "license": ("str", "CC-BY-4.0", "Licence identifier"),
         "creator": ("str", "bforge", "Creator name"),
         "source": ("str", "procedural", "Where the asset came from"),
@@ -260,8 +309,22 @@ def export_blend(ctx, out, compress, pack_textures):
     },
     tags=["export", "io"],
 )
-def export_meta(ctx, out, asset_id, category, license, creator, source, ai_tool, ai_model,
-                ai_prompt, triangles, materials, collision_policy, lod_policy):
+def export_meta(
+    ctx,
+    out,
+    asset_id,
+    category,
+    license,
+    creator,
+    source,
+    ai_tool,
+    ai_model,
+    ai_prompt,
+    triangles,
+    materials,
+    collision_policy,
+    lod_policy,
+):
     identifier = scene_lib.sanitize(asset_id)
     meshes = [o for o in scene_lib.mesh_objects()]
     measured = sum(mesh_lib.tri_count(o) for o in meshes)
@@ -291,9 +354,7 @@ def export_meta(ctx, out, asset_id, category, license, creator, source, ai_tool,
         "measured": {
             "triangles": measured,
             "objects": len(meshes),
-            "materials": sorted(
-                {m.name for o in meshes for m in o.data.materials if m}
-            ),
+            "materials": sorted({m.name for o in meshes for m in o.data.materials if m}),
         },
     }
     path = ctx.out_path(out, ".json")
@@ -309,17 +370,30 @@ def export_meta(ctx, out, asset_id, category, license, creator, source, ai_tool,
         "out_dir": ("path", "", "Directory for the outputs (defaults to the session output dir)"),
         "objects": ("str[]", [], "Objects to export (empty = whole scene)"),
         "engine": (f"enum:{'|'.join(PRESETS)}", "godot", "Target engine preset"),
-        "category": ("enum:prop|character|environment|weapon|architecture|vfx|ui", "prop", "Asset category"),
+        "category": (
+            "enum:prop|character|environment|weapon|architecture|vfx|ui",
+            "prop",
+            "Asset category",
+        ),
         "ai_prompt": ("str", "", "What the asset was asked for — recorded in provenance"),
         "contact_sheet": ("bool", True, "Also render a review contact sheet"),
         "strict": ("bool", True, "Block export on problems that would corrupt the import"),
-        "gate": ("bool", True, "Run gameready.review before writing anything; a failed review blocks the hand-off. Set false only for deliberate blockouts"),
-        "style": ("enum:stylized|realistic", "stylized", "Art direction passed to gameready.review when gate=true"),
+        "gate": (
+            "bool",
+            True,
+            "Run gameready.review before writing anything; a failed review blocks the hand-off. Set false only for deliberate blockouts",
+        ),
+        "style": (
+            "enum:stylized|realistic",
+            "stylized",
+            "Art direction passed to gameready.review when gate=true",
+        ),
     },
     tags=["export", "io"],
 )
-def export_asset(ctx, asset_id, out_dir, objects, engine, category, ai_prompt, contact_sheet,
-                 strict, gate, style):
+def export_asset(
+    ctx, asset_id, out_dir, objects, engine, category, ai_prompt, contact_sheet, strict, gate, style
+):
     from . import gameready as gameready_ops
     from . import render as render_ops
 
@@ -342,14 +416,32 @@ def export_asset(ctx, asset_id, out_dir, objects, engine, category, ai_prompt, c
     blend = export_blend(ctx, f"{prefix}.blend", True, True)
     glb = export_gltf(ctx, f"{prefix}.glb", objects, engine, "glb", True, False, strict, None)
     meta = export_meta(
-        ctx, f"{prefix}.meta.json", identifier, category, "CC-BY-4.0", "bforge",
-        "procedural", "bforge", "", ai_prompt, 0, 2, "explicit", "auto",
+        ctx,
+        f"{prefix}.meta.json",
+        identifier,
+        category,
+        "CC-BY-4.0",
+        "bforge",
+        "procedural",
+        "bforge",
+        "",
+        ai_prompt,
+        0,
+        2,
+        "explicit",
+        "auto",
     )
     outputs = {"blend": blend, "glb": glb, "meta": meta}
     if contact_sheet:
         outputs["contact_sheet"] = render_ops.render_contact_sheet(
-            ctx, f"{prefix}_sheet.png", objects, 400, 20, "auto",
-            ["hero", "front", "left", "top", "wireframe", "checker"], 3,
+            ctx,
+            f"{prefix}_sheet.png",
+            objects,
+            400,
+            20,
+            "auto",
+            ["hero", "front", "left", "top", "wireframe", "checker"],
+            3,
         )
     return {
         "asset_id": identifier,


### PR DESCRIPTION
## What this does

The frozen public benchmark (ADR 0018 milestone M4, first slice) — the thing that turns "trust our numbers" into "bring your own model and watch it try."

```
frozen briefs (6)  →  any agent command  →  Recipe IR  →  bforge cook
                                                          →  score from the artifact:
     validity      the GLB parses, with meshes + materials
     semantics     required nodes/skins/clips/collision IN the binary
     budget        the gates' own measurements, not the brief's hopes
     determinism   a forced rebuild must hash byte-identically
     efficiency    wall time, attempts, agent exit
```

- **`benchmarks/brief-to-asset/briefs/`** — six frozen briefs across prop, weapon, creature, character, and environment, each with requirements and semantic expectations.
- **`bench.py`** — the model-neutral harness. The agent contract is one line: *receive a workspace, write `recipe.json`*. LLM agents, local models, and scripts all play the same game.
- **`agents/scripted_recipe.py`** — the reference agent / control group: six known-good recipes holding the **6/6 baseline**, regenerated and diffed in the hosted bench job (same pattern as the bforge bench).
- **`tests/test_briefbench.py`** — the frozen set is well-formed and the reference agent only uses catalog ops.

## The benchmark earned its keep on its first full run

`prop.barrel` was not byte-deterministic across processes — identical vertex data, varying BMesh face order. It had never been in the byte-pinned bench set, so nobody knew. The fix is at the boundary, per the deterministic-construction doctrine: **`export.gltf` now canonicalizes polygon order for every exported mesh without shape keys** (vertex order untouched, so skins/weights are safe). Full bforge suite: 205 tests green with the fix.

## Acceptance

- Reference agent: 6/6 (validity, semantics, budget, determinism on every brief)
- Static checks in the hosted python job; benchmark regeneration + scorecard diff in the hosted bench job
- claims gate, secret scan, workflow validation, ruff: green

## Next

Real model runs (GPT/Claude/Kimi/local) against the same briefs published as scorecards; then brief→battle (the world-level benchmark) on top of #84's world proofs.
