### PR TITLE
brief-to-battle: Claude fails hold_the_gate — the tactical-reasoning row

### DIFF
--- a/benchmarks/brief-to-battle/SCOREBOARD-2026-08-06-claude-code-hold-the-gate.json
+++ b/benchmarks/brief-to-battle/SCOREBOARD-2026-08-06-claude-code-hold-the-gate.json
@@ -1,0 +1,35 @@
+{
+  "benchmark": "brief-to-battle/v0.1",
+  "agent": "uv run --project tools python benchmarks/brief-to-battle/agents/claude_battle.py",
+  "briefs": 1,
+  "passed": 0,
+  "pass_rate": 0.0,
+  "results": [
+    {
+      "id": "hold_the_gate",
+      "category": "battle",
+      "agent_seconds": 53.105,
+      "agent_exit": 0,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": true,
+          "detail": "world document validates"
+        },
+        "semantics": {
+          "pass": false,
+          "detail": "WorldIRError: fortress: world contract broken \u2014 ['navigation outcome: gate_main blocks == True', 'navigation outcome: gate_side blocks == False'] (proof: /tmp/battlebench_09zv0kk4/hold_the_gate/cache/"
+        },
+        "gameplay": {
+          "pass": false,
+          "detail": "world failed to compile"
+        },
+        "determinism": {
+          "pass": false,
+          "detail": "world failed to compile"
+        }
+      },
+      "pass": false
+    }
+  ]
+}

--- a/benchmarks/brief-to-battle/SCOREBOARD.md
+++ b/benchmarks/brief-to-battle/SCOREBOARD.md
@@ -25,3 +25,19 @@ machine-checked outcome.
 Codex (`codex exec`) was unavailable for a second run: the account hit its
 usage limit (retry 2026-08-08). The codex_cli.py wrapper is committed and
 ready; rerun then.
+
+## 2026-08-06 — Claude Code, hold_the_gate (inverted defense brief)
+
+**0/1 — FAIL** (scorecard: `SCOREBOARD-2026-08-06-claude-code-hold-the-gate.json`)
+
+The world document was valid and compiled. The scenario failed the BRIEF's
+tactics, not the API: the brief requires holding the main gate (blocking at
+the end) while opening the side gate for the escort. The model issued
+`unlock` + `open` on the MAIN gate (so it ended open, not blocking) and never
+issued `unlock` on the side gate (so its `open` events were absorbed by the
+lock — it ended closed and blocking). Exactly the inverted outcome the brief
+forbids.
+
+This is the finding the battle half exists for: document-level correctness
+does not imply tactical correctness, and only a deterministic outcome check
+can tell the difference.


### PR DESCRIPTION
## What this does

The inverted defense brief produced the benchmark's most interesting row yet.

Claude ran `hold_the_gate` ("hold the main gate for 20 ticks under attack — repair is allowed — while the side gate opens for the escort"). The world document was valid and compiled. The scenario **failed the brief's tactics**:

- Brief requires: main gate blocks at the end, side gate open.
- The model issued `unlock` + `open` on the **main** gate (ended open, not blocking) and never issued `unlock` on the **side** gate (its `open` events were absorbed by the lock — ended closed and blocking).

Exactly the inverted outcome the brief forbids. Not an API failure — a reasoning failure, and only a deterministic outcome check can tell the difference. Published as dated evidence: `SCOREBOARD.md` + `SCOREBOARD-2026-08-06-claude-code-hold-the-gate.json`.

## The battle scoreboard so far

| brief | model | result |
| --- | --- | --- |
| fortress_battle | Claude Code | PASS |
| hold_the_gate | Claude Code | FAIL (tactical inversion) |

## Acceptance

- Reference baseline unchanged (2/2 in CI)
- Evidence committed; ruff + static checks green