### PR TITLE
brief-to-battle: retract the hold_the_gate failures, generalize the harness

### DIFF
--- a/benchmarks/brief-to-battle/SCOREBOARD-2026-08-06-claude-code-hold-the-gate-corrected.json
+++ b/benchmarks/brief-to-battle/SCOREBOARD-2026-08-06-claude-code-hold-the-gate-corrected.json
@@ -1,0 +1,38 @@
+{
+  "benchmark": "brief-to-battle/v0.1",
+  "agent": "uv run --project tools python benchmarks/brief-to-battle/agents/claude_battle.py",
+  "briefs": 1,
+  "passed": 1,
+  "pass_rate": 1.0,
+  "results": [
+    {
+      "id": "hold_the_gate",
+      "category": "battle",
+      "agent_seconds": 66.469,
+      "agent_exit": 0,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": true,
+          "detail": "world document validates"
+        },
+        "semantics": {
+          "pass": true,
+          "detail": "all world-proof checks pass"
+        },
+        "gameplay": {
+          "pass": true,
+          "detail": "outcomes match the brief"
+        },
+        "determinism": {
+          "pass": true,
+          "detail": "identical final state hash"
+        }
+      },
+      "world_cache_key": "37c0ab742489975cbf000b8914b4714849844e5c017b63e872d884ab012617fd",
+      "world_proof": "/tmp/hg_fix/hold_the_gate/cache/world-cache/37c0ab742489975cbf000b8914b4714849844e5c017b63e872d884ab012617fd/world_proof.json",
+      "state_hash": "f345cf1a51f49146bc33021aa816881eea126b2247e2c92fb4887e76dbf26373",
+      "pass": true
+    }
+  ]
+}

--- a/benchmarks/brief-to-battle/SCOREBOARD-2026-08-06-claude-code-three-gates.json
+++ b/benchmarks/brief-to-battle/SCOREBOARD-2026-08-06-claude-code-three-gates.json
@@ -1,0 +1,38 @@
+{
+  "benchmark": "brief-to-battle/v0.1",
+  "agent": "uv run --project tools python benchmarks/brief-to-battle/agents/claude_battle.py",
+  "briefs": 1,
+  "passed": 1,
+  "pass_rate": 1.0,
+  "results": [
+    {
+      "id": "three_gates",
+      "category": "battle",
+      "agent_seconds": 106.956,
+      "agent_exit": 0,
+      "attempts": 1,
+      "dimensions": {
+        "validity": {
+          "pass": true,
+          "detail": "world document validates"
+        },
+        "semantics": {
+          "pass": true,
+          "detail": "all world-proof checks pass"
+        },
+        "gameplay": {
+          "pass": true,
+          "detail": "outcomes match the brief"
+        },
+        "determinism": {
+          "pass": true,
+          "detail": "identical final state hash"
+        }
+      },
+      "world_cache_key": "84db82076224e802e75a8cdf18217ed6e0b29420a1d73cbbc52a5cbe5afecf5b",
+      "world_proof": "/tmp/tg/three_gates/cache/world-cache/84db82076224e802e75a8cdf18217ed6e0b29420a1d73cbbc52a5cbe5afecf5b/world_proof.json",
+      "state_hash": "7cb185280d7090f7c9b60a58201ff60ed781a5c90586c9bfda36550a54409cb9",
+      "pass": true
+    }
+  ]
+}

--- a/benchmarks/brief-to-battle/SCOREBOARD.md
+++ b/benchmarks/brief-to-battle/SCOREBOARD.md
@@ -105,3 +105,23 @@ It locks the defended gate so stray `open` events are absorbed, opens the
 escort route, and sustains the repair cadence the brief permits for the full
 20 ticks. Main gate ends intact and blocking; side gate ends open. That is the
 brief, exactly.
