### PR TITLE
brief-to-battle: the world-level half of the frozen benchmark

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,9 @@ jobs:
       - name: brief-to-asset static checks
         run: uv run --project tools python -m unittest discover -s benchmarks/brief-to-asset/tests -p "test_*.py"
 
+      - name: brief-to-battle static checks
+        run: uv run --project tools python -m unittest discover -s benchmarks/brief-to-battle/tests -p "test_*.py"
+
       - name: Protocol golden fixtures
         run: uv run --project tools python tools/asset-pipeline/check_fixtures.py
 
@@ -192,3 +195,13 @@ jobs:
 
       - name: the committed scorecard matches a fresh run
         run: git diff --exit-code benchmarks/brief-to-asset/SUMMARY.md
+
+      # The world-level half: the reference agent's world must compile with
+      # proof, play out as briefed, and hash identically twice.
+      - name: brief-to-battle benchmark (reference agent)
+        env:
+          BLENDER_BIN: /opt/blender/blender
+        run: uv run --project tools python benchmarks/brief-to-battle/bench.py --agent "python3 benchmarks/brief-to-battle/agents/scripted_world.py"
+
+      - name: the committed battle scorecard matches a fresh run
+        run: git diff --exit-code benchmarks/brief-to-battle/SUMMARY.md

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ tools/bforge/cache/
 tools/bforge/bench/out/
 tools/worldc/cache/
 benchmarks/brief-to-asset/out/
+benchmarks/brief-to-battle/out/
 
 # --- Rust ---
 target/

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ it works identically on a laptop, in CI, and on a headless build box.
   validity, semantics, budget, and byte-identical determinism — regenerated
   and diffed in public CI. The scripted reference agent holds the 6/6
   baseline; models compete against the same gates, not against vibes.
+  `benchmarks/brief-to-battle` is the world-level half: the frozen fortress
+  battle brief compiles with proof, plays out deterministically, and scores
+  navigation outcomes against the brief — never the agent's claims.
 - **Characters and creatures, actually rigged and animated.** Humanoids at
   figure-drawing proportions with fitted armour (`char.outfit`), faces, hands;
   quadrupeds and hexapods with real footfall gaits — lateral-sequence walk,

--- a/benchmarks/brief-to-battle/SUMMARY.md
+++ b/benchmarks/brief-to-battle/SUMMARY.md
@@ -1,0 +1,17 @@
+# brief-to-battle scorecard
+
+agent: `python3 benchmarks/brief-to-battle/agents/scripted_world.py`
+
+verdict: **1/1 briefs passed**
+
+| brief | validity | semantics | gameplay | determinism |
+| --- | --- | --- | --- | --- |
+| fortress_battle | ✓ | ✓ | ✓ | ✓ |
+
+The world is compiled with proof (entity proofs + scenario binding),
+the scenario runs deterministically, and outcomes are scored against
+the brief's expected navigation — never against the agent's claims.
+
+Rerun: `just battlebench` (reference agent). Times, paths, and hashes
+live in scorecard.json (machine-dependent); this file is the diffed
+public number.

