### PR TITLE
license: PolyForm Perimeter 1.0.1 + product-attribution additional terms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,66 +3,192 @@ STUDIO FOUNDATION — ENGINE & TOOLING LICENSE
 ================================================================================
 
 Foundation code, tooling, templates, documentation, and infrastructure in this
-repository are licensed under both the MIT License and CC BY 4.0 simultaneously.
+repository — including bforge, worldc, the simulation kernel, the sim-viewer
+adapter, the benchmark harness, and the WebGPU patch tooling (the "Software")
+— are available under the **PolyForm Perimeter License 1.0.1** (Part 1,
+verbatim) plus the **Additional Terms** in Part 2.
 
 SCOPE — IMPORTANT:
   * This grant applies to engine/, services/, tools/, shared/, templates/,
-    docs/, infra/, scripts/, and tests/.
+    docs/, infra/, scripts/, benchmarks/, and tests/.
   * Generated or external projects placed under `games/` are consumers, not
     automatically part of the Foundation distribution. Each game declares its
     own license; see games/LICENSE for the default boundary.
+  * Public revisions of this repository published before 2026-08-06 were
+    offered under MIT/CC BY 4.0 and remain under their original terms. The
+    PolyForm Perimeter License 1.0.1 and the Additional Terms apply from
+    2026-08-06 forward.
 
