### PR TITLE
briefbench: the first real model scoreboard (Claude Code 3/6)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -191,7 +191,7 @@ jobs:
       - name: brief-to-asset benchmark (reference agent)
         env:
           BLENDER_BIN: /opt/blender/blender
-        run: uv run --project tools python benchmarks/brief-to-asset/bench.py --agent "python3 benchmarks/brief-to-asset/agents/scripted_recipe.py"
+        run: uv run --project tools python benchmarks/brief-to-asset/bench.py --summary --agent "python3 benchmarks/brief-to-asset/agents/scripted_recipe.py"
 
       - name: the committed scorecard matches a fresh run
         run: git diff --exit-code benchmarks/brief-to-asset/SUMMARY.md

--- a/benchmarks/brief-to-asset/SCOREBOARD-2026-08-06-claude-code.json
+++ b/benchmarks/brief-to-asset/SCOREBOARD-2026-08-06-claude-code.json
@@ -1,0 +1,171 @@
+{
+  "benchmark": "brief-to-asset/v0.1",
+  "agent": "uv run --project tools python benchmarks/brief-to-asset/agents/claude_cli.py",
+  "briefs": 6,
+  "passed": 3,
+  "pass_rate": 0.5,
+  "results": [
+    {
+      "id": "barrel",
+      "category": "prop",
+      "agent_seconds": 65.161,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": true,
+          "detail": "1 meshes, 2 materials"
+        },
+        "semantics": {
+          "pass": true,
+          "detail": "all required structure present"
+        },
+        "budget": {
+          "pass": true,
+          "detail": "within budgets"
+        },
+        "determinism": {
+          "pass": true,
+          "detail": "byte-identical rebuild"
+        }
+      },
+      "agent_exit": 0,
+      "recipe_hash": "67bf77c0eb8eb1b800c3bf289d7a13130f60f2eab147d8fb75a2a09a07fa20e8",
+      "proof": "/home/kwebb/sf-battle/benchmarks/brief-to-asset/runs/claude-code-2026-08-06/barrel/cache/objects/23e2b087832a0111419848fbf024899a0e13cf7c5474889418e9c640429b4f9b/proof.json",
+      "pass": true
+    },
+    {
+      "id": "camp",
+      "category": "environment",
+      "agent_seconds": 21.032,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: ForgeError: no object named 'camp'. In the scene: ['camp_banner', 'camp_barrel_a', 'camp_crate_a', 'camp_embers', 'camp_fire_logs', 'camp_fire_stones', 'camp_ground', 'camp_"
+        },
+        "semantics": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: ForgeError: no object named 'camp'. In the scene: ['camp_banner', 'camp_barrel_a', 'camp_crate_a', 'camp_embers', 'camp_fire_logs', 'camp_fire_stones', 'camp_ground', 'camp_"
+        },
+        "budget": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: ForgeError: no object named 'camp'. In the scene: ['camp_banner', 'camp_barrel_a', 'camp_crate_a', 'camp_embers', 'camp_fire_logs', 'camp_fire_stones', 'camp_ground', 'camp_"
+        },
+        "determinism": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: ForgeError: no object named 'camp'. In the scene: ['camp_banner', 'camp_barrel_a', 'camp_crate_a', 'camp_embers', 'camp_fire_logs', 'camp_fire_stones', 'camp_ground', 'camp_"
+        }
+      },
+      "agent_exit": 0,
+      "pass": false
+    },
+    {
+      "id": "crate",
+      "category": "prop",
+      "agent_seconds": 37.167,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": true,
+          "detail": "2 meshes, 1 materials"
+        },
+        "semantics": {
+          "pass": true,
+          "detail": "all required structure present"
+        },
+        "budget": {
+          "pass": true,
+          "detail": "within budgets"
+        },
+        "determinism": {
+          "pass": true,
+          "detail": "byte-identical rebuild"
+        }
+      },
+      "agent_exit": 0,
+      "recipe_hash": "5674f8d66198f56eeedb401d5269689702072ebcdc2055764604212418d492e5",
+      "proof": "/home/kwebb/sf-battle/benchmarks/brief-to-asset/runs/claude-code-2026-08-06/crate/cache/objects/5388db77b6f15b3ba9b4f36e0e91f32692f35dd8fb510f9289dfeb842a15ce05/proof.json",
+      "pass": true
+    },
+    {
+      "id": "gladius",
+      "category": "weapon",
+      "agent_seconds": 270.186,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: check.asset: 1 error(s) (proof: /home/kwebb/sf-battle/benchmarks/brief-to-asset/runs/claude-code-2026-08-06/gladius/cache/failures/20260806T061459-c5a3d0c73404/proof.json)"
+        },
+        "semantics": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: check.asset: 1 error(s) (proof: /home/kwebb/sf-battle/benchmarks/brief-to-asset/runs/claude-code-2026-08-06/gladius/cache/failures/20260806T061459-c5a3d0c73404/proof.json)"
+        },
+        "budget": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: check.asset: 1 error(s) (proof: /home/kwebb/sf-battle/benchmarks/brief-to-asset/runs/claude-code-2026-08-06/gladius/cache/failures/20260806T061459-c5a3d0c73404/proof.json)"
+        },
+        "determinism": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: check.asset: 1 error(s) (proof: /home/kwebb/sf-battle/benchmarks/brief-to-asset/runs/claude-code-2026-08-06/gladius/cache/failures/20260806T061459-c5a3d0c73404/proof.json)"
+        }
+      },
+      "agent_exit": 0,
+      "pass": false
+    },
+    {
+      "id": "warden",
+      "category": "character",
+      "agent_seconds": 257.648,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: ForgeError: char.outfit: parameter 'piece' must be one of ['cuirass', 'pteruges', 'greaves', 'bracers', 'helmet', 'shield', 'robe', 'hood'], got 'pauldron' (proof: /home/kwe"
+        },
+        "semantics": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: ForgeError: char.outfit: parameter 'piece' must be one of ['cuirass', 'pteruges', 'greaves', 'bracers', 'helmet', 'shield', 'robe', 'hood'], got 'pauldron' (proof: /home/kwe"
+        },
+        "budget": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: ForgeError: char.outfit: parameter 'piece' must be one of ['cuirass', 'pteruges', 'greaves', 'bracers', 'helmet', 'shield', 'robe', 'hood'], got 'pauldron' (proof: /home/kwe"
+        },
+        "determinism": {
+          "pass": false,
+          "detail": "recipe recipe.json failed: ForgeError: char.outfit: parameter 'piece' must be one of ['cuirass', 'pteruges', 'greaves', 'bracers', 'helmet', 'shield', 'robe', 'hood'], got 'pauldron' (proof: /home/kwe"
+        }
+      },
+      "agent_exit": 0,
+      "pass": false
+    },
+    {
+      "id": "wolf",
+      "category": "creature",
+      "agent_seconds": 95.519,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": true,
+          "detail": "1 meshes, 2 materials"
+        },
+        "semantics": {
+          "pass": true,
+          "detail": "all required structure present"
+        },
+        "budget": {
+          "pass": true,
+          "detail": "within budgets"
+        },
+        "determinism": {
+          "pass": true,
+          "detail": "byte-identical rebuild"
+        }
+      },
+      "agent_exit": 0,
+      "recipe_hash": "17346eaac1161636da9ea1b9920db6d110e18fea42e524ad71aa985e6f9e2e2e",
+      "proof": "/home/kwebb/sf-battle/benchmarks/brief-to-asset/runs/claude-code-2026-08-06/wolf/cache/objects/33d72b97e812cd5acde81db86f08e8bed1acf52f674dd6ad4dffedce54143196/proof.json",
+      "pass": true
+    }
+  ]
+}