+
+## 2026-08-06 — Claude Code, three_gates (first three-entity brief)
+
+**1/1 — PASS** (scorecard:
+`SCOREBOARD-2026-08-06-claude-code-three-gates.json`)
+
+First attempt, 107.0s, 4/4. The old wrapper could not have run this brief at
+all — it rejected any scenario that was not exactly two entities, which
+silently capped the corpus at gate pairs. The model's scenario:
+
+    [1, gate_sally, unlock]   [2, gate_sally, open]
+    [6, gate_main, attack 40] [8, gate_postern, attack 25]
+    [10, gate_main, repair 40][12, gate_postern, repair 25]
+    [18, gate_main, lock]     [18, gate_postern, lock]
+
+Unlock precedes open on the sally port (the reverse order is absorbed by the
+lock), the two gates that must hold take and repair the siege, and both are
+re-locked before the horns. Two holds and one open, with distractor pressure
+from a third entity — a materially different shape from the 1-hold/1-open
+pairs, and the first evidence that the loop is not hardcoded to two gates.

--- a/benchmarks/brief-to-battle/SCOREBOARD.md
+++ b/benchmarks/brief-to-battle/SCOREBOARD.md
@@ -26,7 +26,43 @@ Codex (`codex exec`) was unavailable for a second run: the account hit its
 usage limit (retry 2026-08-08). The codex_cli.py wrapper is committed and
 ready; rerun then.
 
-## 2026-08-06 — Claude Code, hold_the_gate (inverted defense brief)
+## 2026-08-06 — RETRACTION: both hold_the_gate failures below were our bug
+
+**The two `hold_the_gate` FAIL entries in this file are withdrawn.** They
+measured a defect in the harness, not in the model.
+
+`agents/claude_battle.py` ended its prompt with a hardcoded goal sentence:
+
+> Your scenario must end with: the main gate destroyed or open (not blocking),
+> the side gate intact and closed (blocking).
+
+That is the `fortress_battle` objective, and `hold_the_gate` is its exact
+inverse. The wrapper was instructing the model to open the gate the brief said
+to defend, and the harness then scored the model's obedience as a tactical
+reasoning failure. The "systematic, not variance" conclusion was really a
+constant: both runs matched the injected instruction, which is why they looked
+so consistent.
+
+With the goal sentence derived from each brief's `expect_navigation`
+(`goal_clause()`), the same brief and the same model **pass on the first
+attempt** (66.5s, scorecard
+`SCOREBOARD-2026-08-06-claude-code-hold-the-gate-corrected.json`): the model
+locks and closes the main gate at tick 0, unlocks and opens the side gate, and
+holds through a 12-per-tick attack/repair exchange for the full 20 ticks. The
+tactics were never the problem.
+
+`tests/test_battlebench.py::WrapperIsBriefNeutral` now fails if the prompt
+template states any outcome, or if a derived goal contradicts a brief. It fails
+against the old wrapper and passes against the fix.
+
+The lesson is the uncomfortable one for a project whose thesis is that AI
+output must be proven: **the harness needs the same adversarial scrutiny as the
+model.** A published failure that is actually your own misfiring instrument is
+worse than no benchmark, because it spends credibility to buy a false finding.
+The two entries below are kept, struck through, rather than deleted — retracted
+evidence should stay auditable.
+
+## ~~2026-08-06 — Claude Code, hold_the_gate (inverted defense brief)~~ RETRACTED
 
 **0/1 — FAIL** (scorecard: `SCOREBOARD-2026-08-06-claude-code-hold-the-gate.json`)
 
@@ -42,7 +78,7 @@ This is the finding the battle half exists for: document-level correctness
 does not imply tactical correctness, and only a deterministic outcome check
 can tell the difference.
 
-## 2026-08-06 — Claude Code, hold_the_gate, attempt 2 (variance check)
+## ~~2026-08-06 — Claude Code, hold_the_gate, attempt 2 (variance check)~~ RETRACTED
 
 **0/1 — FAIL, same systematic gap** (scorecard:
 `SCOREBOARD-2026-08-06-claude-code-hold-the-gate-attempt-2.json`)
@@ -53,3 +89,19 @@ unlocked and opened the MAIN gate at ticks 14–15. Two runs, two different
 paths, same inversion: the gate that must hold ends open, the gate that must
 open ends closed. A systematic reasoning gap on inverted/defense briefs, not
 luck.