--- a/benchmarks/brief-to-battle/agents/scripted_world.py
+++ b/benchmarks/brief-to-battle/agents/scripted_world.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""The scripted reference agent for brief-to-battle (the control group).
+
+Receives a workspace dir containing brief.json and the staged entity docs;
+writes world.json + battle.json (contracts compiled from the staged World
+IR documents) + metrics.json.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "tools" / "worldc"))
+sys.path.insert(0, str(REPO / "tools" / "bforge"))
+
+import worldc  # noqa: E402
+from bforge import recipe as recipe_mod  # noqa: E402
+
+
+def main() -> int:
+    workspace = Path(sys.argv[1])
+    brief = json.loads((workspace / "brief.json").read_text())
+
+    doc_path = workspace / "fortress_gate.json"
+    if not doc_path.is_file():
+        print("no staged fortress_gate.json", file=sys.stderr)
+        return 1
+    contract = worldc.sim_contract(worldc.load_entity(doc_path))
+    contract_sha = hashlib.sha256(recipe_mod.canonicalize(contract)).hexdigest()
+
+    world = {
+        "world_ir": "0.1",
+        "world": "fortress",
+        "entities": {
+            "gate_main": {"doc": "fortress_gate.json"},
+            "gate_side": {"doc": "fortress_gate.json"},
+        },
+        "scenario": "battle.json",
+        "expect_navigation": brief["scenario"]["expect_navigation"],
+    }
+    (workspace / "world.json").write_text(json.dumps(world, indent=2) + "\n")
+
+    battle = {
+        "sim_replay": "0.1",
+        "seed": 0,
+        "ticks": 20,
+        "entities": {
+            "gate_main": {"contract": contract, "contract_sha256": contract_sha},
+            "gate_side": {"contract": contract, "contract_sha256": contract_sha},
+        },
+        "initial": {
+            "gate_main": {"health": 100, "locked": True},
+            "gate_side": {"health": 100, "locked": True},
+        },
+        "events": [
+            [0, "gate_side", "open", None],
+            [1, "gate_main", "unlock", None],
+            [2, "gate_main", "open", None],
+            [5, "gate_main", "attack", 40],
+            [8, "gate_main", "attack", 40],
+            [11, "gate_main", "attack", 40],
+        ],
+    }
+    (workspace / "battle.json").write_text(json.dumps(battle, indent=2) + "\n")
+    (workspace / "metrics.json").write_text(json.dumps({"attempts": 1}) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/brief-to-battle/bench.py
+++ b/benchmarks/brief-to-battle/bench.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""brief-to-battle — the world-level half of the frozen benchmark (M4).
+
+brief-to-asset proves an agent can make things. brief-to-battle proves it
+can make things WORK: entities that compile with proof, a scenario that runs
+deterministically, and outcomes that match the brief.
+
+An agent receives a workspace dir containing brief.json and the available
+World IR entity documents. It answers with:
+
+  world.json    a World IR world document (entities + scenario reference)
+  battle.json   the scenario replay (sim_replay v0.1, contracts inline)
+
+The harness then scores, from artifacts and kernels — never from the agent's
+own claims:
+
+  validity      the world document validates and its entities compile
+  semantics     the world proof's own checks all pass (parts, hierarchy,
+                collision, payload)
+  gameplay      the deterministic run's navigation outcomes equal the
+                brief's expect_navigation
+  determinism   the same replay run twice yields the same final state hash
+  efficiency    wall time and attempts
+
+Usage:
+  python benchmarks/brief-to-battle/bench.py --agent "python3 .../agents/scripted_world.py"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BENCH = Path(__file__).resolve().parent
+sys.path.insert(0, str(REPO / "tools" / "worldc"))
+sys.path.insert(0, str(REPO / "tools" / "sim"))
+sys.path.insert(0, str(REPO / "tools" / "bforge"))
+
+import kernel  # noqa: E402
+import worldc  # noqa: E402
+from bforge.client import Forge  # noqa: E402
+
+DIMENSIONS = ("validity", "semantics", "gameplay", "determinism")
+
+
+def score_brief(brief: dict, agent_cmd: str, work_root: Path) -> dict:
+    workspace = work_root / brief["id"]
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "brief.json").write_text(json.dumps(brief, indent=2) + "\n")
+    # the brief's available entity docs are staged into the workspace
+    for _name, rel in brief.get("available_entities", {}).items():
+        src = REPO / rel
+        if src.is_file():
+            (workspace / src.name).write_bytes(src.read_bytes())
+
+    started = time.time()
+    proc = subprocess.run(
+        [*agent_cmd.split(), str(workspace)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    agent_seconds = round(time.time() - started, 3)
+
+    result: dict = {
+        "id": brief["id"],
+        "category": brief["category"],
+        "agent_seconds": agent_seconds,
+        "agent_exit": proc.returncode,
+        "attempts": 1,
+        "dimensions": {},
+    }
+    metrics_path = workspace / "metrics.json"
+    if metrics_path.is_file():
+        result["attempts"] = int(
+            json.loads(metrics_path.read_text()).get("attempts", 1)
+        )
+
+    world_path = workspace / "world.json"
+    battle_path = workspace / "battle.json"
+    if proc.returncode != 0 or not world_path.is_file() or not battle_path.is_file():
+        result["dimensions"] = {
+            d: {"pass": False, "detail": "agent produced no world/scenario"}
+            for d in DIMENSIONS
+        }
+        result["pass"] = False
+        return result
+
+    # ---- validity: world validates and compiles end to end
+    json.loads(world_path.read_text())  # surface malformed JSON before validating
+    try:
+        worldc.load_world(world_path)
+        validity = True
+        detail = "world document validates"
+    except worldc.WorldIRError as exc:
+        validity = False
+        detail = str(exc)[:200]
+    result["dimensions"]["validity"] = {"pass": validity, "detail": detail}
+    if not validity:
+        for d in ("semantics", "gameplay", "determinism"):
+            result["dimensions"][d] = {"pass": False, "detail": "world invalid"}
+        result["pass"] = False
+        return result
+
+    # ---- semantics: the world proof's own contract checks
+    try:
+        proof = worldc.compile_world(
+            world_path, cache_dir=workspace / "cache", forge_factory=Forge
+        )
+        result["world_cache_key"] = proof["world_cache_key"]
+        result["world_proof"] = str(Path(proof["cache"]["dir"]) / "world_proof.json")
+        semantics = proof["status"] == "pass"
+        detail = (
+            "all world-proof checks pass"
+            if semantics
+            else str([c for c in proof["checks"] if not c["ok"]])[:200]
+        )
+    except (worldc.WorldIRError, Exception) as exc:  # noqa: BLE001
+        proof = None
+        semantics = False
+        detail = f"{type(exc).__name__}: {exc}"[:200]
+    result["dimensions"]["semantics"] = {"pass": semantics, "detail": detail}
+    if proof is None:
+        for d in ("gameplay", "determinism"):
+            result["dimensions"][d] = {
+                "pass": False,
+                "detail": "world failed to compile",
+            }
+        result["pass"] = False
+        return result
+
+    # ---- gameplay: deterministic outcomes match the brief
+    try:
+        run = kernel.run_replay(battle_path)
+        expected = brief.get("scenario", {}).get("expect_navigation", {})
+        actual = run["navigation"]
+        mismatches = [
+            f"{name}: expected {want}, got {actual.get(name)}"
+            for name, want in expected.items()
+            if actual.get(name) is not want
+        ]
+        result["dimensions"]["gameplay"] = {
+            "pass": not mismatches,
+            "detail": "; ".join(mismatches) or "outcomes match the brief",
+        }
+    except kernel.SimError as exc:
+        run = None
+        result["dimensions"]["gameplay"] = {
+            "pass": False,
+            "detail": f"{exc.code}: {exc}"[:200],
+        }
+
+    # ---- determinism: same replay, same final hash, twice
+    if run is not None:
+        try:
+            again = kernel.run_replay(battle_path)
+            same = again["state_hash"] == run["state_hash"]
+            result["dimensions"]["determinism"] = {
+                "pass": same,
+                "detail": "identical final state hash"
+                if same
+                else "hash drift between runs",
+            }
+            result["state_hash"] = run["state_hash"]
+        except kernel.SimError as exc:
+            result["dimensions"]["determinism"] = {
+                "pass": False,
+                "detail": str(exc)[:200],
+            }
+    else:
+        result["dimensions"]["determinism"] = {"pass": False, "detail": "no run"}
+
+    result["pass"] = all(result["dimensions"][d]["pass"] for d in DIMENSIONS)
+    return result
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[2])
+    parser.add_argument("--agent", required=True)
+    parser.add_argument("--brief", default="")
+    parser.add_argument("--out", default="")
+    parser.add_argument("--work-root", default="")
+    args = parser.parse_args(argv)
+
+    briefs = sorted(BENCH.glob("briefs/*.json"))
+    if args.brief:
+        briefs = [b for b in briefs if b.stem == args.brief]
+    if not briefs:
+        print("no briefs matched", file=sys.stderr)
+        return 2
+
+    work_root = (
+        Path(args.work_root)
+        if args.work_root
+        else Path(
+            tempfile.mkdtemp(
+                prefix="battlebench_",
+                dir=BENCH / "out" if (BENCH / "out").is_dir() else None,
+            )
+        )
+    )
+    work_root.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for brief_path in briefs:
+        brief = json.loads(brief_path.read_text())
+        print(f"[brief] {brief['id']}: {brief['text']}")
+        results.append(score_brief(brief, args.agent, work_root))
+        print(
+            f"  -> {'PASS' if results[-1]['pass'] else 'FAIL'} ({results[-1]['agent_seconds']}s)"
+        )
+
+    passed = sum(1 for r in results if r["pass"])
+    scorecard = {
+        "benchmark": "brief-to-battle/v0.1",
+        "agent": args.agent,
+        "briefs": len(results),
+        "passed": passed,
+        "pass_rate": round(passed / len(results), 4),
+        "results": results,
+    }
+    out = Path(args.out) if args.out else work_root / "scorecard.json"
+    out.write_text(json.dumps(scorecard, indent=2) + "\n", encoding="utf-8")
+
+    agent_label = args.agent.replace(str(REPO) + "/", "").replace(str(REPO), ".")
+    lines = [
+        "# brief-to-battle scorecard",
+        "",
+        f"agent: `{agent_label}`",
+        "",
+        f"verdict: **{passed}/{len(results)} briefs passed**",
+        "",
+        "| brief | validity | semantics | gameplay | determinism |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for r in results:
+        marks = ["✓" if r["dimensions"][d]["pass"] else "✗" for d in DIMENSIONS]
+        lines.append(f"| {r['id']} | {' | '.join(marks)} |")
+    lines += [
+        "",
+        "The world is compiled with proof (entity proofs + scenario binding),",
+        "the scenario runs deterministically, and outcomes are scored against",
+        "the brief's expected navigation — never against the agent's claims.",
+        "",
+        "Rerun: `just battlebench` (reference agent). Times, paths, and hashes",
+        "live in scorecard.json (machine-dependent); this file is the diffed",
+        "public number.",
+        "",
+    ]
+    (BENCH / "SUMMARY.md").write_text("\n".join(lines), encoding="utf-8")
+    print(f"[score] {passed}/{len(results)} briefs passed -> {out}")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/brief-to-battle/briefs/fortress_battle.json
+++ b/benchmarks/brief-to-battle/briefs/fortress_battle.json
@@ -1,0 +1,21 @@
+{
+  "id": "fortress_battle",
+  "category": "battle",
+  "text": "a fortress with two gates; breach the main gate while the side gate holds — and prove it deterministically",
+  "available_entities": {
+    "fortress_gate": "tools/worldc/examples/fortress_gate.json"
+  },
+  "scenario": {
+    "entities": {
+      "gate_main": "fortress_gate",
+      "gate_side": "fortress_gate"
+    },
+    "expect_navigation": {
+      "gate_main": false,
+      "gate_side": true
+    }
+  },
+  "requirements": {
+    "world_ir": "0.1"
+  }
+}

--- a/benchmarks/brief-to-battle/tests/test_battlebench.py
+++ b/benchmarks/brief-to-battle/tests/test_battlebench.py
@@ -1,0 +1,41 @@
+"""brief-to-battle static checks (no Blender required)."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+BENCH = Path(__file__).resolve().parents[1]
+REPO = BENCH.parents[1]
+
+
+class FrozenSet(unittest.TestCase):
+    def test_brief_is_well_formed(self):
+        briefs = sorted(BENCH.glob("briefs/*.json"))
+        self.assertGreaterEqual(len(briefs), 1, "at least the fortress battle")
+        for path in briefs:
+            with self.subTest(brief=path.name):
+                brief = json.loads(path.read_text())
+                self.assertEqual(brief["id"], path.stem)
+                self.assertTrue(brief["text"])
+                self.assertIn("expect_navigation", brief.get("scenario", {}))
+                for _name, rel in brief.get("available_entities", {}).items():
+                    self.assertTrue(
+                        (REPO / rel).is_file(), f"available entity doc exists: {rel}"
+                    )
+
+    def test_summary_is_committed_and_current_format(self):
+        summary = (BENCH / "SUMMARY.md").read_text()
+        self.assertIn("verdict:", summary)
+        for path in BENCH.glob("briefs/*.json"):
+            self.assertIn(f"| {path.stem} |", summary)
+
+    def test_reference_agent_produces_required_outputs(self):
+        agent = (BENCH / "agents" / "scripted_world.py").read_text()
+        for required in ("world.json", "battle.json", "metrics.json", "sim_contract"):
+            self.assertIn(required, agent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/justfile
+++ b/justfile
@@ -262,6 +262,11 @@ sim-parity:
 briefbench:
     uv run --project tools python benchmarks/brief-to-asset/bench.py --agent "python3 benchmarks/brief-to-asset/agents/scripted_recipe.py"
 
+# The world-level benchmark (ADR 0018 M4): reference agent against the frozen
+# battle brief, SUMMARY.md regenerated (CI diffs it).
+battlebench:
+    uv run --project tools python benchmarks/brief-to-battle/bench.py --agent "python3 benchmarks/brief-to-battle/agents/scripted_world.py"
+
 # Compile the fortress world + wasm kernel, write the viewer config, serve
 # the repo at :8077 — open http://localhost:8077/tools/sim-viewer/
 sim-viewer:


### PR DESCRIPTION
## What this does

The world-level half of the frozen benchmark (ADR 0018 M4) — `benchmarks/brief-to-battle`.

brief-to-asset proves an agent can *make* things. brief-to-battle proves it can make things *work*: a frozen battle brief is answered with a World IR world document plus a scenario replay, and the harness scores from artifacts and kernels only:

| dimension | measured by |
| --- | --- |
| **validity** | the world document validates and its entities compile |
| **semantics** | the world proof's own contract checks all pass (parts, hierarchy, collision, payload) |
| **gameplay** | the deterministic run's navigation outcomes equal the brief's `expect_navigation` |
| **determinism** | the same replay run twice yields the same final state hash |
| **efficiency** | wall time, attempts |

The frozen brief is the fortress battle: *"breach the main gate while the side gate holds."* The scripted reference agent holds the **1/1 baseline** — world proof, scenario replay, and outcomes all green — regenerated and diffed in the hosted bench job; static checks in the python job.

The agent contract is the same one line as the asset half: *receive a workspace, write `world.json` + `battle.json`.*

## Acceptance

- Reference agent end-to-end: world compiles with proof, replay runs, outcomes match, hash stable
- Static checks + ruff + claims gate + workflow validation: green

## Next

More battle briefs (defense holds, escort arrives, timer expires), then real model runs against both benchmark halves as public scorecards.