--- a/benchmarks/brief-to-asset/SCOREBOARD.md
+++ b/benchmarks/brief-to-asset/SCOREBOARD.md
@@ -1,0 +1,31 @@
+# brief-to-asset scoreboard
+
+Model agents against the frozen brief set, scored by the harness from the
+compiled artifacts. The reference agent holds the 6/6 control baseline
+(`SUMMARY.md`, regenerated and diffed in CI). Model runs are dated, published
+evidence — not CI-diffed, because model output is not deterministic.
+
+## 2026-08-06 — Claude Code (headless `claude -p`, full op schema in prompt)
+
+**3/6 briefs passed** (scorecard: `SCOREBOARD-2026-08-06-claude-code.json`)
+
+| brief | result | failure class |
+| --- | --- | --- |
+| barrel | ✓ | — |
+| crate | ✓ | — |
+| wolf | ✓ | — |
+| camp | ✗ | assumed object name (`camp` vs the `camp_*` objects env.camp actually makes) |
+| gladius | ✗ | budget gate (`check.asset` rejected the build) |
+| warden | ✗ | hallucinated enum value (`char.outfit piece="pauldron"` — not in the catalog) |
+
+Earlier prompt iterations, same model, same brief (crate), for the record:
+
+1. Summary-only catalog → schema hallucination (`shape` vs `mode`, missing `name`).
+2. Full op schema → a sophisticated recipe that missed the mandatory
+   `material.bake` finishing step; the export gate correctly rejected
+   procedural nodes glTF cannot express.
+3. Prompt hardened with the finishing contract → 3/6 on the full set.
+
+The gates, not the model, decide what passes. That is the point of the
+benchmark: API-mismatch and finishing-step failures are measured, named, and
+published instead of hidden behind a good-looking screenshot.