+
+## 2026-08-06 — Claude Code, hold_the_gate, corrected harness
+
+**1/1 — PASS** (scorecard:
+`SCOREBOARD-2026-08-06-claude-code-hold-the-gate-corrected.json`)
+
+First attempt, 66.5s, all four dimensions green. The model's scenario:
+
+    [0, gate_main, lock]      [0, gate_side, open]
+    [0, gate_main, close]     [0, gate_side, unlock]
+    [2..20, gate_main, attack 12 / repair 12 alternating]
+
+It locks the defended gate so stray `open` events are absorbed, opens the
+escort route, and sustains the repair cadence the brief permits for the full
+20 ticks. Main gate ends intact and blocking; side gate ends open. That is the
+brief, exactly.

--- a/benchmarks/brief-to-battle/SUMMARY.md
+++ b/benchmarks/brief-to-battle/SUMMARY.md
@@ -2,12 +2,13 @@
 
 agent: `python3 benchmarks/brief-to-battle/agents/scripted_world.py`
 
-verdict: **2/2 briefs passed**
+verdict: **3/3 briefs passed**
 
 | brief | validity | semantics | gameplay | determinism |
 | --- | --- | --- | --- | --- |
 | fortress_battle | ✓ | ✓ | ✓ | ✓ |
 | hold_the_gate | ✓ | ✓ | ✓ | ✓ |
+| three_gates | ✓ | ✓ | ✓ | ✓ |
 
 The world is compiled with proof (entity proofs + scenario binding),
 the scenario runs deterministically, and outcomes are scored against

--- a/benchmarks/brief-to-battle/agents/claude_battle.py
+++ b/benchmarks/brief-to-battle/agents/claude_battle.py
@@ -39,8 +39,7 @@ PART 1 — write {workspace}/world.json in exactly this shape:
   "world_ir": "0.1",
   "world": "fortress",
   "entities": {{
-    "{entity_a}": {{ "doc": "{doc_file}" }},
-    "{entity_b}": {{ "doc": "{doc_file}" }}
+{world_entities}
   }},
   "scenario": "battle.json",
   "expect_navigation": {expect_navigation}
@@ -54,15 +53,13 @@ replay; T is an integer tick, verbs come from the affordance list below):
   "seed": 0,
   "ticks": 20,
   "entities": {{
-    "{entity_a}": {{ "contract": {contract_json}, "contract_sha256": "{contract_sha}" }},
-    "{entity_b}": {{ "contract": {contract_json}, "contract_sha256": "{contract_sha}" }}
+{replay_entities}
   }},
   "initial": {{
-    "{entity_a}": {{ "health": 100, "locked": true }},
-    "{entity_b}": {{ "health": 100, "locked": true }}
+{replay_initial}
   }},
   "events": [
-    [0, "{entity_b}", "open", null],
+    [T, "<entity>", "<verb>", <arg or null>],
     ...your scenario...
   ]
 }}
@@ -71,7 +68,7 @@ RULES:
 - Valid JSON only in both files. No commentary files. Do not modify any other file.
 - Copy the contract object and contract_sha256 EXACTLY as given (they are
   precomputed for you — do not alter a single byte).
-- {entity_a} is the MAIN gate, {entity_b} is the SIDE gate.
+- The entities in this scenario are: {entity_list}.
 - Available verbs: open, close, lock, unlock (no argument); attack, repair
   (nonnegative integer amount).
 - A locked gate ignores open/close. At health 0 a gate is destroyed and hangs
@@ -83,6 +80,13 @@ RULES:
 # derived from the brief's expect_navigation so the wrapper stays brief-neutral
 # — a hardcoded goal would tell the model the answer to one brief and the wrong
 # answer to every other one.
+def render_block(names, line) -> str:
+    """Comma-separated JSON object members, one per entity, indented for the
+    template. The scenario's entity count comes from the brief, not the
+    wrapper — a two-entity assumption would cap the corpus at gate pairs."""
+    return ",\n".join(f"    {line(n)}" for n in names)
+
+
 def goal_clause(name: str, blocks: bool) -> str:
     if blocks:
         return f"{name} intact and closed (blocking)"
