### PR TITLE
brief-to-battle: second frozen battle brief (hold_the_gate)

### DIFF
--- a/benchmarks/brief-to-battle/SCOREBOARD.md
+++ b/benchmarks/brief-to-battle/SCOREBOARD.md
@@ -1,7 +1,7 @@
 # brief-to-battle scoreboard
 
 Model agents against the frozen battle brief, scored from the compiled world
-and the deterministic run. The reference agent holds the 1/1 control baseline
+and the deterministic run. The reference agent holds the 2/2 control baseline
 (`SUMMARY.md`, CI-diffed). Model runs are dated evidence, not CI-diffed.
 
 ## 2026-08-06 — Claude Code (headless `claude -p`; contracts precomputed by the wrapper)

--- a/benchmarks/brief-to-battle/SUMMARY.md
+++ b/benchmarks/brief-to-battle/SUMMARY.md
@@ -2,11 +2,12 @@
 
 agent: `python3 benchmarks/brief-to-battle/agents/scripted_world.py`
 
-verdict: **1/1 briefs passed**
+verdict: **2/2 briefs passed**
 
 | brief | validity | semantics | gameplay | determinism |
 | --- | --- | --- | --- | --- |
 | fortress_battle | ✓ | ✓ | ✓ | ✓ |
+| hold_the_gate | ✓ | ✓ | ✓ | ✓ |
 
 The world is compiled with proof (entity proofs + scenario binding),
 the scenario runs deterministically, and outcomes are scored against

--- a/benchmarks/brief-to-battle/agents/scripted_world.py
+++ b/benchmarks/brief-to-battle/agents/scripted_world.py
@@ -20,38 +20,9 @@ sys.path.insert(0, str(REPO / "tools" / "bforge"))
 import worldc  # noqa: E402
 from bforge import recipe as recipe_mod  # noqa: E402
 
-
-def main() -> int:
-    workspace = Path(sys.argv[1])
-    brief = json.loads((workspace / "brief.json").read_text())
-
-    doc_path = workspace / "fortress_gate.json"
-    if not doc_path.is_file():
-        print("no staged fortress_gate.json", file=sys.stderr)
-        return 1
-    contract = worldc.sim_contract(worldc.load_entity(doc_path))
-    contract_sha = hashlib.sha256(recipe_mod.canonicalize(contract)).hexdigest()
-
-    world = {
-        "world_ir": "0.1",
+SCENARIOS = {
+    "fortress_battle": {
         "world": "fortress",
-        "entities": {
-            "gate_main": {"doc": "fortress_gate.json"},
-            "gate_side": {"doc": "fortress_gate.json"},
-        },
-        "scenario": "battle.json",
-        "expect_navigation": brief["scenario"]["expect_navigation"],
-    }
-    (workspace / "world.json").write_text(json.dumps(world, indent=2) + "\n")
-
-    battle = {
-        "sim_replay": "0.1",
-        "seed": 0,
-        "ticks": 20,
-        "entities": {
-            "gate_main": {"contract": contract, "contract_sha256": contract_sha},
-            "gate_side": {"contract": contract, "contract_sha256": contract_sha},
-        },
         "initial": {
             "gate_main": {"health": 100, "locked": True},
             "gate_side": {"health": 100, "locked": True},
@@ -64,6 +35,60 @@ def main() -> int:
             [8, "gate_main", "attack", 40],
             [11, "gate_main", "attack", 40],
         ],
+    },
+    "hold_the_gate": {
+        "world": "fortress",
+        "initial": {
+            "gate_main": {"health": 100, "locked": True},
+            "gate_side": {"health": 100, "locked": True},
+        },
+        "events": [
+            [2, "gate_main", "attack", 30],
+            [5, "gate_main", "attack", 30],
+            [8, "gate_main", "attack", 30],
+            [9, "gate_main", "repair", 50],
+            [10, "gate_side", "unlock", None],
+            [11, "gate_side", "open", None],
+        ],
+    },
+}
+
+
+def main() -> int:
+    workspace = Path(sys.argv[1])
+    brief = json.loads((workspace / "brief.json").read_text())
+    scenario = SCENARIOS.get(brief["id"])
+    if scenario is None:
+        print(f"no scripted answer for {brief['id']}", file=sys.stderr)
+        return 1
+
+    doc_path = workspace / "fortress_gate.json"
+    if not doc_path.is_file():
+        print("no staged fortress_gate.json", file=sys.stderr)
+        return 1
+    contract = worldc.sim_contract(worldc.load_entity(doc_path))
+    contract_sha = hashlib.sha256(recipe_mod.canonicalize(contract)).hexdigest()
+
+    names = sorted(brief["scenario"]["entities"])
+    world = {
+        "world_ir": "0.1",
+        "world": scenario["world"],
+        "entities": {name: {"doc": "fortress_gate.json"} for name in names},
+        "scenario": "battle.json",
+        "expect_navigation": brief["scenario"]["expect_navigation"],
+    }
+    (workspace / "world.json").write_text(json.dumps(world, indent=2) + "\n")
+
+    battle = {
+        "sim_replay": "0.1",
+        "seed": 0,
+        "ticks": 20,
+        "entities": {
+            name: {"contract": contract, "contract_sha256": contract_sha}
+            for name in names
+        },
+        "initial": scenario["initial"],
+        "events": scenario["events"],
     }
     (workspace / "battle.json").write_text(json.dumps(battle, indent=2) + "\n")
     (workspace / "metrics.json").write_text(json.dumps({"attempts": 1}) + "\n")

--- a/benchmarks/brief-to-battle/briefs/hold_the_gate.json
+++ b/benchmarks/brief-to-battle/briefs/hold_the_gate.json
@@ -1,0 +1,21 @@
+{
+  "id": "hold_the_gate",
+  "category": "battle",
+  "text": "hold the main gate for 20 ticks under attack — repair is allowed — while the side gate opens for the escort",
+  "available_entities": {
+    "fortress_gate": "tools/worldc/examples/fortress_gate.json"
+  },
+  "scenario": {
+    "entities": {
+      "gate_main": "fortress_gate",
+      "gate_side": "fortress_gate"
+    },
+    "expect_navigation": {
+      "gate_main": true,
+      "gate_side": false
+    }
+  },
+  "requirements": {
+    "world_ir": "0.1"
+  }
+}


### PR DESCRIPTION
## What this does

Grows the battle corpus to two frozen briefs and inverts the shape:

- **fortress_battle** (existing): breach the main gate, side holds.
- **hold_the_gate** (new): *defense* — hold the main gate for 20 ticks under attack (repair allowed) while the side gate opens for the escort. Expectations inverted: main must still block, side must be open.

The scripted reference agent now maps brief ids to scenarios; the baseline regenerates at **2/2** in public CI. The harness needed zero changes — expectations were generic from the start, which is exactly what a benchmark corpus is for.

## Acceptance

- Reference agent: 2/2 (validity, semantics, gameplay, determinism on both briefs)
- Static checks + ruff + claims gate: green