--- a/benchmarks/brief-to-asset/agents/claude_cli.py
+++ b/benchmarks/brief-to-asset/agents/claude_cli.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""brief-to-asset agent wrapper for the claude CLI (headless).
+
+Receives a workspace dir containing brief.json; prompts the model with the
+brief and the compact bforge op catalog; the model writes recipe.json. The
+harness scores the artifact, never the transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "tools" / "bforge"))
+from bforge import schema as schema_mod  # noqa: E402
+
+TIMEOUT_S = 600
+
+PROMPT = """You are an agent in the brief-to-asset benchmark. Produce a bforge Recipe IR
+document that builds the briefed asset. You may ONLY use the ops listed below,
+with exactly these parameter names. Output is judged by compiling the recipe
+and measuring the artifact — not by your prose.
+
+RECIPE FORMAT (write exactly this shape to {workspace}/recipe.json):
+
+{{
+  "recipe_version": 1,
+  "asset_id": "{asset_id}",
+  "brief": "<the brief text>",
+  "steps": [
+    {{ "op": "<op name>", "args": {{ "<param>": <value> }} }}
+  ],
+  "requirements": {requirements},
+  "export": {{ "engine": "godot", "category": "{category}" }}
+}}
+
+RULES:
+- Write the file {workspace}/recipe.json with valid JSON only. No prose file, no commentary file.
+- Use only ops and parameters from the catalog below, with EXACTLY the listed
+  parameter names and types. Every op that creates or modifies an object takes
+  `name` (the object's snake_case id); later ops reference that same name.
+- Sizes are metres. Use a seed (integer) on generative ops for determinism.
+- Stay inside the requirements (triangle/material budgets; collision if required).
+- session.reset is NOT needed, and do NOT add export.asset/check.asset steps —
+  the harness finishes, gates, and exports for you.
+- FINISHING CONTRACT: procedural materials (material.pbr, material.detail_normal,
+  noise/AO/bump node graphs) CANNOT be expressed by glTF. If you use them, you
+  MUST add a material.bake step for that object afterwards, or the export gate
+  will reject the asset. Simple preset materials need no bake.
+- Do not modify any other file.
+
+BRIEF: {brief_text}
+
+REQUIREMENTS: {requirements}
+
+CATEGORY: {category}
+
+AVAILABLE OPS (name — parameters with types and defaults — summary):
+{catalog}
+"""
+
+
+def main() -> int:
+    workspace = Path(sys.argv[1]).resolve()
+    brief = json.loads((workspace / "brief.json").read_text())
+    catalog = schema_mod.load_catalog()
+    catalog_text = "\n".join(
+        "- "
+        + op["name"]
+        + " — "
+        + ", ".join(
+            f"{k}: {v.get('type', 'any')}"
+            + ("=" + json.dumps(v["default"]) if "default" in v else " (required)")
+            for k, v in op["inputSchema"].get("properties", {}).items()
+        )
+        + " — "
+        + op["summary"][:80]
+        for op in catalog
+    )
+    req = {
+        k: v for k, v in brief.get("requirements", {}).items() if k != "payload_kb_max"
+    }
+    prompt = PROMPT.format(
+        workspace=workspace,
+        asset_id=brief["id"],
+        brief_text=brief["text"],
+        requirements=json.dumps(req),
+        category=brief["category"] if brief["category"] != "creature" else "character",
+        catalog=catalog_text,
+    )
+    proc = subprocess.run(
+        ["claude", "-p", prompt, "--allowedTools", "Write"],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_S,
+    )
+    (workspace / "agent_stdout.txt").write_text(proc.stdout[-8000:])
+    (workspace / "agent_stderr.txt").write_text(proc.stderr[-4000:])
+    (workspace / "metrics.json").write_text(
+        json.dumps({"attempts": 1, "agent_exit": proc.returncode}) + "\n"
+    )
+    if not (workspace / "recipe.json").is_file():
+        print("model produced no recipe.json", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/brief-to-asset/bench.py
+++ b/benchmarks/brief-to-asset/bench.py
@@ -177,6 +177,11 @@ def main(argv=None) -> int:
     )
     parser.add_argument("--brief", default="", help="run only this brief id")
     parser.add_argument("--out", default="", help="write the scorecard JSON here")
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="also rewrite SUMMARY.md (only the reference baseline is CI-diffed)",
+    )
     parser.add_argument("--work-root", default="", help="scratch directory for runs")
     args = parser.parse_args(argv)
 