@@ -98,24 +102,34 @@ def main() -> int:
 
     entities = brief.get("scenario", {}).get("entities", {})
     names = sorted(entities)
-    if len(names) != 2:
-        print("this wrapper expects exactly two scenario entities", file=sys.stderr)
+    if not names:
+        print("brief has no scenario entities", file=sys.stderr)
         return 1
 
     expect = brief["scenario"]["expect_navigation"]
-    main_name = names[0] if "main" in names[0] else names[1]
-    side_name = names[1] if "main" in names[0] else names[0]
-    goal_line = ", ".join(
-        goal_clause(n, expect[n]) for n in (main_name, side_name) if n in expect
-    )
+    missing = [n for n in names if n not in expect]
+    if missing:
+        print(f"brief lacks expect_navigation for {missing}", file=sys.stderr)
+        return 1
+    goal_line = ", ".join(goal_clause(n, expect[n]) for n in names)
 
     prompt = PROMPT.format(
         goal_line=goal_line,
         workspace=workspace,
         brief_text=brief["text"],
-        expect_navigation=json.dumps(brief["scenario"]["expect_navigation"]),
-        entity_a=names[0] if "main" in names[0] else names[1],
-        entity_b=names[1] if "main" in names[0] else names[0],
+        expect_navigation=json.dumps(expect),
+        entity_list=", ".join(names),
+        world_entities=render_block(
+            names, lambda n: f'"{n}": {{ "doc": "{doc_file}" }}'
+        ),
+        replay_entities=render_block(
+            names,
+            lambda n: f'"{n}": {{ "contract": {json.dumps(contract)}, '
+            f'"contract_sha256": "{contract_sha}" }}',
+        ),
+        replay_initial=render_block(
+            names, lambda n: f'"{n}": {{ "health": 100, "locked": true }}'
+        ),
         doc_file=doc_file,
         contract_json=json.dumps(contract),
         contract_sha=contract_sha,

--- a/benchmarks/brief-to-battle/agents/claude_battle.py
+++ b/benchmarks/brief-to-battle/agents/claude_battle.py
@@ -76,9 +76,17 @@ RULES:
   (nonnegative integer amount).
 - A locked gate ignores open/close. At health 0 a gate is destroyed and hangs
   open. openness integrates at 250 milli-units per tick toward its target.
-- Use ticks 0..20 only. Your scenario must end with: the main gate destroyed
-  or open (not blocking), the side gate intact and closed (blocking).
+- Use ticks 0..20 only. Your scenario must end with: {goal_line}
 """
+
+# A gate "blocks navigation" when it is intact and shut. The goal sentence is
+# derived from the brief's expect_navigation so the wrapper stays brief-neutral
+# — a hardcoded goal would tell the model the answer to one brief and the wrong
+# answer to every other one.
+def goal_clause(name: str, blocks: bool) -> str:
+    if blocks:
+        return f"{name} intact and closed (blocking)"
+    return f"{name} destroyed or open (not blocking)"
 
 
 def main() -> int:
@@ -94,7 +102,15 @@ def main() -> int:
         print("this wrapper expects exactly two scenario entities", file=sys.stderr)
         return 1
 
+    expect = brief["scenario"]["expect_navigation"]
+    main_name = names[0] if "main" in names[0] else names[1]
+    side_name = names[1] if "main" in names[0] else names[0]
+    goal_line = ", ".join(
+        goal_clause(n, expect[n]) for n in (main_name, side_name) if n in expect
+    )
+
     prompt = PROMPT.format(
+        goal_line=goal_line,
         workspace=workspace,
         brief_text=brief["text"],
         expect_navigation=json.dumps(brief["scenario"]["expect_navigation"]),

--- a/benchmarks/brief-to-battle/agents/scripted_world.py
+++ b/benchmarks/brief-to-battle/agents/scripted_world.py
@@ -51,6 +51,25 @@ SCENARIOS = {
             [11, "gate_side", "open", None],
         ],
     },
+    "three_gates": {
+        "world": "fortress",
+        "initial": {
+            "gate_main": {"health": 100, "locked": True},
+            "gate_postern": {"health": 100, "locked": True},
+            "gate_sally": {"health": 100, "locked": True},
+        },
+        "events": [
+            # the sally port opens for the cavalry: unlock first or the lock
+            # absorbs the open, then 3+ ticks to integrate past the 700 threshold
+            [0, "gate_sally", "unlock", None],
+            [1, "gate_sally", "open", None],
+            # the two that must hold stay locked and simply take the siege
+            [4, "gate_main", "attack", 40],
+            [7, "gate_postern", "attack", 40],
+            [10, "gate_main", "repair", 25],
+            [13, "gate_postern", "repair", 25],
+        ],
+    },
 }
 
 

--- a/benchmarks/brief-to-battle/briefs/three_gates.json
+++ b/benchmarks/brief-to-battle/briefs/three_gates.json
@@ -1,0 +1,23 @@
+{
+  "id": "three_gates",
+  "category": "battle",
+  "text": "three gates ring the keep; the sally port opens to let the cavalry out, and both the main gate and the postern must still be standing and shut when the horns sound at tick 20",
+  "available_entities": {
+    "fortress_gate": "tools/worldc/examples/fortress_gate.json"
+  },
+  "scenario": {
+    "entities": {
+      "gate_main": "fortress_gate",
+      "gate_postern": "fortress_gate",
+      "gate_sally": "fortress_gate"
+    },
+    "expect_navigation": {
+      "gate_main": true,
+      "gate_postern": true,
+      "gate_sally": false
+    }
+  },
+  "requirements": {
+    "world_ir": "0.1"
+  }
+}

--- a/benchmarks/brief-to-battle/tests/test_battlebench.py
+++ b/benchmarks/brief-to-battle/tests/test_battlebench.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import unittest
 from pathlib import Path
@@ -35,6 +36,50 @@ class FrozenSet(unittest.TestCase):
         agent = (BENCH / "agents" / "scripted_world.py").read_text()
         for required in ("world.json", "battle.json", "metrics.json", "sim_contract"):
             self.assertIn(required, agent)
+
+class WrapperIsBriefNeutral(unittest.TestCase):
+    """The wrapper must never tell the model the objective.
+
+    A wrapper that states one brief's goal states the INVERSE of another's, and
+    the harness then scores obedience as a reasoning failure. That is exactly
+    what happened to hold_the_gate in the 2026-08-06 runs: the prompt ended
+    with the fortress_battle objective for every brief.
+    """
+
+    def _wrapper(self):
+        spec = importlib.util.spec_from_file_location(
+            "claude_battle", BENCH / "agents" / "claude_battle.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_prompt_template_states_no_outcome(self):
+        prompt = self._wrapper().PROMPT
+        for leak in ("destroyed or open", "intact and closed"):
+            self.assertNotIn(
+                leak,
+                prompt,
+                "the goal sentence must come from the brief, not the template",
+            )
+
+    def test_goal_line_matches_every_brief(self):
+        wrapper = self._wrapper()
+        for path in sorted(BENCH.glob("briefs/*.json")):
+            brief = json.loads(path.read_text())
+            expect = brief["scenario"]["expect_navigation"]
+            with self.subTest(brief=path.stem):
+                for name, blocks in expect.items():
+                    clause = wrapper.goal_clause(name, blocks)
+                    other = wrapper.goal_clause(name, not blocks)
+                    self.assertIn("blocking", clause)
+                    self.assertNotEqual(clause, other)
+                    # blocking == intact and shut; not-blocking == open/destroyed
+                    self.assertEqual(
+                        "intact and closed" in clause,
+                        blocks,
+                        f"{path.stem}/{name}: goal contradicts expect_navigation",
+                    )
 
 
 if __name__ == "__main__":

--- a/benchmarks/brief-to-battle/tests/test_battlebench.py
+++ b/benchmarks/brief-to-battle/tests/test_battlebench.py
@@ -37,6 +37,29 @@ class FrozenSet(unittest.TestCase):
         for required in ("world.json", "battle.json", "metrics.json", "sim_contract"):
             self.assertIn(required, agent)
 
+    def test_every_brief_has_a_control_answer(self):
+        """A brief with no scripted answer has no control group: the reference
+        run fails on it, so any model score for that brief is unanchored."""
+        spec = importlib.util.spec_from_file_location(
+            "scripted_world", BENCH / "agents" / "scripted_world.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        for path in sorted(BENCH.glob("briefs/*.json")):
+            brief = json.loads(path.read_text())
+            with self.subTest(brief=path.stem):
+                scenario = module.SCENARIOS.get(path.stem)
+                self.assertIsNotNone(scenario, "brief needs a reference answer")
+                self.assertEqual(
+                    sorted(scenario["initial"]),
+                    sorted(brief["scenario"]["entities"]),
+                    "reference initial state must cover exactly the brief's entities",
+                )
+                known = set(brief["scenario"]["entities"])
+                for _tick, entity, _verb, _arg in scenario["events"]:
+                    self.assertIn(entity, known, "event names an unknown entity")
+
+
 class WrapperIsBriefNeutral(unittest.TestCase):
     """The wrapper must never tell the model the objective.
 


### PR DESCRIPTION
## Retraction

PRs #92 and #93 published a finding that Claude has a **"systematic reasoning gap on inverted/defense briefs."** That finding is withdrawn. It measured a defect in our harness.

`agents/claude_battle.py` ended its prompt with a hardcoded goal sentence:

> Your scenario must end with: the main gate destroyed or open (not blocking), the side gate intact and closed (blocking).

That is the `fortress_battle` objective. `hold_the_gate` is its exact inverse — and every brief got the same sentence. The harness was instructing the model to open the gate the brief said to defend, then scoring the model's compliance as a tactical failure.

The "not variance, systematic" conclusion was really "not variance, **constant**": both runs matched the injected instruction, which is precisely why they looked so consistent. The consistency we treated as evidence of a model gap was evidence of a harness bug.

## The corrected results

With the goal derived per-brief, the same brief and the same model **pass on the first attempt** — 66.5s, 4/4 dimensions:

    [0, gate_main, lock]      [0, gate_side, open]
    [0, gate_main, close]     [0, gate_side, unlock]
    [2..20, gate_main, attack 12 / repair 12 alternating]

It locks the defended gate so stray `open` events are absorbed, opens the escort route, and sustains the permitted repair cadence for all 20 ticks. The tactics were never the problem.

## The second, quieter limit

The wrapper also rejected any scenario that was not exactly two entities. The brief format already supported arbitrary entity maps, so this cap was invisible unless you read the wrapper — the corpus could only ever contain gate pairs.

Generalized to N, plus a brief that exercises it: **`three_gates`** — the sally port opens, the main gate and the postern must both be standing and shut at tick 20. Two holds and one open, with a third entity as distractor pressure. Claude Code passes it first attempt, 107.0s, 4/4. The reference baseline is now 3/3.

The neutral example event matters too: the old template showed the side gate opening, which is the answer to two briefs and the wrong answer to the third.

## Changes

- `goal_clause()` derives the goal from each brief's `expect_navigation`; the template states no outcome
- `render_block()` builds world/replay/initial sections from the brief's entity list
- `WrapperIsBriefNeutral` — fails if the template states any outcome, or if a derived goal contradicts a brief. Verified: fails against the old wrapper, passes against the fix
- `SCOREBOARD.md` — the two entries struck through and retracted in place rather than deleted; retracted evidence should stay auditable
- Corrected + three_gates scorecards committed

## Why this matters more than the bug

This project's thesis is that AI output is untrusted input that must be compiled, measured, and proven. The instrument doing the proving was not held to that standard, and it published a false finding about someone else's model as a result. A benchmark whose failures might be its own misfiring costs more credibility than it buys.

Both defects were the same species: an assumption baked into the wrapper that the brief format was already general enough to avoid. The follow-up worth doing is harness self-tests as a category, not a one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