-Both license texts follow. Where the two differ, the recipient may rely on
-either license; attribution under CC BY 4.0 is satisfied by retaining the
-copyright notice and a link to this repository.
-
---------------------------------------------------------------------------------
-PART 1 — MIT License
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) 2026 Studio Foundation contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Required Notice: Studio Foundation (https://github.com/lxsolutions/studio-foundation)
 
 --------------------------------------------------------------------------------
-PART 2 — Creative Commons Attribution 4.0 International (CC BY 4.0)
+PART 1 — PolyForm Perimeter License 1.0.1 (verbatim)
 --------------------------------------------------------------------------------
 
-This work is licensed under the Creative Commons Attribution 4.0 International
-License. To view a copy of this license, visit
-https://creativecommons.org/licenses/by/4.0/ or send a letter to Creative
-Commons, PO Box 1866, Mountain View, CA 94042, USA.
+# PolyForm Perimeter License 1.0.1
 
-Under CC BY 4.0 you are free to:
-  * Share — copy and redistribute the material in any medium or format, and
-  * Adapt — remix, transform, and build upon the material for any purpose,
-    even commercially,
-under the following terms:
-  * Attribution — You must give appropriate credit, provide a link to the
-    license, and indicate if changes were made. You may do so in any reasonable
-    manner, but not in any way that suggests the licensor endorses you or your
-    use.
-  * No additional restrictions — You may not apply legal terms or technological
-    measures that legally restrict others from doing anything the license
-    permits.
+https://polyformproject.org/licenses/perimeter/1.0.1
 
-The full canonical CC BY 4.0 legal code is at:
-https://creativecommons.org/licenses/by/4.0/legalcode
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both
+strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything
+you might do with the software that would otherwise infringe the licensor's
+copyright in it for any permitted purpose. However, you may only distribute
+the software according to Distribution License and make changes or new works
+based on the software according to Changes and New Works License.
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies
+of the software. Your license to distribute covers distributing the software
+with changes and new works permitted by Changes and New Works License.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from
+you also gets a copy of these terms or the URL for them above, as well as
+copies of any plain-text lines beginning with `Required Notice:` that the
+licensor provided with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and
+new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent
+claims the licensor can license, or becomes able to license, that you would
+infringe by using the software.
+
+## Noncompete
+
+Any purpose is a permitted purpose, except for providing to others any
+product that competes with the software.
+
+## Competition
+
+If you use this software to market a product as a substitute for the
+functionality or value of the software, it competes with the software. A
+product may compete regardless how it is designed or deployed. For example, a
+product may compete even if it provides its functionality via any kind of
+interface (including services, libraries or plug-ins), even if it is ported
+to a different platform or programming language, and even if it is provided
+free of charge.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do
+not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses
+to anyone else, or prevent the licensor from granting licenses to anyone
+else. These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software granted
+under these terms ends immediately. If your company makes such a claim, your
+patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of
+these terms, or done anything with the software not covered by your licenses,
+your licenses can nonetheless continue if you come into full compliance with
+these terms, and take practical steps to correct past violations, within 32
+days of receiving notice. Otherwise, all your licenses end immediately.
+
+## No Liability
+
+_**As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.**_
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the
+**software** is the software the licensor makes available under these terms.
+
+A **product** can be a good or service, or a combination of them.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. **Control** means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**Use** means anything you do with the software requiring one of your
+licenses.
+
+--------------------------------------------------------------------------------
+PART 2 — ADDITIONAL TERMS (not part of the PolyForm Perimeter License 1.0.1)
+--------------------------------------------------------------------------------
+
+The following Additional Terms are conditions imposed by the licensor in
+addition to the PolyForm Perimeter License 1.0.1. They are deliberately
+separate from the verbatim PolyForm text. To the maximum extent the law
+allows, the licensor's intent is that these Additional Terms govern alongside
+Part 1.
+
+2.1 Product Attribution Condition
+
+As a condition of the licenses granted for the Software, if you publicly
+distribute or commercially provide a game, film, simulation, asset pack, or
+other product in which assets were created or materially modified using the
+Software, you must include the following attribution once per product in a
+reasonably accessible credits, acknowledgments, legal notices, documentation,
+or product-listing location:
+
+    "Asset production powered in part by bforge, developed by
+    Studio Foundation."
+
+The attribution must be at least as prominent as comparable third-party
+engine, middleware, or production-tool acknowledgments. No attribution is
+required for private, internal, testing, or prototype use. This requirement
+does not transfer ownership of generated outputs to the licensor and does not
+imply endorsement of the product.
+
+2.2 Contractor Pass-Through
+
+If you provide assets created or materially modified using the Software to
+another person for incorporation into a publicly distributed product, you
+must inform that person of the attribution requirement in Section 2.1 and
+ensure that the final product includes the required attribution.
+
+2.3 Attribution Metadata Support
+
+The Software may embed nonintrusive provenance metadata (for example, a
+`generator` or `attribution` field) into exported asset packages and their
+sidecar manifests. This metadata supports compliance with Section 2.1; it is
+not a visible watermark, and removing it does not remove the obligation in
+Section 2.1.
+
+--------------------------------------------------------------------------------
+
+Plain-English summary (not legally binding): use bforge and the Studio
+Foundation toolsets freely to build and sell games and assets, credit
+Studio Foundation once per product, and do not offer a competing bforge
+product. Commercial licensing that waives the attribution condition may be
+available separately.
+
+The boundary between the Foundation's independent host tooling and code
+executed through Blender (GPL-2.0-or-later) is documented in
+docs/architecture/dependency-licenses.md and ADR 0006.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,5 +1,12 @@
 # Notices and Attribution
 
+Studio Foundation's own code, tooling, templates, documentation, and
+infrastructure are available under the **PolyForm Perimeter License 1.0.1**
+plus the Additional Terms in [LICENSE](LICENSE), including the product
+attribution condition ("Asset production powered in part by bforge, developed
+by Studio Foundation"). Revisions published before 2026-08-06 were offered
+under MIT/CC BY 4.0.
+
 Studio Foundation contains original platform work and incorporates
 third-party open-source components. The dependency and license inventory is in
 `docs/architecture/dependency-licenses.md`.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,10 @@ Contributor workflow is in
 reporting instructions are in [SECURITY.md](SECURITY.md).
 
 Foundation code, tooling, templates, documentation, and infrastructure are
-dual-licensed under MIT and CC BY 4.0; see [LICENSE](LICENSE). Third-party attribution
-is in [NOTICE.md](NOTICE.md) and
+available under the **PolyForm Perimeter License 1.0.1** plus the Additional
+Terms in [LICENSE](LICENSE): use it freely to build and sell games and assets,
+credit Studio Foundation once per product ("Asset production powered in part
+by bforge"), and do not offer a competing bforge product. Revisions published
+before 2026-08-06 remain under their original MIT/CC BY 4.0 terms. Third-party
+attribution is in [NOTICE.md](NOTICE.md) and
 [dependency-licenses.md](docs/architecture/dependency-licenses.md).

--- a/docs/adr/0013-dependency-license-policy.md
+++ b/docs/adr/0013-dependency-license-policy.md
@@ -12,8 +12,10 @@ silently become no-ops when an optional local utility is absent.
 
 ## Decision
 
-- Platform code remains dual MIT and CC BY 4.0; games/ remains governed by
-  games/LICENSE unless a game supplies its own license.
+- Platform code is available under the PolyForm Perimeter License 1.0.1 plus
+  the Additional Terms in LICENSE (adopted 2026-08-06; earlier revisions stay
+  MIT/CC BY 4.0). games/ remains governed by games/LICENSE unless a game
+  supplies its own license.
 - Linked/runtime dependencies require reviewed SPDX license expressions.
   Approved permissive identifiers are MIT, MIT-0, Apache-2.0 (including the
   LLVM exception), BSD-2-Clause, BSD-3-Clause, 0BSD, ISC, Zlib, PostgreSQL,

--- a/docs/architecture/dependency-licenses.md
+++ b/docs/architecture/dependency-licenses.md
@@ -11,7 +11,7 @@ Exact resolved versions live in the lockfiles (`Cargo.lock`, `uv.lock`,
 | Component | Pin | License | Role | Notes |
 |---|---|---|---|---|
 | Godot Engine | 4.7.1-stable `a13da4feb…` | MIT | Primary engine | ADR 0001 |
-| Studio Foundation WebGPU integration | official 4.7.1 + local checksummed patches; source lineage `f329e39ce...` | MIT plus included third-party licenses | Browser WebGPU export backend | ADR 0002; beta; see NOTICE.md |
+| Studio Foundation WebGPU integration | official 4.7.1 + local checksummed patches; source lineage `f329e39ce...` | PolyForm Perimeter 1.0.1 + Additional Terms (LICENSE), with included third-party licenses (MIT etc.) | Browser WebGPU export backend | ADR 0002; beta; see NOTICE.md |
 | Godot export templates (web) | 4.7.1.stable official | MIT | WebGL2 browser export | installed via editor |
 | Blender | 4.5.12 LTS | GPL-2.0-or-later | Master asset tool (standalone process only) | ADR 0006 isolation note; the version CI and the byte-identical bench verify against |
 | Emscripten | 4.0.11 | MIT/UIUC | Web engine builds | pinned for the local integration |

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -33,7 +33,7 @@ http-body-util = "0.1"
 
 [workspace.package]
 edition = "2021"
-license = "MIT"
+license = "PolyForm-Perimeter-1.0.1"
 rust-version = "1.85"
 
 [profile.release]

--- a/services/sim-kernel/Cargo.toml
+++ b/services/sim-kernel/Cargo.toml
@@ -3,7 +3,7 @@ name = "sim-kernel"
 version = "0.1.0"
 edition = "2021"
 description = "Deterministic gate simulation kernel (ADR 0018 M3): native + Wasm parity"
-license = "MIT"
+license = "PolyForm-Perimeter-1.0.1"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/tools/bforge/runtime/ops/export.py
+++ b/tools/bforge/runtime/ops/export.py
@@ -334,6 +334,9 @@ def export_meta(
         "license": license,
         "source": source,
         "creator": creator,
+        # LICENSE Part 2 (Product Attribution Condition) support: a
+        # nonintrusive provenance field, not a watermark.
+        "attribution": "Asset production powered in part by bforge, developed by Studio Foundation.",
         "provenance": {
             "method": "ai_generated",
             "commercial_use_allowed": True,

--- a/tools/bforge/tests/test_forge.py
+++ b/tools/bforge/tests/test_forge.py
@@ -578,6 +578,8 @@ class Export(ForgeCase):
         self.assertEqual(meta["asset_id"], "crate_a")
         self.assertEqual(meta["provenance"]["method"], "ai_generated")
         self.assertEqual(meta["provenance"]["ai"]["prompt"], "a wooden crate")
+        self.assertIn("bforge", meta["attribution"])
+        self.assertIn("Studio Foundation", meta["attribution"])
 
     def test_export_asset_writes_the_full_hand_off(self):
         self.forge.call("prop.barrel", name="barrel", seed=1)

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -3,7 +3,7 @@ name = "studio-tools"
 version = "0.1.0"
 description = "Studio Foundation tooling: asset pipeline, doctor, generator, studio-mcp, CI helpers"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = { text = "PolyForm-Perimeter-1.0.1" }
 dependencies = [
     # Runtime tooling is deliberately stdlib-only (auditability + offline-first).
 ]


### PR DESCRIPTION
## What this does

Moves Studio Foundation — bforge, worldc, the sim kernel, the sim-viewer adapter, the benchmark harness, and the WebGPU tooling — from dual MIT/CC BY 4.0 to the **PolyForm Perimeter License 1.0.1**, plus clearly-separated Additional Terms. Revisions published before 2026-08-06 remain under their original terms.

## Structure (deliberately conservative, per licensing guidance)

- **Part 1 is the verbatim Perimeter text.** Nothing in it was edited; silently modifying a license and keeping its name is how you lose it. The `Required Notice:` line identifies Studio Foundation.
- **Part 2 carries the Additional Terms, labeled as additional terms:**
  - **Product attribution condition** — one credit per publicly distributed product: *"Asset production powered in part by bforge, developed by Studio Foundation."* Project-level, not per-asset; no requirement for private/internal/prototype use; output ownership stays with the user.
  - **Contractor pass-through** — a studio receiving bforge-made assets from a contractor must be informed and must include the credit.
  - **Metadata support** — `export.meta` now writes the attribution string into every asset sidecar as nonintrusive provenance (compliance support, not a watermark). Test added.
- **Plain-English summary in LICENSE**: build and sell freely, credit once per product, don't offer a competing bforge product; commercial attribution-waiving licenses may be offered separately.

## Sweep

`LICENSE`, `NOTICE.md`, `README.md`, ADR 0013, `dependency-licenses.md` project row, `tools/pyproject.toml`, `services/Cargo.toml` (+ sim-kernel), and the export sidecar. The asset-level `license` parameter in `export.meta` is the consuming studio's own choice for its assets — intentionally untouched.

## Flagged for counsel before commercial reliance

- Final wording of the Part 2 rider (enforceability of product-level attribution).
- The Blender (GPL-2.0) boundary already documented in ADR 0006 (bforge's host tooling vs code executed through Blender).

## Acceptance

- Full bforge suite green (205 tests, including the new sidecar attribution assertions)
- claims gate OK; ruff clean