@@ -225,6 +230,10 @@ def main(argv=None) -> int:
     # hashes — the public pass/fail table CI can diff (scorecard.json keeps
     # the machine-dependent detail). The agent string is normalized so a run
     # from any checkout path diffs clean.
+    if not args.summary:
+        print(f"[score] {passed}/{len(results)} briefs passed -> {out}")
+        return 0 if passed == len(results) else 1
+
     agent_label = args.agent.replace(str(REPO) + "/", "").replace(str(REPO), ".")
     lines = [
         "# brief-to-asset scorecard",

--- a/justfile
+++ b/justfile
@@ -260,7 +260,7 @@ sim-parity:
 # The frozen public benchmark (ADR 0018 M4): reference agent against the frozen
 # brief set, SUMMARY.md regenerated (CI diffs it).
 briefbench:
-    uv run --project tools python benchmarks/brief-to-asset/bench.py --agent "python3 benchmarks/brief-to-asset/agents/scripted_recipe.py"
+    uv run --project tools python benchmarks/brief-to-asset/bench.py --summary --agent "python3 benchmarks/brief-to-asset/agents/scripted_recipe.py"
 
 # The world-level benchmark (ADR 0018 M4): reference agent against the frozen
 # battle brief, SUMMARY.md regenerated (CI diffs it).


### PR DESCRIPTION
## What this does

The first real model scoreboard — the benchmark stops being self-referential.

A new `claude_cli.py` agent wrapper (full op schema + the finishing contract in the prompt) ran the frozen six-brief set headlessly through `claude -p`. The harness scored the compiled artifacts, and the result is published as dated evidence:

## 2026-08-06 — Claude Code: 3/6

| brief | result | failure class |
| --- | --- | --- |
| barrel | ✓ | — |
| crate | ✓ | — |
| wolf | ✓ | — |
| camp | ✗ | assumed object name (`camp` vs the `camp_*` objects `env.camp` actually makes) |
| gladius | ✗ | budget gate (`check.asset` rejected the build) |
| warden | ✗ | hallucinated enum value (`char.outfit piece="pauldron"` — not in the catalog) |

The earlier iterations are documented too, because they show the failure classes this benchmark exists to measure:

1. **Summary-only catalog** → schema hallucination (`shape` vs `mode`, missing `name`).
2. **Full op schema** → a sophisticated recipe (procedural PBR, corner braces, UV pass) that missed the mandatory `material.bake` step — the export gate correctly rejected nodes glTF cannot express.
3. **Prompt hardened with the finishing contract** → 3/6 on the full set.

The gates, not the model, decide what passes. Published: `SCOREBOARD.md` + `SCOREBOARD-2026-08-06-claude-code.json` (dated, not CI-diffed — model output is not deterministic).

Also: `bench.py` now writes `SUMMARY.md` only under `--summary` (wired for the reference baseline), so model runs can't pollute the CI-diffed public number.

## Acceptance

- Reference baseline still 6/6 (verified after the --summary change)
- Static checks, ruff, claims gate: green
