### PR TITLE
bforge: add auto-framed camera and AAA sprite forge

### DIFF
--- a/.claude/skills/bforge/SKILL.md
+++ b/.claude/skills/bforge/SKILL.md
@@ -5,7 +5,7 @@ description: Build game-ready 3D assets with Blender — props, modular kits, te
 
 # bforge — headless Blender asset forge
 
-`bforge` drives a persistent background Blender session through 127 typed
+`bforge` drives a persistent background Blender session through 138 typed
 operations. It never needs the Blender GUI, it is deterministic (same params +
 same seed → same mesh, forever), and every generated asset comes out chamfered,
 UV'd, materialled, pivoted and validated against the studio's ADR 0006 rules.

--- a/BOOTSTRAP_REPORT.md
+++ b/BOOTSTRAP_REPORT.md
@@ -1,6 +1,6 @@
 # Studio Foundation verification report
 
-Last updated: 2026-08-05
+Last updated: 2026-08-15
 
 This report separates verified repository behavior from work still in progress.
 It is not a product roadmap. The numbers it and the README state publicly are
@@ -33,8 +33,8 @@ consumer.
 | 3D render, Forward+ | First verified frame 2026-07-28, patch series 0023–0033, Tesla P40, headed Chrome/WebGPU, non-fallback adapter: the clustered renderer presents at 59 fps, 188 objects / 2,015,266 primitives, with 0 invalid `commandEncoder.finish` out of 10,842, 0 rejected `queue.submit`, and 0 bind-group failure classes. **Three WebGPU validation errors remain outside the presented-frame path** |
 | WebGPU shader coverage | 199 of 205 shader modules translate to valid WGSL offline with 0 GLSL compile failures, measured at the engine's real target env (Vulkan 1.1 / SPIR-V 1.3). None of the 6 remaining failures blocks Forward+: two are Forward Mobile's subpass tonemap, one is FSR's 16-bit variant (fallback translates), two are subgroup variants WebGPU does not select, one is an editor debug gizmo |
 | bforge determinism | `tools/bforge/bench.py` runs six briefs twice through the persistent daemon; all six pass the quality gate and the two GLB exports hash byte-identical (SHA-256 in `bench/report.json`). CI installs the pinned Blender 4.5.12 LTS, reruns the bench, and diffs the committed summary |
-| bforge surface | 137 whitelisted, typed operations across 21 namespaces; the committed `catalog.json` is checked against the live registry by full-schema comparison (not just op names), and `docs/bforge/OPS.md` is a generated file with a freshness gate |
-| bforge tests | 205 test methods in `tools/bforge/tests` — 166 in suites that boot a real Blender daemon, the rest pure schema/protocol/compiler units; the public CI bench job runs the full suite, not a subset |
+| bforge surface | 138 whitelisted, typed operations across 21 namespaces; the committed `catalog.json` is checked against the live registry by full-schema comparison (not just op names), and `docs/bforge/OPS.md` is a generated file with a freshness gate |
+| bforge tests | 217 test methods in `tools/bforge/tests` — 174 in suites that boot a real Blender daemon, the rest pure schema/protocol/compiler units; the public CI bench job runs the full suite, not a subset |
 | Browser evidence | The runtime probe instruments engine-owned adapter, device, and canvas-context requests, rejects fallback adapters and any WebGL request, and reports `inconclusive` rather than passing on incomplete evidence |
 | Prose/artifact consistency | `tools/ci/check_claims.py` derives op, namespace, test, and patch counts from the pinned artifacts and fails the hosted policy job when a documented surface disagrees; absolute-exclusivity claims ("only public …") are rejected outright |
 | Optional Nakama bridge | The bridge carries opaque consumer-owned payloads and remains optional |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Rust services behind.**
 The pillars:
 
 - **bforge** — a deterministic headless-Blender asset forge for AI agents:
-  137 whitelisted, typed operations with a quality gate that rejects output
-  below the bar, byte-identical regeneration, and 205 bforge tests, 166 in suites that start a real Blender daemon.
+  138 whitelisted, typed operations with a quality gate that rejects output
+  below the bar, byte-identical regeneration, and 217 bforge tests, 174 in suites that start a real Blender daemon.
 - **Verification** — GLB budget gates, pixel-diff captures, provenance, and
   render probes, so agent output is measured rather than trusted.
 - **Engine-neutral assets, standardized runtime** — the forge outputs portable
@@ -51,9 +51,9 @@ reproduction path. Other implementations may exist; this one you can audit.
 [Play it in your browser](https://lxsolutions.github.io/studio-foundation/).
 
 **🔨 A deterministic, quality-gated Blender forge for AI agents.**
-bforge is 137 typed, whitelisted operations driven into a persistent headless
+bforge is 138 typed, whitelisted operations driven into a persistent headless
 Blender daemon — LODs, collision, budgets, rigs, gaits, baking, validation —
-with byte-identical output run to run and 205 tests, 166 of them in suites that start a real Blender daemon.
+with byte-identical output run to run and 217 tests, 174 of them in suites that start a real Blender daemon.
 No GUI remote-control, no arbitrary code execution, no "same
 prompt, different mesh." We know of nothing else public that does all four of those.
 
@@ -107,7 +107,7 @@ open.
 Most Blender-AI integrations are remote controls for a GUI Blender: arbitrary
 code into a live session, a different mesh every run, nothing CI can test.
 **bforge inverts that** — a persistent headless Blender daemon driven through
-137 whitelisted, typed, deterministic operations. Same params + same seed →
+138 whitelisted, typed, deterministic operations. Same params + same seed →
 byte-identical GLB, forever. It is how this toolkit's games get their art, and
 it works identically on a laptop, in CI, and on a headless build box.
 
@@ -142,9 +142,10 @@ it works identically on a laptop, in CI, and on a headless build box.
   are verified by parsing the file, not by trusting the log.
 - **The agent can see and prove what it made.** Six-panel contact sheets
   (hero/front/side/top/wireframe/UV-checker), luminance and palette
-  measurement, silhouette scoring, impostor sprite sheets for distant LOD,
-  and concept-image → extruded-mesh with a silhouette-IoU fidelity score.
-- **205 tests, 166 of them in suites that start a real Blender daemon.** Schema,
+  measurement, silhouette scoring, silhouette-fitted and supersampled inventory
+  icons plus directional sprite sheets, impostor sprite sheets for distant
+  LOD, and concept-image → extruded-mesh with a silhouette-IoU fidelity score.
+- **217 tests, 174 of them in suites that start a real Blender daemon.** Schema,
   MCP protocol, and per-op integration — including byte-determinism asserted
   on exports.
 

--- a/docs/bforge/OPS.md
+++ b/docs/bforge/OPS.md
@@ -1,6 +1,6 @@
 # bforge op reference
 
-137 operations.
+138 operations.
 
 ## `arch.*`
 
@@ -1366,8 +1366,8 @@ Bake 'dirt in the crevices' or 'edge wear' without textures: a deterministic geo
 
 | parameter | type | default | description |
 | --- | --- | --- | --- |
-| `name` | string | None | Mesh object to paint — needs real surface relief; a flat quad has no curvature to find |
-| `color` | any | None | Colour blended into the crevices/edges: palette name, #rrggbb, or linear [r,g,b]. Dark browns read as grime, light greys as worn edges |
+| `name` | string | **required** | Mesh object to paint — needs real surface relief; a flat quad has no curvature to find |
+| `color` | any | **required** | Colour blended into the crevices/edges: palette name, #rrggbb, or linear [r,g,b]. Dark browns read as grime, light greys as worn edges |
 | `mode` | cavity \| edge | 'cavity' | cavity paints concave spots (dirt), edge paints convex ridges (wear) |
 | `strength` | number | 1.0 | Blend strength multiplier; the deepest cavity gets the full colour at 1.0 |
 | `invert` | boolean | False | Flip the result — paint everything EXCEPT the crevices/edges |
@@ -1379,8 +1379,8 @@ Set every loop of a mesh to one vertex colour. The base coat for the other paint
 
 | parameter | type | default | description |
 | --- | --- | --- | --- |
-| `name` | string | None | Mesh object to paint |
-| `color` | any | None | Colour: palette name, #rrggbb, or linear [r,g,b]. White leaves the material unchanged when the engine multiplies COLOR_0 in |
+| `name` | string | **required** | Mesh object to paint |
+| `color` | any | **required** | Colour: palette name, #rrggbb, or linear [r,g,b]. White leaves the material unchanged when the engine multiplies COLOR_0 in |
 | `layer` | string | 'color' | Colour attribute name; the glTF exporter ships the active one as COLOR_0 |
 
 ### `paint.height`
@@ -1389,9 +1389,9 @@ Paint a two-colour gradient along an axis — dust at the base of a wall, a snow
 
 | parameter | type | default | description |
 | --- | --- | --- | --- |
-| `name` | string | None | Mesh object to paint |
-| `low` | any | None | Colour at the bottom of the range: palette name, #rrggbb, or linear [r,g,b] |
-| `high` | any | None | Colour at the top of the range |
+| `name` | string | **required** | Mesh object to paint |
+| `low` | any | **required** | Colour at the bottom of the range: palette name, #rrggbb, or linear [r,g,b] |
+| `high` | any | **required** | Colour at the top of the range |
 | `axis` | x \| y \| z | 'z' | Axis the gradient runs along (z is up). Measured in the mesh's LOCAL space, like material.face_assign |
 | `min` | number | None | Axis value for 100% `low`; omit to use the mesh's own lower bound. Set both min and max to share one gradient across several objects |
 | `max` | number | None | Axis value for 100% `high`; omit to use the mesh's upper bound |
@@ -1404,9 +1404,9 @@ Blend two colours by deterministic fBm noise sampled at vertex positions — mot
 
 | parameter | type | default | description |
 | --- | --- | --- | --- |
-| `name` | string | None | Mesh object to paint |
-| `color_a` | any | None | Colour where the noise is low: palette name, #rrggbb, or linear [r,g,b] |
-| `color_b` | any | None | Colour where the noise is high |
+| `name` | string | **required** | Mesh object to paint |
+| `color_a` | any | **required** | Colour where the noise is low: palette name, #rrggbb, or linear [r,g,b] |
+| `color_b` | any | **required** | Colour where the noise is high |
 | `scale` | number | 2.0 | Noise frequency in 1/metres — higher gives smaller, busier patches |
 | `seed` | integer | 0 | Random seed; same seed gives the same pattern forever |
 | `octaves` | integer | 3 | Fractal detail levels; more octaves, finer grain |
@@ -1658,7 +1658,7 @@ Render from an explicit camera position and target. Auto-framing always fits the
 | parameter | type | default | description |
 | --- | --- | --- | --- |
 | `out` | string | 'shot.png' | PNG output path |
-| `position` | array | None | Camera position in metres |
+| `position` | array | **required** | Camera position in metres. This op exists to place the camera by hand; use render.cinematic or render.view when you want the framing fitted for you |
 | `target` | array | [0.0, 0.0, 0.0] | Point to look at |
 | `lens` | number | 50.0 | Focal length in mm — 24 is wide, 50 neutral, 105 compressed |
 | `resolution` | integer | 640 | Width in pixels |
@@ -1675,8 +1675,8 @@ A film-grade beauty render: physical sun and sky, global illumination, atmospher
 | parameter | type | default | description |
 | --- | --- | --- | --- |
 | `out` | string | 'hero.png' | PNG output path |
-| `position` | array | None | Camera position in metres |
-| `target` | array | [0.0, 0.0, 0.0] | Point to look at |
+| `position` | array | None | Camera position in metres. Omit it and a three-quarter beauty angle is fitted to the subject — set it for a close-up or a specific composition |
+| `target` | array | None | Point to look at. When both camera position and target are omitted, the camera aims at the subject's own centre so assets built off-origin are still framed. An explicit position with no target keeps the established world-origin target |
 | `lens` | number | 40.0 | Focal length in mm |
 | `resolution` | integer | 1280 | Width in pixels |
 | `aspect` | number | 2.39 | Width / height. 2.39 is anamorphic, 1.78 is 16:9 |
@@ -1721,6 +1721,40 @@ Bake an object into a billboard impostor sprite sheet: N orthographic views orbi
 | `normals` | boolean | False | Also write <stem>_normal.png: world-space normals packed into 0..1 colour, so the billboard can be lit instead of looking pasted on. Doubles render cost |
 | `samples` | integer | 16 | Cycles samples per frame. 16 is plenty at these sizes; raise only if the sprites look grainy |
 | `elevation` | number | 0.0 | Camera height above the horizon in degrees, the same for every view. Ground props read best at 0-15; high values waste frame area on the top face |
+
+### `render.sprite`
+
+Render a GAME ICON, not a screenshot: a silhouette-fitted three-quarter hero angle on a long lens, a warm-key/cool-fill/bright-kicker rig anchored to the camera so a whole set matches, a real contact shadow, supersampled edges, a radial backdrop or clean alpha, and a linear-light post chain (highlight bloom, ACES tonemap, grade, vignette). Pass views>1 for a directional sprite sheet lit identically at every angle.
+
+| parameter | type | default | description |
+| --- | --- | --- | --- |
+| `name` | string | None | Object to shoot; its children come with it. Omit to frame every mesh in the scene |
+| `out` | string | 'sprite.png' | PNG output path. With views>1 a <stem>.json sidecar describing the grid is written next to it |
+| `size` | integer | 512 | Output size in pixels per frame (square). 256-1024 is the useful icon range |
+| `supersample` | integer | 2 | Render each axis at 1-4x then area-downsample in premultiplied linear light for cleaner silhouette edges. The internal render is capped at 4096 px per axis |
+| `views` | integer | 1 | How many yaw angles to shoot. 1 is an icon; 8 or 16 packs a directional sprite sheet for a 2D game |
+| `azimuth` | number | -47.0 | Camera compass angle in degrees. -47 is the standard three-quarter view that shows a front and a side at once |
+| `elevation` | number | 24.0 | Camera height above the horizon in degrees. 20-30 reads as 'held up in front of you'; 45+ becomes a map marker |
+| `lens` | number | 85.0 | Focal length in mm. Long lenses flatten perspective, which is why product and icon work uses them — 85-135 keeps the far side of the object from tapering away |
+| `fill` | number | 0.86 | Fraction of the frame the subject spans at its widest. Hold this constant across a set and the icons line up; that is the whole trick |
+| `background` | gradient \| solid \| alpha | 'gradient' | gradient is a radial backdrop that separates the silhouette everywhere; alpha leaves it transparent for compositing into a UI; solid is a flat fill |
+| `bg_inner` | any | '#4a5a72' | Backdrop colour behind the subject |
+| `bg_outer` | any | '#1a2130' | Backdrop colour at the corners (gradient only) |
+| `key_color` | any | '#fff1d6' | Key light colour — warm reads as sunlight |
+| `fill_color` | any | '#b9d0f2' | Fill light colour — cool reads as sky, and the warm/cool split is most of what makes a surface look lit rather than painted |
+| `rim_color` | any | '#dcecff' | Kicker colour; the light that draws the silhouette |
+| `rim` | number | 1.0 | Kicker strength. 0 turns separation off, 1.5-2 is a hero/legendary treatment |
+| `key_energy` | number | 1.0 | Key light strength multiplier. 1.0 puts an 18% grey card near the top of the mid-tones, which is where an icon wants to sit |
+| `fill_energy` | number | 0.38 | Fill light strength multiplier. Raise it when the analysis reports crushed shadows — the shadow side of a three-quarter view is half the icon |
+| `exposure` | number | 0.0 | Exposure compensation in stops, clamped to -16..16 and applied in linear light before the tonemap |
+| `bloom` | number | 0.3 | Highlight glow strength. 0 disables it; above ~0.8 the asset starts to dissolve |
+| `bloom_threshold` | number | 0.85 | Linear luminance a pixel must exceed to bloom |
+| `contrast` | number | 1.06 | Contrast multiplier about mid-grey, applied after the tonemap |
+| `saturation` | number | 1.04 | Saturation multiplier. Stylised game icons run hot; 1.0 is neutral |
+| `vignette` | number | 0.22 | Corner darkening. Ignored when background=alpha, which must stay compositable |
+| `look` | aces \| punchy \| linear | 'aces' | Tonemap. aces is the film-style curve games ship; punchy adds saturation in the curve; linear clips, for data |
+| `shadow` | boolean | True | Cast a real contact shadow onto an invisible ground plane so the subject sits on something |
+| `samples` | integer | 96 | Path-tracing samples. Icons are small and seen close; 96-256 is the honest range |
 
 ### `render.turntable`
 

--- a/tools/bforge/README.md
+++ b/tools/bforge/README.md
@@ -130,7 +130,7 @@ tools/bforge/
     daemon.py          JSON-line RPC loop
     registry.py        @op decorator: types, coercion, schema generation
     lib/               mesh, uvs, materials, scene-graph, finishing pass
-    ops/               the 137 operations, grouped by namespace
+    ops/               the 138 operations, grouped by namespace
   catalog.json       committed op snapshot (so tools/list needs no Blender)
   tests/             unit + live-integration + visual gallery
 ```
@@ -165,7 +165,7 @@ in this repo's `.mcp.json`:
 ```
 
 Five tools by default — `bforge_ops`, `bforge_describe`, `bforge_run`,
-`bforge_run_batch`, `bforge_session` — because 89 individual MCP tools swamps
+`bforge_run_batch`, `bforge_session` — because 138 individual MCP tools swamp
 most clients' tool lists. `bforge_run_batch` builds a whole asset in one round
 trip. Pass `--tools full` to expose every op as its own MCP tool instead.
 
@@ -211,7 +211,7 @@ wrong" that no metric shows.
 
 ## What it can make
 
-137 ops across 21 namespaces. Full reference: [`docs/bforge/OPS.md`](../../docs/bforge/OPS.md).
+138 ops across 21 namespaces. Full reference: [`docs/bforge/OPS.md`](../../docs/bforge/OPS.md).
 
 - **`prop.*`** — crate, barrel, chest, sack, rock, crystal, tree, pillar, torch,
   fence, furniture, weapon, banner, debris
@@ -240,9 +240,11 @@ wrong" that no metric shows.
 - **`gameready.*`** — LOD chains, collision proxies, platform budgets, atlasing,
   pivots, attachment sockets
 - **`render.*` / `check.*` / `export.*`** — contact sheets, turntables,
-  **`render.camera`** (explicit position/target/lens, because auto-framing is
-  useless on a 700 m stadium), **`render.impostor`** (billboard sprite sheets +
-  normal sheets + JSON sidecar — the distant-LOD technique), studio validation,
+  **`render.camera`** (explicit position/target/lens), auto-framed cinematic
+  shots, **`render.sprite`** (silhouette-fitted, linear-light, supersampled game
+  icons and directional sheets with clean alpha), **`render.impostor`**
+  (billboard sprite sheets + normal sheets + JSON sidecar — the distant-LOD
+  technique), studio validation,
   critique, **`check.materials`** (perceptual material separation, the mud-blob
   detector), silhouette scoring, gated glTF/blend/meta export
 - **`session.import`** — pull in an existing GLB/glTF/OBJ/FBX/blend to inspect,

--- a/tools/bforge/catalog.json
+++ b/tools/bforge/catalog.json
@@ -5739,7 +5739,11 @@
             "default": "color"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "color"
+        ]
       }
     },
     {
@@ -5779,7 +5783,11 @@
             "default": "color"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "color"
+        ]
       }
     },
     {
@@ -5862,7 +5870,12 @@
             "default": "color"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "low",
+          "high"
+        ]
       }
     },
     {
@@ -5933,7 +5946,12 @@
             "default": "color"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "color_a",
+          "color_b"
+        ]
       }
     },
     {
@@ -7078,7 +7096,7 @@
             },
             "minItems": 3,
             "maxItems": 3,
-            "description": "Camera position in metres"
+            "description": "Camera position in metres. This op exists to place the camera by hand; use render.cinematic or render.view when you want the framing fitted for you"
           },
           "target": {
             "type": "array",
@@ -7135,7 +7153,10 @@
             "default": 0.32
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": [
+          "position"
+        ]
       }
     },
     {
@@ -7161,7 +7182,7 @@
             },
             "minItems": 3,
             "maxItems": 3,
-            "description": "Camera position in metres"
+            "description": "Camera position in metres. Omit it and a three-quarter beauty angle is fitted to the subject \u2014 set it for a close-up or a specific composition"
           },
           "target": {
             "type": "array",
@@ -7170,12 +7191,7 @@
             },
             "minItems": 3,
             "maxItems": 3,
-            "description": "Point to look at",
-            "default": [
-              0.0,
-              0.0,
-              0.0
-            ]
+            "description": "Point to look at. When both camera position and target are omitted, the camera aims at the subject's own centre so assets built off-origin are still framed. An explicit position with no target keeps the established world-origin target"
           },
           "lens": {
             "type": "number",
@@ -7424,6 +7440,225 @@
             "type": "number",
             "description": "Camera height above the horizon in degrees, the same for every view. Ground props read best at 0-15; high values waste frame area on the top face",
             "default": 0.0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "render.sprite",
+      "summary": "Render a GAME ICON, not a screenshot: a silhouette-fitted three-quarter hero angle on a long lens, a warm-key/cool-fill/bright-kicker rig anchored to the camera so a whole set matches, a real contact shadow, supersampled edges, a radial backdrop or clean alpha, and a linear-light post chain (highlight bloom, ACES tonemap, grade, vignette). Pass views>1 for a directional sprite sheet lit identically at every angle.",
+      "tags": [
+        "render"
+      ],
+      "mutates": true,
+      "returns": "object",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Object to shoot; its children come with it. Omit to frame every mesh in the scene"
+          },
+          "out": {
+            "type": "string",
+            "description": "PNG output path. With views>1 a <stem>.json sidecar describing the grid is written next to it",
+            "default": "sprite.png"
+          },
+          "size": {
+            "type": "integer",
+            "description": "Output size in pixels per frame (square). 256-1024 is the useful icon range",
+            "default": 512
+          },
+          "supersample": {
+            "type": "integer",
+            "description": "Render each axis at 1-4x then area-downsample in premultiplied linear light for cleaner silhouette edges. The internal render is capped at 4096 px per axis",
+            "default": 2
+          },
+          "views": {
+            "type": "integer",
+            "description": "How many yaw angles to shoot. 1 is an icon; 8 or 16 packs a directional sprite sheet for a 2D game",
+            "default": 1
+          },
+          "azimuth": {
+            "type": "number",
+            "description": "Camera compass angle in degrees. -47 is the standard three-quarter view that shows a front and a side at once",
+            "default": -47.0
+          },
+          "elevation": {
+            "type": "number",
+            "description": "Camera height above the horizon in degrees. 20-30 reads as 'held up in front of you'; 45+ becomes a map marker",
+            "default": 24.0
+          },
+          "lens": {
+            "type": "number",
+            "description": "Focal length in mm. Long lenses flatten perspective, which is why product and icon work uses them \u2014 85-135 keeps the far side of the object from tapering away",
+            "default": 85.0
+          },
+          "fill": {
+            "type": "number",
+            "description": "Fraction of the frame the subject spans at its widest. Hold this constant across a set and the icons line up; that is the whole trick",
+            "default": 0.86
+          },
+          "background": {
+            "type": "string",
+            "enum": [
+              "gradient",
+              "solid",
+              "alpha"
+            ],
+            "description": "gradient is a radial backdrop that separates the silhouette everywhere; alpha leaves it transparent for compositing into a UI; solid is a flat fill",
+            "default": "gradient"
+          },
+          "bg_inner": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Backdrop colour behind the subject",
+            "default": "#4a5a72"
+          },
+          "bg_outer": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Backdrop colour at the corners (gradient only)",
+            "default": "#1a2130"
+          },
+          "key_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Key light colour \u2014 warm reads as sunlight",
+            "default": "#fff1d6"
+          },
+          "fill_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Fill light colour \u2014 cool reads as sky, and the warm/cool split is most of what makes a surface look lit rather than painted",
+            "default": "#b9d0f2"
+          },
+          "rim_color": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 4
+              }
+            ],
+            "description": "Kicker colour; the light that draws the silhouette",
+            "default": "#dcecff"
+          },
+          "rim": {
+            "type": "number",
+            "description": "Kicker strength. 0 turns separation off, 1.5-2 is a hero/legendary treatment",
+            "default": 1.0
+          },
+          "key_energy": {
+            "type": "number",
+            "description": "Key light strength multiplier. 1.0 puts an 18% grey card near the top of the mid-tones, which is where an icon wants to sit",
+            "default": 1.0
+          },
+          "fill_energy": {
+            "type": "number",
+            "description": "Fill light strength multiplier. Raise it when the analysis reports crushed shadows \u2014 the shadow side of a three-quarter view is half the icon",
+            "default": 0.38
+          },
+          "exposure": {
+            "type": "number",
+            "description": "Exposure compensation in stops, clamped to -16..16 and applied in linear light before the tonemap",
+            "default": 0.0
+          },
+          "bloom": {
+            "type": "number",
+            "description": "Highlight glow strength. 0 disables it; above ~0.8 the asset starts to dissolve",
+            "default": 0.3
+          },
+          "bloom_threshold": {
+            "type": "number",
+            "description": "Linear luminance a pixel must exceed to bloom",
+            "default": 0.85
+          },
+          "contrast": {
+            "type": "number",
+            "description": "Contrast multiplier about mid-grey, applied after the tonemap",
+            "default": 1.06
+          },
+          "saturation": {
+            "type": "number",
+            "description": "Saturation multiplier. Stylised game icons run hot; 1.0 is neutral",
+            "default": 1.04
+          },
+          "vignette": {
+            "type": "number",
+            "description": "Corner darkening. Ignored when background=alpha, which must stay compositable",
+            "default": 0.22
+          },
+          "look": {
+            "type": "string",
+            "enum": [
+              "aces",
+              "punchy",
+              "linear"
+            ],
+            "description": "Tonemap. aces is the film-style curve games ship; punchy adds saturation in the curve; linear clips, for data",
+            "default": "aces"
+          },
+          "shadow": {
+            "type": "boolean",
+            "description": "Cast a real contact shadow onto an invisible ground plane so the subject sits on something",
+            "default": true
+          },
+          "samples": {
+            "type": "integer",
+            "description": "Path-tracing samples. Icons are small and seen close; 96-256 is the honest range",
+            "default": 96
           }
         },
         "additionalProperties": false

--- a/tools/bforge/runtime/lib/post.py
+++ b/tools/bforge/runtime/lib/post.py
@@ -1,0 +1,274 @@
+"""Post-processing for 2D output — the half of icon quality that is not modelling.
+
+A game icon is not a screenshot. Put the same mesh under a review rig and under
+an icon rig and the second one looks like it cost money: the difference is a
+separation light on the silhouette, a backdrop that is darker at the edges than
+behind the subject, highlight bloom, and a grade. None of that is geometry.
+
+Everything here works on **linear scene-referred float RGBA**, top-down, shaped
+``(height, width, 4)``. That matters: bloom, compositing and exposure are only
+correct in linear light. Renders reach this module through OpenEXR rather than
+PNG for the same reason — an 8-bit PNG has already clipped the highlights that
+bloom is supposed to find, so blooming a PNG blooms whatever survived the clip.
+
+Pure numpy plus ``bpy`` for image IO. No operators, so it runs headless.
+"""
+
+from __future__ import annotations
+
+import bpy
+
+LUMA = (0.2126, 0.7152, 0.0722)
+
+
+def require_numpy():
+    try:
+        import numpy
+    except ImportError as exc:  # pragma: no cover - Blender bundles numpy
+        raise RuntimeError("numpy is unavailable in this Blender build") from exc
+    return numpy
+
+
+# --------------------------------------------------------------------------
+# image IO
+# --------------------------------------------------------------------------
+
+
+def load(path, flip=True):
+    """Read an image into a linear float RGBA array, top-down."""
+    numpy = require_numpy()
+    image = bpy.data.images.load(str(path))
+    try:
+        width, height = image.size
+        data = numpy.array(image.pixels[:], dtype=numpy.float32).reshape((height, width, 4))
+        return numpy.flipud(data) if flip else data
+    finally:
+        bpy.data.images.remove(image)
+
+
+def premultiply(rgba):
+    """Return an RGBA copy whose RGB channels are multiplied by alpha."""
+    out = rgba.copy()
+    out[..., :3] *= out[..., 3:4]
+    return out
+
+
+def unpremultiply(rgba, epsilon=1e-6):
+    """Return straight-alpha RGBA without NaNs or colour in empty pixels."""
+    numpy = require_numpy()
+    out = rgba.copy()
+    alpha = out[..., 3:4]
+    out[..., :3] = numpy.divide(
+        out[..., :3],
+        alpha,
+        out=numpy.zeros_like(out[..., :3]),
+        where=alpha > epsilon,
+    )
+    return out
+
+
+def save(array, path, name="_bforge_post", premultiplied=False):
+    """Write a display-referred linear RGBA array (top-down) as a PNG.
+
+    Blender applies the sRGB transfer on save. PNG stores straight alpha while
+    Cycles EXR returns premultiplied alpha, so callers carrying render data must
+    opt into the conversion or antialiased edges are saved with dark fringes.
+    """
+    numpy = require_numpy()
+    pixels = unpremultiply(array) if premultiplied else array
+    height, width = pixels.shape[:2]
+    image = bpy.data.images.new(name, width=width, height=height, alpha=True)
+    try:
+        image.alpha_mode = "STRAIGHT"
+        # Blender images are bottom-up; ours are top-down.
+        image.pixels = numpy.flipud(numpy.clip(pixels, 0.0, 1.0)).ravel().tolist()
+        image.filepath_raw = str(path)
+        image.file_format = "PNG"
+        image.save()
+    finally:
+        bpy.data.images.remove(image)
+    return path
+
+
+# --------------------------------------------------------------------------
+# filters
+# --------------------------------------------------------------------------
+
+
+def box_blur(array, radius, iterations=3):
+    """Separable box blur by cumulative sum; 3 passes approximate a gaussian.
+
+    O(pixels) regardless of radius, and exactly reproducible — a real gaussian
+    kernel built from floats is neither.
+    """
+    numpy = require_numpy()
+    radius = int(radius)
+    if radius < 1:
+        return array
+    out = array
+    for _ in range(max(1, iterations)):
+        for axis in (0, 1):
+            out = _box_blur_axis(numpy, out, radius, axis)
+    return out
+
+
+def _box_blur_axis(numpy, array, radius, axis):
+    moved = numpy.swapaxes(array, 0, axis)
+    # Clamp-to-edge padding: zero padding would darken the border, which on a
+    # bloom pass reads as a black vignette nobody asked for.
+    padded = numpy.concatenate(
+        [numpy.repeat(moved[:1], radius, axis=0), moved, numpy.repeat(moved[-1:], radius, axis=0)],
+        axis=0,
+    )
+    sums = numpy.cumsum(padded, axis=0, dtype=numpy.float32)
+    sums = numpy.concatenate([numpy.zeros_like(sums[:1]), sums], axis=0)
+    window = 2 * radius + 1
+    return numpy.swapaxes((sums[window:] - sums[:-window]) / window, 0, axis)
+
+
+def downsample(array, width, height):
+    """Area-average an integer-multiple image down to the requested dimensions.
+
+    Sprite renders are premultiplied linear RGBA. Averaging them in that form
+    preserves both sub-pixel silhouette coverage and edge colour; resizing a
+    straight-alpha or display-referred image is what creates dark fringes.
+    """
+    numpy = require_numpy()
+    source_height, source_width = array.shape[:2]
+    if (source_width, source_height) == (width, height):
+        return array
+    if width < 1 or height < 1 or source_width % width or source_height % height:
+        raise ValueError(
+            f"downsample requires an integer reduction, got "
+            f"{source_width}x{source_height} -> {width}x{height}"
+        )
+    scale_x = source_width // width
+    scale_y = source_height // height
+    if scale_x < 1 or scale_y < 1:
+        raise ValueError(
+            f"downsample cannot enlarge {source_width}x{source_height} to {width}x{height}"
+        )
+    shape = (height, scale_y, width, scale_x) + array.shape[2:]
+    return array.reshape(shape).mean(axis=(1, 3), dtype=numpy.float32)
+
+
+def luminance(rgb):
+    numpy = require_numpy()
+    return rgb @ numpy.array(LUMA, dtype=numpy.float32)
+
+
+def bloom(rgba, threshold=1.0, strength=0.35, radius=0.04, premultiplied=True):
+    """Add a glow around anything brighter than `threshold`.
+
+    Two blur radii, not one: a tight halo reads as a hot specular and a wide one
+    reads as atmosphere. Only one of them is the effect people mean by "bloom",
+    but a single radius always looks either grimy or radioactive.
+
+    `radius` is a fraction of the image's short side, so a 256 px and a 2048 px
+    render of the same asset bloom identically.
+    """
+    numpy = require_numpy()
+    if strength <= 0.0:
+        return rgba
+    rgb = rgba[..., :3]
+    luma = luminance(rgb)
+    # Soft knee: a hard threshold makes the bloom boundary visible as a ring.
+    knee = numpy.clip((luma - threshold) / max(1e-6, threshold * 0.5 + 1e-6), 0.0, 1.0)
+    highlights = rgb * knee[..., None]
+    short_side = min(rgba.shape[0], rgba.shape[1])
+    tight = box_blur(highlights, max(1, int(short_side * radius * 0.35)))
+    wide = box_blur(highlights, max(2, int(short_side * radius * 1.6)))
+    glow = (tight * 0.65 + wide * 0.35) * strength
+    out = rgba.copy()
+    out[..., :3] = rgb + glow
+    if premultiplied:
+        # Glow spreads past the silhouette. With premultiplied alpha the coverage
+        # has to spread with it or the halo is invisible over any background but
+        # the one it was composited onto — which is the whole point of shipping
+        # an icon with alpha.
+        spread = box_blur(rgba[..., 3:4] * knee[..., None], max(2, int(short_side * radius * 1.6)))
+        out[..., 3] = numpy.clip(rgba[..., 3] + spread[..., 0] * strength, 0.0, 1.0)
+    return out
+
+
+def tonemap(rgb, look="aces", exposure=0.0):
+    """Scene-referred linear -> display-referred linear.
+
+    `aces` is the Narkowicz ACES fit: the curve games actually ship, contrasty
+    with a highlight roll-off that desaturates towards white instead of clipping
+    to a flat primary. `punchy` is that plus saturation, which is the stylised
+    look. `linear` just clips, for when the output is data rather than a picture.
+    """
+    numpy = require_numpy()
+    x = rgb * (2.0**exposure)
+    if look == "linear":
+        return numpy.clip(x, 0.0, 1.0)
+    fitted = (x * (2.51 * x + 0.03)) / (x * (2.43 * x + 0.59) + 0.14)
+    fitted = numpy.clip(fitted, 0.0, 1.0)
+    if look == "punchy":
+        fitted = saturate(fitted, 1.14)
+    return fitted
+
+
+def saturate(rgb, amount):
+    numpy = require_numpy()
+    if abs(amount - 1.0) < 1e-6:
+        return rgb
+    grey = luminance(rgb)[..., None]
+    return numpy.clip(grey + (rgb - grey) * amount, 0.0, 1.0)
+
+
+def contrast(rgb, amount, pivot=0.45):
+    numpy = require_numpy()
+    if abs(amount - 1.0) < 1e-6:
+        return rgb
+    return numpy.clip((rgb - pivot) * amount + pivot, 0.0, 1.0)
+
+
+def vignette(rgb, amount=0.25, softness=0.65):
+    """Darken the corners. Costs nothing and focuses the eye on the subject."""
+    numpy = require_numpy()
+    if amount <= 0.0:
+        return rgb
+    height, width = rgb.shape[:2]
+    ys = numpy.linspace(-1.0, 1.0, height, dtype=numpy.float32)[:, None]
+    xs = numpy.linspace(-1.0, 1.0, width, dtype=numpy.float32)[None, :]
+    radius = numpy.sqrt(xs * xs + ys * ys) / 1.41421356
+    falloff = numpy.clip((radius - softness) / max(1e-6, 1.0 - softness), 0.0, 1.0)
+    return rgb * (1.0 - falloff[..., None] * amount)
+
+
+# --------------------------------------------------------------------------
+# backdrops and compositing
+# --------------------------------------------------------------------------
+
+
+def radial_backdrop(width, height, inner, outer, centre_y=0.42, spread=1.05):
+    """A radial gradient, brightest behind the subject.
+
+    The single most effective backdrop for an icon: it separates the silhouette
+    everywhere at once, where a flat colour separates it only where the subject
+    happens to differ in value.
+    """
+    numpy = require_numpy()
+    ys = numpy.linspace(0.0, 1.0, height, dtype=numpy.float32)[:, None]
+    xs = numpy.linspace(0.0, 1.0, width, dtype=numpy.float32)[None, :]
+    radius = numpy.sqrt((xs - 0.5) ** 2 + (ys - centre_y) ** 2) / max(1e-6, spread * 0.7071)
+    t = numpy.clip(radius, 0.0, 1.0)
+    t = t * t * (3.0 - 2.0 * t)  # smoothstep — a linear ramp bands visibly
+    inner_rgb = numpy.array(inner[:3], dtype=numpy.float32)
+    outer_rgb = numpy.array(outer[:3], dtype=numpy.float32)
+    return inner_rgb + (outer_rgb - inner_rgb) * t[..., None]
+
+
+def over(foreground, background_rgb, premultiplied=True):
+    """Composite RGBA over an opaque RGB backdrop."""
+    numpy = require_numpy()
+    alpha = foreground[..., 3:4]
+    rgb = foreground[..., :3]
+    if not premultiplied:
+        rgb = rgb * alpha
+    out = numpy.empty_like(foreground)
+    out[..., :3] = rgb + background_rgb * (1.0 - alpha)
+    out[..., 3] = 1.0
+    return out

--- a/tools/bforge/runtime/ops/paint.py
+++ b/tools/bforge/runtime/ops/paint.py
@@ -20,7 +20,7 @@ import math
 from lib import mat as mat_lib
 from lib import mesh as mesh_lib
 from lib import scene as scene_lib
-from registry import OpError, op
+from registry import REQUIRED, OpError, op
 
 WHITE = (1.0, 1.0, 1.0, 1.0)
 
@@ -84,9 +84,17 @@ def _mean_edge_length(mesh):
     "paint.fill",
     summary="Set every loop of a mesh to one vertex colour. The base coat for the other paint.* ops — fill white before paint.cavity so unpainted areas stay neutral, or fill a flat tint for a stylised asset.",
     params={
-        "name": ("str", None, "Mesh object to paint"),
-        "color": ("colorref", None, "Colour: palette name, #rrggbb, or linear [r,g,b]. White leaves the material unchanged when the engine multiplies COLOR_0 in"),
-        "layer": ("str", "color", "Colour attribute name; the glTF exporter ships the active one as COLOR_0"),
+        "name": ("str", REQUIRED, "Mesh object to paint"),
+        "color": (
+            "colorref",
+            REQUIRED,
+            "Colour: palette name, #rrggbb, or linear [r,g,b]. White leaves the material unchanged when the engine multiplies COLOR_0 in",
+        ),
+        "layer": (
+            "str",
+            "color",
+            "Colour attribute name; the glTF exporter ships the active one as COLOR_0",
+        ),
     },
     tags=["paint"],
 )
@@ -109,14 +117,34 @@ def paint_fill(ctx, name, color, layer):
     "paint.height",
     summary="Paint a two-colour gradient along an axis — dust at the base of a wall, a snow line on a peak, waterline grime on a hull. Cheaper than any texture and it can never stretch or seam.",
     params={
-        "name": ("str", None, "Mesh object to paint"),
-        "low": ("colorref", None, "Colour at the bottom of the range: palette name, #rrggbb, or linear [r,g,b]"),
-        "high": ("colorref", None, "Colour at the top of the range"),
-        "axis": ("enum:x|y|z", "z", "Axis the gradient runs along (z is up). Measured in the mesh's LOCAL space, like material.face_assign"),
-        "min": ("num", None, "Axis value for 100% `low`; omit to use the mesh's own lower bound. Set both min and max to share one gradient across several objects"),
+        "name": ("str", REQUIRED, "Mesh object to paint"),
+        "low": (
+            "colorref",
+            REQUIRED,
+            "Colour at the bottom of the range: palette name, #rrggbb, or linear [r,g,b]",
+        ),
+        "high": ("colorref", REQUIRED, "Colour at the top of the range"),
+        "axis": (
+            "enum:x|y|z",
+            "z",
+            "Axis the gradient runs along (z is up). Measured in the mesh's LOCAL space, like material.face_assign",
+        ),
+        "min": (
+            "num",
+            None,
+            "Axis value for 100% `low`; omit to use the mesh's own lower bound. Set both min and max to share one gradient across several objects",
+        ),
         "max": ("num", None, "Axis value for 100% `high`; omit to use the mesh's upper bound"),
-        "curve": ("enum:linear|smooth", "linear", "Gradient easing; smooth eases in and out, which hides the band edges"),
-        "layer": ("str", "color", "Colour attribute name; the glTF exporter ships the active one as COLOR_0"),
+        "curve": (
+            "enum:linear|smooth",
+            "linear",
+            "Gradient easing; smooth eases in and out, which hides the band edges",
+        ),
+        "layer": (
+            "str",
+            "color",
+            "Colour attribute name; the glTF exporter ships the active one as COLOR_0",
+        ),
     },
     tags=["paint"],
 )
@@ -162,12 +190,32 @@ def paint_height(ctx, name, low, high, axis, min, max, curve, layer):
     "paint.cavity",
     summary="Bake 'dirt in the crevices' or 'edge wear' without textures: a deterministic geometric curvature estimate per vertex. Concave spots (recesses, grooves, inside corners) take the colour in cavity mode; convex ridges take it in edge mode. Blends over the existing layer, so fill white first if the mesh is unpainted.",
     params={
-        "name": ("str", None, "Mesh object to paint — needs real surface relief; a flat quad has no curvature to find"),
-        "color": ("colorref", None, "Colour blended into the crevices/edges: palette name, #rrggbb, or linear [r,g,b]. Dark browns read as grime, light greys as worn edges"),
-        "mode": ("enum:cavity|edge", "cavity", "cavity paints concave spots (dirt), edge paints convex ridges (wear)"),
-        "strength": ("num", 1.0, "Blend strength multiplier; the deepest cavity gets the full colour at 1.0"),
+        "name": (
+            "str",
+            REQUIRED,
+            "Mesh object to paint — needs real surface relief; a flat quad has no curvature to find",
+        ),
+        "color": (
+            "colorref",
+            REQUIRED,
+            "Colour blended into the crevices/edges: palette name, #rrggbb, or linear [r,g,b]. Dark browns read as grime, light greys as worn edges",
+        ),
+        "mode": (
+            "enum:cavity|edge",
+            "cavity",
+            "cavity paints concave spots (dirt), edge paints convex ridges (wear)",
+        ),
+        "strength": (
+            "num",
+            1.0,
+            "Blend strength multiplier; the deepest cavity gets the full colour at 1.0",
+        ),
         "invert": ("bool", False, "Flip the result — paint everything EXCEPT the crevices/edges"),
-        "layer": ("str", "color", "Colour attribute name; the glTF exporter ships the active one as COLOR_0"),
+        "layer": (
+            "str",
+            "color",
+            "Colour attribute name; the glTF exporter ships the active one as COLOR_0",
+        ),
     },
     tags=["paint"],
 )
@@ -245,13 +293,21 @@ def paint_cavity(ctx, name, color, mode, strength, invert, layer):
     "paint.noise",
     summary="Blend two colours by deterministic fBm noise sampled at vertex positions — mottled wear, rust patches, moss, dirt variation. Breaks up flat fills so large surfaces stop looking computer-perfect.",
     params={
-        "name": ("str", None, "Mesh object to paint"),
-        "color_a": ("colorref", None, "Colour where the noise is low: palette name, #rrggbb, or linear [r,g,b]"),
-        "color_b": ("colorref", None, "Colour where the noise is high"),
+        "name": ("str", REQUIRED, "Mesh object to paint"),
+        "color_a": (
+            "colorref",
+            REQUIRED,
+            "Colour where the noise is low: palette name, #rrggbb, or linear [r,g,b]",
+        ),
+        "color_b": ("colorref", REQUIRED, "Colour where the noise is high"),
         "scale": ("num", 2.0, "Noise frequency in 1/metres — higher gives smaller, busier patches"),
         "seed": ("int", 0, "Random seed; same seed gives the same pattern forever"),
         "octaves": ("int", 3, "Fractal detail levels; more octaves, finer grain"),
-        "layer": ("str", "color", "Colour attribute name; the glTF exporter ships the active one as COLOR_0"),
+        "layer": (
+            "str",
+            "color",
+            "Colour attribute name; the glTF exporter ships the active one as COLOR_0",
+        ),
     },
     tags=["paint"],
 )
@@ -265,8 +321,7 @@ def paint_noise(ctx, name, color_a, color_b, scale, seed, octaves, layer):
 
     vertex_colors = []
     for vert in mesh.vertices:
-        value = _fbm3(vert.co.x * scale, vert.co.y * scale, vert.co.z * scale,
-                      seed, octaves)
+        value = _fbm3(vert.co.x * scale, vert.co.y * scale, vert.co.z * scale, seed, octaves)
         vertex_colors.append(_lerp(rgba_a, rgba_b, _clamp01(value * 0.5 + 0.5)))
     attr = _layer(obj, layer)
     _write_per_vertex(obj, attr, vertex_colors)

--- a/tools/bforge/runtime/ops/render.py
+++ b/tools/bforge/runtime/ops/render.py
@@ -22,16 +22,16 @@ import bpy
 from lib import mesh as mesh_lib
 from lib import scene as scene_lib
 from mathutils import Euler, Vector
-from registry import OpError, op
+from registry import REQUIRED, OpError, op
 
 VIEWS = {
-    "hero":  (math.radians(62), math.radians(0), math.radians(43)),
+    "hero": (math.radians(62), math.radians(0), math.radians(43)),
     "front": (math.radians(90), 0.0, 0.0),
-    "back":  (math.radians(90), 0.0, math.radians(180)),
-    "left":  (math.radians(90), 0.0, math.radians(-90)),
+    "back": (math.radians(90), 0.0, math.radians(180)),
+    "left": (math.radians(90), 0.0, math.radians(-90)),
     "right": (math.radians(90), 0.0, math.radians(90)),
-    "top":   (0.0, 0.0, 0.0),
-    "low":   (math.radians(102), 0.0, math.radians(30)),
+    "top": (0.0, 0.0, 0.0),
+    "low": (math.radians(102), 0.0, math.radians(30)),
 }
 
 
@@ -115,7 +115,7 @@ def _setup_lights(centre, radius):
         # dark albedo render as pale stone — and cost several rounds of "fixing"
         # a material that was correct all along. Re-run the calibration after
         # touching anything here.
-        data.energy = power_scale * 105.0 * (radius ** 2) + 6.0
+        data.energy = power_scale * 105.0 * (radius**2) + 6.0
         light = bpy.data.objects.new(f"_bforge_{name}", data)
         bpy.context.scene.collection.objects.link(light)
         offset = Vector(direction).normalized() * distance
@@ -232,7 +232,7 @@ def _camera_is_buried(eye, target):
     it faces the SAME way we are looking, we are seeing a backface, which means
     we started inside the mesh.
     """
-    direction = (Vector(target) - Vector(eye))
+    direction = Vector(target) - Vector(eye)
     if direction.length < 1e-6:
         return None
     direction.normalize()
@@ -256,8 +256,7 @@ def _analyse(ctx, path):
     from .check import check_image
 
     try:
-        report = check_image(ctx, path=str(path), colors=4,
-                             background=[0.05, 0.055, 0.065, 1.0])
+        report = check_image(ctx, path=str(path), colors=4, background=[0.05, 0.055, 0.065, 1.0])
     except Exception as exc:  # noqa: BLE001 — diagnostics must never fail a render
         return {"error": str(exc)}
     return {
@@ -298,9 +297,17 @@ def _hide_others(keep):
         "view": ("enum:hero|front|back|left|right|top|low", "hero", "Camera angle"),
         "resolution": ("int", 512, "Square render resolution in pixels"),
         "samples": ("int", 24, "Render samples — 24 is enough to judge form"),
-        "engine": ("enum:auto|cycles|eevee", "auto", "Render engine. 'auto' means Cycles/CPU, which is the only one that works without a GPU context; 'eevee' is faster but crashes headless on machines with no display server"),
+        "engine": (
+            "enum:auto|cycles|eevee",
+            "auto",
+            "Render engine. 'auto' means Cycles/CPU, which is the only one that works without a GPU context; 'eevee' is faster but crashes headless on machines with no display server",
+        ),
         "ortho": ("bool", False, "Orthographic projection (right for front/side/top reference)"),
-        "world_light": ("num", 0.32, "Ambient dome strength. Higher fills shadows but piles white specular sheen onto every surface, which washes out saturated albedo"),
+        "world_light": (
+            "num",
+            0.32,
+            "Ambient dome strength. Higher fills shadows but piles white specular sheen onto every surface, which washes out saturated albedo",
+        ),
     },
     tags=["render"],
 )
@@ -320,8 +327,12 @@ def render_view(ctx, out, objects, view, resolution, samples, engine, ortho, wor
         for obj in hidden:
             obj.hide_render = False
     return {
-        "path": str(path), "rel": ctx.rel(path), "view": view, "engine": used,
-        "resolution": resolution, "subject_radius_m": round(radius, 4),
+        "path": str(path),
+        "rel": ctx.rel(path),
+        "view": view,
+        "engine": used,
+        "resolution": resolution,
+        "subject_radius_m": round(radius, 4),
         "analysis": _analyse(ctx, path),
     }
 
@@ -331,7 +342,11 @@ def render_view(ctx, out, objects, view, resolution, samples, engine, ortho, wor
     summary="Render from an explicit camera position and target. Auto-framing always fits the WHOLE subject, which is useless on a 700 m stadium or a 40 m terrain — this is how you get a close-up, an eye-level gameplay view, or a hero shot.",
     params={
         "out": ("path", "shot.png", "PNG output path"),
-        "position": ("vec3", None, "Camera position in metres"),
+        "position": (
+            "vec3",
+            REQUIRED,
+            "Camera position in metres. This op exists to place the camera by hand; use render.cinematic or render.view when you want the framing fitted for you",
+        ),
         "target": ("vec3", [0.0, 0.0, 0.0], "Point to look at"),
         "lens": ("num", 50.0, "Focal length in mm — 24 is wide, 50 neutral, 105 compressed"),
         "resolution": ("int", 640, "Width in pixels"),
@@ -339,12 +354,27 @@ def render_view(ctx, out, objects, view, resolution, samples, engine, ortho, wor
         "samples": ("int", 32, "Render samples"),
         "engine": ("enum:auto|cycles|eevee", "auto", "Render engine"),
         "light_distance": ("num", 0.0, "Light rig scale in metres; 0 fits it to the whole scene"),
-        "world_light": ("num", 0.32, "Ambient dome strength. Higher fills shadows but piles white specular sheen onto every surface, which washes out saturated albedo"),
+        "world_light": (
+            "num",
+            0.32,
+            "Ambient dome strength. Higher fills shadows but piles white specular sheen onto every surface, which washes out saturated albedo",
+        ),
     },
     tags=["render"],
 )
-def render_camera(ctx, out, position, target, lens, resolution, aspect, samples, engine,
-                  light_distance, world_light):
+def render_camera(
+    ctx,
+    out,
+    position,
+    target,
+    lens,
+    resolution,
+    aspect,
+    samples,
+    engine,
+    light_distance,
+    world_light,
+):
     if not [o for o in bpy.context.scene.objects if o.type == "MESH"]:
         raise OpError("nothing to render — the scene has no mesh objects")
     centre = Vector(target)
@@ -379,11 +409,45 @@ def render_camera(ctx, out, position, target, lens, resolution, aspect, samples,
     finally:
         _cleanup_rig(lights + [camera])
     return {
-        "path": str(path), "rel": ctx.rel(path), "engine": used,
-        "position": [round(v, 3) for v in eye], "target": [round(v, 3) for v in centre],
-        "lens_mm": lens, "resolution": [scene.render.resolution_x, scene.render.resolution_y],
+        "path": str(path),
+        "rel": ctx.rel(path),
+        "engine": used,
+        "position": [round(v, 3) for v in eye],
+        "target": [round(v, 3) for v in centre],
+        "lens_mm": lens,
+        "resolution": [scene.render.resolution_x, scene.render.resolution_y],
         "analysis": _analyse(ctx, path),
     }
+
+
+def _frame_distance(radius, lens, aspect, margin, sensor=36.0):
+    """How far back a `lens` mm camera must sit to fit a sphere of `radius`.
+
+    Framing on the horizontal FOV alone crops the subject's head off at 2.39:1,
+    because the vertical field is 2.39x narrower. Fit whichever axis is tighter.
+    """
+    half_x = math.atan(sensor / (2.0 * max(8.0, lens)))
+    half_y = math.atan(math.tan(half_x) / max(0.1, aspect))
+    return (max(1e-6, radius) * max(1.0, margin)) / max(math.sin(min(half_x, half_y)), 1e-4)
+
+
+def _cinematic_eye(centre, radius, lens, aspect, margin=1.35, elevation=22.0, azimuth=-47.0):
+    """A three-quarter beauty angle scaled to the subject.
+
+    Slightly lower and looser than the review rig's `hero` view: a beauty shot
+    wants some sky under the horizon line and air around the silhouette, where
+    a review frame wants the subject as large as it can legibly be.
+    """
+    distance = _frame_distance(radius, lens, aspect, margin)
+    el, az = math.radians(elevation), math.radians(azimuth)
+    direction = Vector(
+        (
+            math.cos(el) * math.cos(az),
+            math.cos(el) * math.sin(az),
+            math.sin(el),
+        )
+    )
+    return centre + direction * distance
 
 
 @op(
@@ -391,38 +455,94 @@ def render_camera(ctx, out, position, target, lens, resolution, aspect, samples,
     summary="A film-grade beauty render: physical sun and sky, global illumination, atmospheric haze, depth of field and a filmic tonemap. render.view and render.camera are flat REVIEW rigs built to judge albedo honestly; this one is built to show the asset at its best, and it is the render that tells you whether the art actually holds up.",
     params={
         "out": ("path", "hero.png", "PNG output path"),
-        "position": ("vec3", None, "Camera position in metres"),
-        "target": ("vec3", [0.0, 0.0, 0.0], "Point to look at"),
+        "position": (
+            "vec3",
+            None,
+            "Camera position in metres. Omit it and a three-quarter beauty angle is fitted to the subject — set it for a close-up or a specific composition",
+        ),
+        "target": (
+            "vec3",
+            None,
+            "Point to look at. When both camera position and target are omitted, the camera aims at the subject's own centre so assets built off-origin are still framed. An explicit position with no target keeps the established world-origin target",
+        ),
         "lens": ("num", 40.0, "Focal length in mm"),
         "resolution": ("int", 1280, "Width in pixels"),
         "aspect": ("num", 2.39, "Width / height. 2.39 is anamorphic, 1.78 is 16:9"),
         "samples": ("int", 96, "Path-tracing samples. This is a beauty render; it costs time"),
         "sun_energy": ("num", 4.0, "Sun strength in W/m2. 3-6 reads as hard daylight"),
-        "sun_angle": ("vec2", [52.0, 35.0], "Sun elevation and azimuth in degrees. Low sun = long shadows"),
+        "sun_angle": (
+            "vec2",
+            [52.0, 35.0],
+            "Sun elevation and azimuth in degrees. Low sun = long shadows",
+        ),
         "sun_color": ("colorref", "#fff2dc", "Sunlight colour; warmer at low elevation"),
         "sky_color": ("colorref", "#6fa3dc", "Zenith sky colour, which is also the fill light"),
         "horizon_color": ("colorref", "#e8dcc0", "Horizon haze colour"),
         "sky_strength": ("num", 1.1, "Sky/ambient strength"),
-        "haze": ("num", 0.0, "Volumetric atmosphere density. 0.0005-0.004 separates distant forms; costs render time"),
+        "haze": (
+            "num",
+            0.0,
+            "Volumetric atmosphere density. 0.0005-0.004 separates distant forms; costs render time",
+        ),
         "focus": ("num", 0.0, "Depth of field focus distance; 0 measures it to the target"),
         "aperture": ("num", 0.0, "f-stop. 0 disables depth of field. 2.8 is shallow, 8 is deep"),
         "bounces": ("int", 6, "Light bounces. GI is most of what makes a render look expensive"),
         "exposure": ("num", 0.0, "Exposure compensation in stops"),
-        "look": ("enum:filmic|agx|standard|contrast", "agx", "View transform. Filmic/AgX roll off highlights like film; standard clips them"),
+        "look": (
+            "enum:filmic|agx|standard|contrast",
+            "agx",
+            "View transform. Filmic/AgX roll off highlights like film; standard clips them",
+        ),
     },
     tags=["render"],
 )
-def render_cinematic(ctx, out, position, target, lens, resolution, aspect, samples, sun_energy,
-                     sun_angle, sun_color, sky_color, horizon_color, sky_strength, haze, focus,
-                     aperture, bounces, exposure, look):
+def render_cinematic(
+    ctx,
+    out,
+    position,
+    target,
+    lens,
+    resolution,
+    aspect,
+    samples,
+    sun_energy,
+    sun_angle,
+    sun_color,
+    sky_color,
+    horizon_color,
+    sky_strength,
+    haze,
+    focus,
+    aperture,
+    bounces,
+    exposure,
+    look,
+):
     from lib import mat as mat_lib
 
     if not [o for o in bpy.context.scene.objects if o.type == "MESH"]:
         raise OpError("nothing to render — the scene has no mesh objects")
 
     scene = bpy.context.scene
-    centre = Vector(target)
-    eye = Vector(position)
+    # `position` has no sensible fixed default — a camera at a hardcoded point is
+    # either inside a stadium or a speck away from a gem. Omitting it means "frame
+    # the subject for me", which is what every other render op does; without this
+    # the documented default of None reached Vector(None) and raised.
+    auto_framed = position is None
+    subject_radius = None
+    if auto_framed:
+        subject_centre, subject_radius = _bounding_sphere(_targets(None))
+        centre = subject_centre if target is None else Vector(target)
+        # A caller can aim away from the subject centre for a deliberate
+        # composition. Fit the sphere around that aim point as well, otherwise
+        # an off-centre target can put part of the asset outside the frame.
+        frame_radius = subject_radius + (subject_centre - centre).length
+        eye = _cinematic_eye(centre, frame_radius, lens, aspect)
+    else:
+        # Preserve the original explicit-camera contract: before auto-framing,
+        # an omitted target meant world origin.
+        centre = Vector((0.0, 0.0, 0.0)) if target is None else Vector(target)
+        eye = Vector(position)
 
     # --- sky: a real gradient environment, not a flat backdrop -----------
     if scene.world is None:
@@ -463,11 +583,13 @@ def render_cinematic(ctx, out, position, target, lens, resolution, aspect, sampl
     scene.collection.objects.link(sun)
     elevation = math.radians(max(2.0, min(88.0, sun_angle[0])))
     azimuth = math.radians(sun_angle[1])
-    direction = Vector((
-        math.cos(elevation) * math.cos(azimuth),
-        math.cos(elevation) * math.sin(azimuth),
-        math.sin(elevation),
-    ))
+    direction = Vector(
+        (
+            math.cos(elevation) * math.cos(azimuth),
+            math.cos(elevation) * math.sin(azimuth),
+            math.sin(elevation),
+        )
+    )
     sun.rotation_euler = (-direction).to_track_quat("-Z", "Y").to_euler()
 
     # --- atmosphere -------------------------------------------------------
@@ -475,8 +597,9 @@ def render_cinematic(ctx, out, position, target, lens, resolution, aspect, sampl
     if haze > 0.0:
         extent = max(200.0, (eye - centre).length * 8.0)
         haze_bm = mesh_lib.new_bmesh()
-        mesh_lib.add_box(haze_bm, size=(extent, extent, extent * 0.5),
-                         center=(centre.x, centre.y, centre.z))
+        mesh_lib.add_box(
+            haze_bm, size=(extent, extent, extent * 0.5), center=(centre.x, centre.y, centre.z)
+        )
         haze_volume = mesh_lib.to_object(haze_bm, "_bforge_haze")
         material = bpy.data.materials.new("_bforge_haze")
         material.use_nodes = True
@@ -494,11 +617,21 @@ def render_cinematic(ctx, out, position, target, lens, resolution, aspect, sampl
     camera = bpy.data.objects.new("_bforge_cine", camera_data)
     scene.collection.objects.link(camera)
     scene.camera = camera
-    camera_data.lens = max(8.0, lens)
+    focal_length = max(8.0, lens)
+    camera_data.lens = focal_length
+    if auto_framed:
+        # `_frame_distance` uses the 36 mm horizontal sensor. Lock Blender to
+        # that same fit so portrait and landscape outputs obey identical math.
+        camera_data.sensor_fit = "HORIZONTAL"
     camera.location = eye
     camera.rotation_euler = (centre - eye).to_track_quat("-Z", "Y").to_euler()
     distance = max(0.1, (eye - centre).length)
-    camera_data.clip_start = max(0.01, distance * 0.001)
+    # A fixed 1 cm near plane erases millimetre-scale jewellery. Auto-framing
+    # knows its distance is safe, so scale the near plane with it. Keep the
+    # established explicit-camera value unchanged.
+    camera_data.clip_start = (
+        max(1e-5, distance * 0.001) if auto_framed else max(0.01, distance * 0.001)
+    )
     camera_data.clip_end = distance * 40.0
     if aperture > 0.0:
         camera_data.dof.use_dof = True
@@ -523,8 +656,9 @@ def render_cinematic(ctx, out, position, target, lens, resolution, aspect, sampl
     scene.render.image_settings.color_mode = "RGB"
 
     view = scene.view_settings
-    transform = {"filmic": "Filmic", "agx": "AgX", "standard": "Standard",
-                 "contrast": "Standard"}[look]
+    transform = {"filmic": "Filmic", "agx": "AgX", "standard": "Standard", "contrast": "Standard"}[
+        look
+    ]
     for candidate in (transform, "AgX", "Filmic", "Standard"):
         try:
             view.view_transform = candidate
@@ -532,8 +666,10 @@ def render_cinematic(ctx, out, position, target, lens, resolution, aspect, sampl
         except TypeError:
             continue
     try:
-        view.look = "AgX - Punchy" if look == "agx" else (
-            "Medium High Contrast" if look == "contrast" else "None"
+        view.look = (
+            "AgX - Punchy"
+            if look == "agx"
+            else ("Medium High Contrast" if look == "contrast" else "None")
         )
     except TypeError:
         pass
@@ -556,10 +692,19 @@ def render_cinematic(ctx, out, position, target, lens, resolution, aspect, sampl
         _cleanup_rig([sun, camera] + ([haze_volume] if haze_volume else []))
 
     return {
-        "path": str(path), "rel": ctx.rel(path),
+        "path": str(path),
+        "rel": ctx.rel(path),
         "resolution": [scene.render.resolution_x, scene.render.resolution_y],
-        "samples": samples, "bounces": bounces, "look": view.view_transform,
-        "haze": haze, "depth_of_field": aperture > 0.0,
+        "samples": samples,
+        "bounces": bounces,
+        "look": view.view_transform,
+        "haze": haze,
+        "depth_of_field": aperture > 0.0,
+        "auto_framed": auto_framed,
+        "position": [round(v, 5) for v in eye],
+        "target": [round(v, 5) for v in centre],
+        "lens_mm": focal_length,
+        "subject_radius_m": (round(subject_radius, 5) if subject_radius is not None else None),
         "analysis": _analyse(ctx, path),
     }
 
@@ -573,7 +718,11 @@ def render_cinematic(ctx, out, position, target, lens, resolution, aspect, sampl
         "tile": ("int", 400, "Pixel size of each tile"),
         "samples": ("int", 20, "Render samples per tile"),
         "engine": ("enum:auto|cycles|eevee", "auto", "Render engine"),
-        "panels": ("str[]", ["hero", "front", "left", "top", "wireframe", "checker"], "Which panels to include"),
+        "panels": (
+            "str[]",
+            ["hero", "front", "left", "top", "wireframe", "checker"],
+            "Which panels to include",
+        ),
         "columns": ("int", 3, "Tiles per row"),
     },
     tags=["render", "inspect"],
@@ -582,7 +731,9 @@ def render_contact_sheet(ctx, out, objects, tile, samples, engine, panels, colum
     try:
         import numpy
     except ImportError as exc:  # pragma: no cover - Blender bundles numpy
-        raise OpError("numpy is unavailable in this Blender build; use render.view instead") from exc
+        raise OpError(
+            "numpy is unavailable in this Blender build; use render.view instead"
+        ) from exc
 
     targets = _targets(objects)
     hidden = _hide_others(targets) if objects else []
@@ -723,8 +874,8 @@ def _wireframe_material():
     mix = tree.nodes.new("ShaderNodeMix")
     mix.data_type = "RGBA"
     mix.location = (-320, 0)
-    mix.inputs["A"].default_value = (0.30, 0.32, 0.36, 1.0)   # surface
-    mix.inputs["B"].default_value = (0.02, 0.85, 0.65, 1.0)   # wire
+    mix.inputs["A"].default_value = (0.30, 0.32, 0.36, 1.0)  # surface
+    mix.inputs["B"].default_value = (0.02, 0.85, 0.65, 1.0)  # wire
     tree.links.new(wire.outputs["Fac"], mix.inputs["Factor"])
     tree.links.new(mix.outputs["Result"], bsdf.inputs["Base Color"])
     # Emission carries the wire so it stays legible in unlit areas.
@@ -796,13 +947,16 @@ def render_turntable(ctx, out_dir, objects, frames, resolution, samples, elevati
         for index in range(frames):
             azimuth = math.tau * index / frames
             tilt = math.radians(elevation)
-            offset = Vector(
-                (
-                    math.cos(azimuth) * math.cos(tilt),
-                    math.sin(azimuth) * math.cos(tilt),
-                    math.sin(tilt),
+            offset = (
+                Vector(
+                    (
+                        math.cos(azimuth) * math.cos(tilt),
+                        math.sin(azimuth) * math.cos(tilt),
+                        math.sin(tilt),
+                    )
                 )
-            ) * distance
+                * distance
+            )
             camera.location = centre + offset
             camera.rotation_euler = (-offset).to_track_quat("-Z", "Y").to_euler()
             path = base / f"frame_{index:03d}.png"
@@ -814,8 +968,11 @@ def render_turntable(ctx, out_dir, objects, frames, resolution, samples, elevati
             obj.hide_render = False
 
     return {
-        "directory": str(base), "rel": ctx.rel(base), "frames": len(paths),
-        "files": paths, "engine": used,
+        "directory": str(base),
+        "rel": ctx.rel(base),
+        "frames": len(paths),
+        "files": paths,
+        "engine": used,
     }
 
 
@@ -867,13 +1024,41 @@ def _save_sheet_png(numpy, grid, path, cols, rows, size):
     "render.impostor",
     summary="Bake an object into a billboard impostor sprite sheet: N orthographic views orbiting it, packed left-to-right then top-to-bottom into ONE transparent PNG, plus a JSON sidecar (grid layout, yaw angles, bounds) with everything a game engine needs to billboard it. This is THE distant-LOD technique — swap the real mesh for a camera-facing quad with this sheet beyond a few hundred metres and a browser can show thousands of instances at full frame rate. Pass normals=True to also bake a world-space normal sheet so the billboard can react to scene lighting.",
     params={
-        "name": ("str", None, "Object to bake; its children are baked with it. Use object.list if you are unsure of the exact name"),
-        "out": ("path", "impostor.png", "Sprite-sheet PNG path. The JSON sidecar is written next to it as <stem>.json"),
-        "views": ("int", 8, "Yaw angles around the object, evenly spaced over 360 degrees. 8 is the standard for props; 4 is enough for near-symmetric ones and halves the bake time"),
-        "size": ("int", 128, "Pixel size of each frame (frames are square). Billboards are only ever seen at distance, so 64-256 is the useful range — bigger just costs render time"),
-        "normals": ("bool", False, "Also write <stem>_normal.png: world-space normals packed into 0..1 colour, so the billboard can be lit instead of looking pasted on. Doubles render cost"),
-        "samples": ("int", 16, "Cycles samples per frame. 16 is plenty at these sizes; raise only if the sprites look grainy"),
-        "elevation": ("num", 0.0, "Camera height above the horizon in degrees, the same for every view. Ground props read best at 0-15; high values waste frame area on the top face"),
+        "name": (
+            "str",
+            None,
+            "Object to bake; its children are baked with it. Use object.list if you are unsure of the exact name",
+        ),
+        "out": (
+            "path",
+            "impostor.png",
+            "Sprite-sheet PNG path. The JSON sidecar is written next to it as <stem>.json",
+        ),
+        "views": (
+            "int",
+            8,
+            "Yaw angles around the object, evenly spaced over 360 degrees. 8 is the standard for props; 4 is enough for near-symmetric ones and halves the bake time",
+        ),
+        "size": (
+            "int",
+            128,
+            "Pixel size of each frame (frames are square). Billboards are only ever seen at distance, so 64-256 is the useful range — bigger just costs render time",
+        ),
+        "normals": (
+            "bool",
+            False,
+            "Also write <stem>_normal.png: world-space normals packed into 0..1 colour, so the billboard can be lit instead of looking pasted on. Doubles render cost",
+        ),
+        "samples": (
+            "int",
+            16,
+            "Cycles samples per frame. 16 is plenty at these sizes; raise only if the sprites look grainy",
+        ),
+        "elevation": (
+            "num",
+            0.0,
+            "Camera height above the horizon in degrees, the same for every view. Ground props read best at 0-15; high values waste frame area on the top face",
+        ),
     },
     tags=["render"],
 )
@@ -947,13 +1132,16 @@ def render_impostor(ctx, name, out, views, size, normals, samples, elevation):
             # The camera orbits while the light rig stays fixed — the sprite
             # lighting is then consistent across frames, as if the object spun.
             yaw = math.tau * index / views
-            offset = Vector(
-                (
-                    math.cos(yaw) * math.cos(tilt),
-                    math.sin(yaw) * math.cos(tilt),
-                    math.sin(tilt),
+            offset = (
+                Vector(
+                    (
+                        math.cos(yaw) * math.cos(tilt),
+                        math.sin(yaw) * math.cos(tilt),
+                        math.sin(tilt),
+                    )
                 )
-            ) * distance
+                * distance
+            )
             camera.location = centre + offset
             camera.rotation_euler = (-offset).to_track_quat("-Z", "Y").to_euler()
             _render_to(scratch / f"{stem}_{index:03d}.png")
@@ -1008,3 +1196,656 @@ def render_impostor(ctx, name, out, views, size, normals, samples, elevation):
     if normals:
         result["normal_sheet"] = ctx.rel(normal_path)
     return result
+
+
+# ==========================================================================
+# render.sprite — the icon rig
+# ==========================================================================
+#
+# render.view judges albedo, render.cinematic judges whether the art holds up
+# in a world, and neither produces something you can put in an inventory grid.
+# An icon has requirements those two do not: every asset must occupy the same
+# fraction of its frame however big it is, the silhouette must separate from
+# the backdrop without relying on the subject happening to be lighter than it,
+# the alpha has to survive being composited onto a UI nobody has designed yet,
+# and forty of them shot on different days have to look like one set.
+
+ICON_KEY = "#fff1d6"  # warm key — the sun side
+ICON_FILL = "#b9d0f2"  # cool fill — the sky side. Warm/cool split is most
+ICON_RIM = "#dcecff"  # of what separates a lit object from a coloured one.
+
+
+def _camera_basis(view_dir):
+    """Right/up/forward for a camera looking along `view_dir`."""
+    forward = Vector(view_dir).normalized()
+    world_up = Vector((0.0, 0.0, 1.0))
+    if abs(forward.dot(world_up)) > 0.999:  # looking straight down: pick any right
+        world_up = Vector((0.0, 1.0, 0.0))
+    right = forward.cross(world_up).normalized()
+    up = right.cross(forward).normalized()
+    return right, up, forward
+
+
+def _fit_subject(meshes, view_dir, lens, aspect, fill, sensor=36.0):
+    """Frame the subject to occupy `fill` of the frame, whatever shape it is.
+
+    Bounding-sphere framing is why generated icon sets look untidy: a sword and
+    a shield with the same bounding radius fill wildly different fractions of
+    the frame, so in a grid one floats and the other crowds. Project the real
+    corners onto the camera's own axes instead and fit that rectangle, which
+    also recentres a subject whose pivot is not its visual centre.
+    """
+    bpy.context.view_layer.update()
+    corners = [o.matrix_world @ Vector(c) for o in meshes for c in o.bound_box]
+    if not corners:
+        raise OpError("nothing to frame — the subject has no geometry")
+    centre = sum(corners, Vector((0.0, 0.0, 0.0))) / len(corners)
+    right, up, forward = _camera_basis(view_dir)
+
+    us = [(p - centre).dot(right) for p in corners]
+    vs = [(p - centre).dot(up) for p in corners]
+    ws = [(p - centre).dot(forward) for p in corners]
+    half_u = max(1e-4, (max(us) - min(us)) * 0.5)
+    half_v = max(1e-4, (max(vs) - min(vs)) * 0.5)
+    # Aim at the middle of the projected rectangle, not at the pivot.
+    target = centre + right * ((max(us) + min(us)) * 0.5) + up * ((max(vs) + min(vs)) * 0.5)
+
+    half_x = math.atan(sensor / (2.0 * max(8.0, lens)))
+    half_y = math.atan(math.tan(half_x) / max(0.1, aspect))
+    fill = max(0.05, min(0.98, fill))
+    distance = max(half_u / (math.tan(half_x) * fill), half_v / (math.tan(half_y) * fill))
+    # The near face projects larger than the centre plane. Pushing back by the
+    # nearest corner's depth is exact, not a safety fudge.
+    distance -= min(ws)
+    radius = max(half_u, half_v, (max(ws) - min(ws)) * 0.5)
+    return target, max(distance, radius * 1.05), radius
+
+
+def _icon_lights(
+    target,
+    radius,
+    right,
+    up,
+    forward,
+    key_color,
+    fill_color,
+    rim_color,
+    rim,
+    key_energy,
+    fill_energy,
+):
+    """A three-point rig defined in CAMERA space, not world space.
+
+    World-space lights mean an asset modelled facing +X and one facing -Y light
+    differently, so a set shot over several sessions never matches. Anchoring
+    the rig to the camera makes the lighting a property of the shot.
+    """
+    for obj in [o for o in bpy.context.scene.objects if o.type == "LIGHT"]:
+        scene_lib.delete(obj)
+    # Distance and light size both scale with the subject, so the rig subtends a
+    # constant solid angle and energy proportional to radius^2 holds exposure
+    # fixed from a gem to a stadium. No additive floor term: a constant watt is
+    # the one thing in this expression that would break that invariance.
+    #
+    # 420 is an icon-specific baseline, intentionally ~4x the calibrated
+    # review-rig constant: a review render preserves albedo, while an icon puts
+    # mid-tones high and leaves enough highlight energy for the bloom pass.
+    distance = radius * 3.2
+    base = 420.0 * (radius**2)
+    rig = [
+        # name    direction (camera space: right, up, -forward=towards camera)
+        ("key", (-0.85, 0.95, 1.15), key_energy, radius * 2.4, key_color),
+        # Big, soft, and slightly BELOW the lens axis. The shadow side of a
+        # three-quarter view is half the icon; letting it fall to black reads as
+        # a rendering fault rather than as shape.
+        ("fill", (1.25, -0.15, 0.85), fill_energy, radius * 4.5, fill_color),
+        # The kicker sits BEHIND the subject and rakes across it. This is the
+        # separation light: it draws a bright line down the silhouette so the
+        # shape reads against any backdrop, which is the single biggest
+        # difference between a render and an icon.
+        ("rim", (0.75, 0.85, -1.35), 0.85 * rim, radius * 1.1, rim_color),
+    ]
+    made = []
+    for name, (dr, du, dt), power, size, color in rig:
+        if power <= 0.0:
+            continue
+        data = bpy.data.lights.new(f"_bforge_icon_{name}", type="AREA")
+        data.size = max(0.05, size)
+        data.energy = power * base
+        data.color = color[:3]
+        light = bpy.data.objects.new(f"_bforge_icon_{name}", data)
+        bpy.context.scene.collection.objects.link(light)
+        offset = (right * dr + up * du + (-forward) * dt).normalized() * distance
+        light.location = target + offset
+        light.rotation_euler = (-offset).to_track_quat("-Z", "Y").to_euler()
+        made.append(light)
+    return made
+
+
+def _shadow_catcher(meshes, radius):
+    """A ground plane that renders only the shadow falling on it.
+
+    An icon with no contact shadow floats. One with a painted-on ellipse looks
+    like a sticker. A real shadow catcher costs one plane and stays correct when
+    the subject changes shape.
+    """
+    bpy.context.view_layer.update()
+    corners = [o.matrix_world @ Vector(c) for o in meshes for c in o.bound_box]
+    floor = min(p.z for p in corners)
+    centre = sum(corners, Vector((0.0, 0.0, 0.0))) / len(corners)
+    bm = mesh_lib.new_bmesh()
+    mesh_lib.add_plane(
+        bm,
+        size=(radius * 14.0, radius * 14.0),
+        center=(centre.x, centre.y, floor - max(1e-5, radius * 1e-4)),
+    )
+    plane = mesh_lib.to_object(bm, "_bforge_icon_floor")
+    plane.is_shadow_catcher = True
+    return plane
+
+
+@op(
+    "render.sprite",
+    summary="Render a GAME ICON, not a screenshot: a silhouette-fitted three-quarter hero angle on a long lens, a warm-key/cool-fill/bright-kicker rig anchored to the camera so a whole set matches, a real contact shadow, supersampled edges, a radial backdrop or clean alpha, and a linear-light post chain (highlight bloom, ACES tonemap, grade, vignette). Pass views>1 for a directional sprite sheet lit identically at every angle.",
+    params={
+        "name": (
+            "str",
+            None,
+            "Object to shoot; its children come with it. Omit to frame every mesh in the scene",
+        ),
+        "out": (
+            "path",
+            "sprite.png",
+            "PNG output path. With views>1 a <stem>.json sidecar describing the grid is written next to it",
+        ),
+        "size": (
+            "int",
+            512,
+            "Output size in pixels per frame (square). 256-1024 is the useful icon range",
+        ),
+        "supersample": (
+            "int",
+            2,
+            "Render each axis at 1-4x then area-downsample in premultiplied linear light for cleaner silhouette edges. The internal render is capped at 4096 px per axis",
+        ),
+        "views": (
+            "int",
+            1,
+            "How many yaw angles to shoot. 1 is an icon; 8 or 16 packs a directional sprite sheet for a 2D game",
+        ),
+        "azimuth": (
+            "num",
+            -47.0,
+            "Camera compass angle in degrees. -47 is the standard three-quarter view that shows a front and a side at once",
+        ),
+        "elevation": (
+            "num",
+            24.0,
+            "Camera height above the horizon in degrees. 20-30 reads as 'held up in front of you'; 45+ becomes a map marker",
+        ),
+        "lens": (
+            "num",
+            85.0,
+            "Focal length in mm. Long lenses flatten perspective, which is why product and icon work uses them — 85-135 keeps the far side of the object from tapering away",
+        ),
+        "fill": (
+            "num",
+            0.86,
+            "Fraction of the frame the subject spans at its widest. Hold this constant across a set and the icons line up; that is the whole trick",
+        ),
+        "background": (
+            "enum:gradient|solid|alpha",
+            "gradient",
+            "gradient is a radial backdrop that separates the silhouette everywhere; alpha leaves it transparent for compositing into a UI; solid is a flat fill",
+        ),
+        "bg_inner": ("colorref", "#4a5a72", "Backdrop colour behind the subject"),
+        "bg_outer": ("colorref", "#1a2130", "Backdrop colour at the corners (gradient only)"),
+        "key_color": ("colorref", ICON_KEY, "Key light colour — warm reads as sunlight"),
+        "fill_color": (
+            "colorref",
+            ICON_FILL,
+            "Fill light colour — cool reads as sky, and the warm/cool split is most of what makes a surface look lit rather than painted",
+        ),
+        "rim_color": ("colorref", ICON_RIM, "Kicker colour; the light that draws the silhouette"),
+        "rim": (
+            "num",
+            1.0,
+            "Kicker strength. 0 turns separation off, 1.5-2 is a hero/legendary treatment",
+        ),
+        "key_energy": (
+            "num",
+            1.0,
+            "Key light strength multiplier. 1.0 puts an 18% grey card near the top of the mid-tones, which is where an icon wants to sit",
+        ),
+        "fill_energy": (
+            "num",
+            0.38,
+            "Fill light strength multiplier. Raise it when the analysis reports crushed shadows — the shadow side of a three-quarter view is half the icon",
+        ),
+        "exposure": (
+            "num",
+            0.0,
+            "Exposure compensation in stops, clamped to -16..16 and applied in linear light before the tonemap",
+        ),
+        "bloom": (
+            "num",
+            0.3,
+            "Highlight glow strength. 0 disables it; above ~0.8 the asset starts to dissolve",
+        ),
+        "bloom_threshold": ("num", 0.85, "Linear luminance a pixel must exceed to bloom"),
+        "contrast": ("num", 1.06, "Contrast multiplier about mid-grey, applied after the tonemap"),
+        "saturation": (
+            "num",
+            1.04,
+            "Saturation multiplier. Stylised game icons run hot; 1.0 is neutral",
+        ),
+        "vignette": (
+            "num",
+            0.22,
+            "Corner darkening. Ignored when background=alpha, which must stay compositable",
+        ),
+        "look": (
+            "enum:aces|punchy|linear",
+            "aces",
+            "Tonemap. aces is the film-style curve games ship; punchy adds saturation in the curve; linear clips, for data",
+        ),
+        "shadow": (
+            "bool",
+            True,
+            "Cast a real contact shadow onto an invisible ground plane so the subject sits on something",
+        ),
+        "samples": (
+            "int",
+            96,
+            "Path-tracing samples. Icons are small and seen close; 96-256 is the honest range",
+        ),
+    },
+    tags=["render"],
+)
+def render_sprite(
+    ctx,
+    name,
+    out,
+    size,
+    supersample,
+    views,
+    azimuth,
+    elevation,
+    lens,
+    fill,
+    background,
+    bg_inner,
+    bg_outer,
+    key_color,
+    fill_color,
+    rim_color,
+    rim,
+    key_energy,
+    fill_energy,
+    exposure,
+    bloom,
+    bloom_threshold,
+    contrast,
+    saturation,
+    vignette,
+    look,
+    shadow,
+    samples,
+):
+    from lib import mat as mat_lib
+    from lib import post
+
+    try:
+        numpy = post.require_numpy()
+    except RuntimeError as exc:
+        raise OpError(str(exc)) from exc
+
+    if name:
+        try:
+            root = scene_lib.get_object(name)
+        except ValueError as exc:
+            raise OpError(f"{exc} Run 'object.list' to see the names in the scene.") from exc
+        meshes = [o for o in [root, *root.children_recursive] if o.type == "MESH"]
+        if not meshes:
+            raise OpError(
+                f"'{name}' has no mesh geometry to shoot — it and its children are "
+                "empties, armatures or lights. Run 'session.info' to see what is there."
+            )
+        object_name = root.name
+    else:
+        meshes = [o for o in bpy.context.scene.objects if o.type == "MESH"]
+        if not meshes:
+            raise OpError("nothing to render — the scene has no mesh objects")
+        object_name = ""
+
+    try:
+        inner = mat_lib.resolve_color(bg_inner)
+        outer = mat_lib.resolve_color(bg_outer)
+        resolved_key = mat_lib.resolve_color(key_color)
+        resolved_fill = mat_lib.resolve_color(fill_color)
+        resolved_rim = mat_lib.resolve_color(rim_color)
+    except ValueError as exc:
+        raise OpError(str(exc)) from exc
+
+    size = max(32, min(2048, size))
+    supersample = max(1, min(4, supersample, 4096 // size))
+    render_size = size * supersample
+    views = max(1, min(64, views))
+    elevation = max(-85.0, min(85.0, elevation))
+    lens = max(8.0, lens)
+    fill = max(0.05, min(0.98, fill))
+    exposure = max(-16.0, min(16.0, exposure))
+    samples = max(8, samples)
+    cols = math.ceil(math.sqrt(views))
+    rows = math.ceil(views / cols)
+    el = math.radians(elevation)
+    az = math.radians(azimuth)
+
+    def _view_dir(yaw):
+        """Unit vector FROM the camera TOWARDS the subject."""
+        return -Vector(
+            (
+                math.cos(el) * math.cos(yaw),
+                math.cos(el) * math.sin(yaw),
+                math.sin(el),
+            )
+        )
+
+    yaws = [az + (math.tau * index / views if views > 1 else 0.0) for index in range(views)]
+    rigs = []
+    for yaw in yaws:
+        direction = _view_dir(yaw)
+        target, distance, frame_radius = _fit_subject(meshes, direction, lens, 1.0, fill)
+        right, up, forward = _camera_basis(direction)
+        rigs.append((yaw, direction, target, distance, frame_radius, right, up, forward))
+    _subject_centre, subject_radius = _bounding_sphere(meshes)
+
+    scene = bpy.context.scene
+    settings = scene.render.image_settings
+    view = scene.view_settings
+    previous_render = {
+        "resolution_x": scene.render.resolution_x,
+        "resolution_y": scene.render.resolution_y,
+        "resolution_percentage": scene.render.resolution_percentage,
+        "film_transparent": scene.render.film_transparent,
+        "filepath": scene.render.filepath,
+    }
+    previous_image = {
+        "file_format": settings.file_format,
+        "color_mode": settings.color_mode,
+        "color_depth": settings.color_depth,
+        "exr_codec": settings.exr_codec,
+    }
+    previous_view = {
+        "transform": view.view_transform,
+        "look": view.look,
+        "exposure": view.exposure,
+        "gamma": view.gamma,
+    }
+
+    hidden = _hide_others(meshes)
+    path = ctx.out_path(out, ".png")
+    scratch = ctx.out_dir / "_sprite"
+    scratch.mkdir(parents=True, exist_ok=True)
+    sheet = numpy.zeros((rows * size, cols * size, 4), dtype=numpy.float32)
+    floor = None
+    camera = None
+    lights = []
+    frame_metrics = []
+    try:
+        floor = _shadow_catcher(meshes, subject_radius) if shadow else None
+
+        camera_data = bpy.data.cameras.new("_bforge_sprite")
+        camera = bpy.data.objects.new("_bforge_sprite", camera_data)
+        scene.collection.objects.link(camera)
+        scene.camera = camera
+        camera_data.lens = lens
+        camera_data.sensor_width = 36.0
+        camera_data.sensor_fit = "HORIZONTAL"
+
+        if scene.world is None:
+            scene.world = bpy.data.worlds.new("World")
+        scene.world.use_nodes = True
+        world_tree = scene.world.node_tree
+        world_tree.nodes.clear()
+        world_output = world_tree.nodes.new("ShaderNodeOutputWorld")
+        dome = world_tree.nodes.new("ShaderNodeBackground")
+        dome.inputs["Color"].default_value = (0.05, 0.055, 0.07, 1.0)
+        dome.inputs["Strength"].default_value = 0.35
+        world_tree.links.new(dome.outputs["Background"], world_output.inputs["Surface"])
+
+        scene.render.engine = "CYCLES"
+        scene.cycles.device = "CPU"
+        scene.cycles.samples = samples
+        scene.cycles.seed = 0
+        scene.cycles.use_denoising = True
+        scene.cycles.max_bounces = 4
+        scene.cycles.diffuse_bounces = 4
+        scene.cycles.glossy_bounces = 4
+        scene.cycles.transmission_bounces = 4
+        scene.cycles.caustics_reflective = False
+        scene.cycles.caustics_refractive = False
+        scene.render.resolution_x = render_size
+        scene.render.resolution_y = render_size
+        scene.render.resolution_percentage = 100
+        scene.render.film_transparent = True
+
+        # EXR preserves the scene-linear highlights that bloom needs. PNG would
+        # clip and display-transform them before the post chain ever saw them.
+        settings.file_format = "OPEN_EXR"
+        settings.color_mode = "RGBA"
+        settings.color_depth = "32"
+        settings.exr_codec = "ZIP"
+        for candidate in ("Raw", "Standard"):
+            try:
+                view.view_transform = candidate
+                break
+            except TypeError:
+                continue
+        try:
+            view.look = "None"
+        except TypeError:
+            pass
+        view.exposure = 0.0
+        view.gamma = 1.0
+
+        for index, rig_data in enumerate(rigs):
+            yaw, direction, target, distance, frame_radius, right, up, forward = rig_data
+            camera.location = target - direction * distance
+            camera.rotation_euler = direction.to_track_quat("-Z", "Y").to_euler()
+            nearest = max(1e-5, distance - subject_radius * 1.1)
+            camera_data.clip_start = max(1e-5, min(distance * 0.001, nearest))
+            camera_data.clip_end = max(distance * 8.0, distance + subject_radius * 2.0)
+
+            _cleanup_rig(lights)
+            lights = _icon_lights(
+                target,
+                subject_radius,
+                right,
+                up,
+                forward,
+                resolved_key,
+                resolved_fill,
+                resolved_rim,
+                rim,
+                key_energy,
+                fill_energy,
+            )
+            bpy.context.view_layer.update()
+
+            exr = scratch / f"frame_{index:03d}.exr"
+            _render_to(exr)
+            raw = post.load(exr)
+            frame = _compose_sprite(
+                post,
+                numpy,
+                raw,
+                size,
+                background,
+                inner,
+                outer,
+                exposure,
+                bloom,
+                bloom_threshold,
+                look,
+                contrast,
+                saturation,
+                vignette,
+            )
+            row, column = divmod(index, cols)
+            sheet[row * size : (row + 1) * size, column * size : (column + 1) * size] = frame
+            frame_metrics.append(
+                {
+                    "index": index,
+                    "yaw_degrees": round(math.degrees(yaw) % 360.0, 6),
+                    "target_m": [round(value, 5) for value in target],
+                    "distance_m": round(distance, 5),
+                    "frame_radius_m": round(frame_radius, 5),
+                }
+            )
+
+        post.save(
+            sheet,
+            path,
+            name="_bforge_sprite_out",
+            premultiplied=background == "alpha",
+        )
+        saved = post.load(path)
+        for record in frame_metrics:
+            row, column = divmod(record["index"], cols)
+            frame = saved[
+                row * size : (row + 1) * size,
+                column * size : (column + 1) * size,
+            ]
+            record.update(_alpha_metrics(numpy, frame))
+    finally:
+        _cleanup_rig(lights + [camera] + ([floor] if floor is not None else []))
+        for obj in hidden:
+            obj.hide_render = False
+        view.view_transform = previous_view["transform"]
+        try:
+            view.look = previous_view["look"]
+        except TypeError:
+            pass
+        view.exposure = previous_view["exposure"]
+        view.gamma = previous_view["gamma"]
+        for key, value in previous_image.items():
+            setattr(settings, key, value)
+        for key, value in previous_render.items():
+            setattr(scene.render, key, value)
+
+    result = {
+        "path": str(path),
+        "rel": ctx.rel(path),
+        "object": object_name,
+        "frames": views,
+        "cols": cols,
+        "rows": rows,
+        "frame_px": size,
+        "render_px": render_size,
+        "supersample": supersample,
+        "samples": samples,
+        "fill_target": round(fill, 4),
+        "subject_radius_m": round(subject_radius, 5),
+        "camera": {
+            "azimuth": azimuth,
+            "elevation": elevation,
+            "lens_mm": lens,
+            "distance_m": frame_metrics[0]["distance_m"],
+        },
+        "frame_metrics": frame_metrics,
+        "background": background,
+        "exposure": exposure,
+        "bytes": path.stat().st_size,
+    }
+    if views > 1:
+        sidecar = path.with_suffix(".json")
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "frames": views,
+                    "cols": cols,
+                    "rows": rows,
+                    "frame_px": size,
+                    "render_px": render_size,
+                    "supersample": supersample,
+                    "samples": samples,
+                    "fill_target": round(fill, 4),
+                    "background": background,
+                    "exposure": exposure,
+                    "elevation": elevation,
+                    "lens_mm": lens,
+                    "object": object_name,
+                    "camera_frames": frame_metrics,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        result["sidecar"] = ctx.rel(sidecar)
+    result["analysis"] = _analyse(ctx, path)
+    return result
+
+
+def _compose_sprite(
+    post,
+    numpy,
+    raw,
+    size,
+    background,
+    inner,
+    outer,
+    exposure,
+    bloom,
+    bloom_threshold,
+    look,
+    contrast,
+    saturation,
+    vignette,
+):
+    """Scene-referred premultiplied RGBA -> a finished icon frame."""
+    raw = post.downsample(raw, size, size)
+
+    frame = post.bloom(
+        raw,
+        threshold=bloom_threshold,
+        strength=bloom,
+        radius=0.045,
+        premultiplied=True,
+    )
+
+    # Colour curves are nonlinear, so apply them to straight RGB and then
+    # premultiply again. Applying ACES directly to premultiplied antialiasing
+    # values creates bright or dark fringes around the cut-out.
+    straight = post.unpremultiply(frame)
+    straight[..., :3] = post.tonemap(straight[..., :3], look=look, exposure=exposure)
+
+    if background == "alpha":
+        straight[..., :3] = post.saturate(post.contrast(straight[..., :3], contrast), saturation)
+        return numpy.clip(post.premultiply(straight), 0.0, 1.0)
+
+    frame = post.premultiply(straight)
+    height, width = frame.shape[:2]
+    if background == "solid":
+        backdrop = numpy.broadcast_to(
+            numpy.array(inner[:3], dtype=numpy.float32), (height, width, 3)
+        ).copy()
+    else:
+        backdrop = post.radial_backdrop(width, height, inner, outer)
+    composed = post.over(frame, backdrop, premultiplied=True)
+    composed[..., :3] = post.saturate(post.contrast(composed[..., :3], contrast), saturation)
+    composed[..., :3] = post.vignette(composed[..., :3], vignette)
+    return numpy.clip(composed, 0.0, 1.0)
+
+
+def _alpha_metrics(numpy, frame):
+    """Small saved-file proof that transparency survived the PNG path."""
+    alpha = frame[..., 3]
+    edge = numpy.concatenate((alpha[0, :], alpha[-1, :], alpha[:, 0], alpha[:, -1]))
+    return {
+        "alpha_min": round(float(alpha.min()), 5),
+        "alpha_max": round(float(alpha.max()), 5),
+        "alpha_coverage": round(float((alpha > (1.0 / 255.0)).mean()), 5),
+        "edge_alpha_max": round(float(edge.max()), 5),
+    }

--- a/tools/bforge/tests/test_forge.py
+++ b/tools/bforge/tests/test_forge.py
@@ -417,6 +417,12 @@ class ExplicitCamera(ForgeCase):
         with self.assertRaises(ForgeError):
             self.forge.call("render.camera", out="x.png", position=[1, 1, 1], samples=1)
 
+    def test_camera_position_is_required_with_a_clear_error(self):
+        self.forge.call("build.box", name="subject")
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call("render.camera", out="x.png", samples=1)
+        self.assertIn("missing required parameter 'position'", str(ctx.exception))
+
 
 class UVs(ForgeCase):
     def test_unwrap_creates_usable_uvs(self):
@@ -619,6 +625,52 @@ class Rendering(ForgeCase):
         with self.assertRaises(ForgeError) as ctx:
             self.forge.call("render.view", out="empty.png", resolution=64, samples=1)
         self.assertIn("no mesh objects", str(ctx.exception))
+
+    def test_cinematic_defaults_frame_an_off_origin_tall_subject(self):
+        location = [12.0, -7.0, 3.0]
+        self.forge.call(
+            "build.box",
+            name="off_origin_subject",
+            size=[0.2, 0.4, 1.8],
+            location=location,
+            bevel=0.0,
+        )
+        result = self.forge.call(
+            "render.cinematic",
+            out="auto_cinematic.png",
+            resolution=128,
+            aspect=2.39,
+            samples=1,
+            bounces=2,
+            look="standard",
+            _timeout=900,
+        )
+        path = Path(result["path"])
+        self.assertTrue(path.is_file())
+        self.assertGreater(path.stat().st_size, 1000)
+        self.assertTrue(result["auto_framed"])
+        for actual, expected in zip(result["target"], location, strict=True):
+            self.assertAlmostEqual(actual, expected, places=4)
+        self.assertGreater(result["subject_radius_m"], 0.9)
+        self.assertGreater(result["analysis"]["subject_coverage"], 0.01)
+
+    def test_cinematic_explicit_position_keeps_the_world_origin_target(self):
+        self.forge.call("build.box", name="subject", bevel=0.0)
+        position = [4.0, -4.0, 3.0]
+        result = self.forge.call(
+            "render.cinematic",
+            out="explicit_cinematic.png",
+            position=position,
+            resolution=96,
+            aspect=1.78,
+            samples=1,
+            bounces=2,
+            look="standard",
+            _timeout=900,
+        )
+        self.assertFalse(result["auto_framed"])
+        self.assertEqual(result["position"], position)
+        self.assertEqual(result["target"], [0.0, 0.0, 0.0])
 
 
 if __name__ == "__main__":

--- a/tools/bforge/tests/test_schema.py
+++ b/tools/bforge/tests/test_schema.py
@@ -60,6 +60,33 @@ class Catalog(unittest.TestCase):
         names = [op["name"] for op in self.ops]
         self.assertEqual(len(names), len(set(names)))
 
+    def test_explicit_camera_position_is_required(self):
+        camera = next(op for op in self.ops if op["name"] == "render.camera")
+        self.assertIn("position", camera["inputSchema"].get("required", []))
+
+    def test_cinematic_camera_position_and_target_are_optional(self):
+        cinematic = next(op for op in self.ops if op["name"] == "render.cinematic")
+        required = cinematic["inputSchema"].get("required", [])
+        self.assertNotIn("position", required)
+        self.assertNotIn("target", required)
+        self.assertNotIn("default", cinematic["inputSchema"]["properties"]["position"])
+        self.assertNotIn("default", cinematic["inputSchema"]["properties"]["target"])
+
+    def test_sprite_supersampling_is_explicit(self):
+        sprite = next(op for op in self.ops if op["name"] == "render.sprite")
+        self.assertEqual(sprite["inputSchema"]["properties"]["supersample"]["default"], 2)
+
+    def test_paint_operations_declare_their_real_required_inputs(self):
+        expected = {
+            "paint.fill": {"name", "color"},
+            "paint.height": {"name", "low", "high"},
+            "paint.cavity": {"name", "color"},
+            "paint.noise": {"name", "color_a", "color_b"},
+        }
+        for name, required in expected.items():
+            operation = next(op for op in self.ops if op["name"] == name)
+            self.assertEqual(set(operation["inputSchema"].get("required", [])), required)
+
 
 class Filters(unittest.TestCase):
     def setUp(self):

--- a/tools/bforge/tests/test_sprite.py
+++ b/tools/bforge/tests/test_sprite.py
@@ -1,0 +1,207 @@
+"""Live regression tests for render.sprite game icons and directional sheets."""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bforge.client import DaemonError, Forge, ForgeError, find_blender  # noqa: E402
+
+FORGE: Forge | None = None
+TEMP: tempfile.TemporaryDirectory | None = None
+
+
+def setUpModule():
+    global FORGE, TEMP
+    if os.environ.get("BFORGE_SKIP_LIVE"):
+        raise unittest.SkipTest("BFORGE_SKIP_LIVE is set")
+    try:
+        find_blender()
+    except DaemonError as exc:
+        raise unittest.SkipTest(f"Blender not available: {exc}") from exc
+    TEMP = tempfile.TemporaryDirectory(prefix="bforge_sprite_test_")
+    FORGE = Forge(workdir=TEMP.name, out_dir=str(Path(TEMP.name) / "out"))
+    FORGE.start()
+
+
+def tearDownModule():
+    if FORGE is not None:
+        FORGE.stop()
+    if TEMP is not None:
+        TEMP.cleanup()
+
+
+def png_size(path) -> tuple[int, int]:
+    data = Path(path).read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise AssertionError(f"{path} is not a PNG file")
+    _length, kind = struct.unpack_from(">I4s", data, 8)
+    if kind != b"IHDR":
+        raise AssertionError(f"{path}: first chunk is {kind!r}, not IHDR")
+    return struct.unpack_from(">II", data, 16)
+
+
+class ForgeCase(unittest.TestCase):
+    def setUp(self):
+        FORGE.call("session.reset")
+
+    @property
+    def forge(self) -> Forge:
+        return FORGE
+
+    def out_file(self, rel_path: str) -> Path:
+        return Path(TEMP.name) / rel_path
+
+
+class Sprite(ForgeCase):
+    def test_alpha_icon_is_clean_and_byte_deterministic(self):
+        self.forge.call(
+            "build.box",
+            name="subject",
+            size=[0.4, 0.8, 1.6],
+            bevel=0.02,
+        )
+        args = {
+            "name": "subject",
+            "size": 48,
+            "background": "alpha",
+            "shadow": False,
+            "bloom": 0.0,
+            "samples": 1,
+            "_timeout": 900,
+        }
+        first = self.forge.call("render.sprite", out="alpha_a.png", **args)
+        second = self.forge.call("render.sprite", out="alpha_b.png", **args)
+
+        self.assertNotIn("sidecar", first)
+        self.assertEqual(png_size(first["path"]), (48, 48))
+        self.assertEqual(first["supersample"], 2)
+        self.assertEqual(first["render_px"], 96)
+        metric = first["frame_metrics"][0]
+        self.assertEqual(metric["alpha_min"], 0.0)
+        self.assertEqual(metric["alpha_max"], 1.0)
+        self.assertGreater(metric["alpha_coverage"], 0.05)
+        self.assertLess(metric["alpha_coverage"], 0.9)
+        self.assertEqual(metric["edge_alpha_max"], 0.0)
+        self.assertEqual(
+            Path(first["path"]).read_bytes(),
+            Path(second["path"]).read_bytes(),
+            "the same scene and sprite parameters must produce byte-identical PNGs",
+        )
+
+    def test_gradient_icon_is_opaque_and_reports_effective_controls(self):
+        self.forge.call("build.box", name="subject", bevel=0.0)
+        result = self.forge.call(
+            "render.sprite",
+            name="subject",
+            out="gradient.png",
+            size=8,
+            supersample=99,
+            fill=2.0,
+            lens=2.0,
+            elevation=100.0,
+            exposure=99.0,
+            background="gradient",
+            shadow=False,
+            bloom=0.0,
+            samples=1,
+            _timeout=900,
+        )
+
+        self.assertEqual(result["frame_px"], 32)
+        self.assertEqual(result["render_px"], 128)
+        self.assertEqual(result["supersample"], 4)
+        self.assertEqual(result["samples"], 8)
+        self.assertEqual(result["exposure"], 16.0)
+        self.assertEqual(png_size(result["path"]), (32, 32))
+        self.assertEqual(result["fill_target"], 0.98)
+        self.assertEqual(result["camera"]["lens_mm"], 8.0)
+        self.assertEqual(result["camera"]["elevation"], 85.0)
+        metric = result["frame_metrics"][0]
+        self.assertEqual(metric["alpha_min"], 1.0)
+        self.assertEqual(metric["alpha_max"], 1.0)
+        self.assertEqual(metric["alpha_coverage"], 1.0)
+
+    def test_exposure_changes_linear_subject_luminance(self):
+        self.forge.call("build.box", name="subject", bevel=0.0)
+        common = {
+            "name": "subject",
+            "size": 32,
+            "supersample": 1,
+            "background": "solid",
+            "bg_inner": "#000000",
+            "shadow": False,
+            "bloom": 0.0,
+            "look": "linear",
+            "contrast": 1.0,
+            "saturation": 1.0,
+            "vignette": 0.0,
+            "samples": 1,
+            "_timeout": 900,
+        }
+        low = self.forge.call("render.sprite", out="exposure_low.png", exposure=-2.0, **common)
+        high = self.forge.call("render.sprite", out="exposure_high.png", exposure=2.0, **common)
+
+        self.assertGreater(
+            high["analysis"]["luma_linear"]["mean"],
+            low["analysis"]["luma_linear"]["mean"],
+        )
+
+    def test_directional_sheet_refits_each_view_and_writes_sidecar(self):
+        self.forge.call(
+            "build.box",
+            name="long_subject",
+            size=[3.0, 0.25, 1.0],
+            bevel=0.0,
+        )
+        result = self.forge.call(
+            "render.sprite",
+            name="long_subject",
+            out="directions.png",
+            size=32,
+            views=4,
+            azimuth=0.0,
+            background="alpha",
+            shadow=False,
+            bloom=0.0,
+            samples=1,
+            _timeout=900,
+        )
+
+        self.assertEqual((result["cols"], result["rows"]), (2, 2))
+        self.assertEqual(png_size(result["path"]), (64, 64))
+        metrics = result["frame_metrics"]
+        self.assertEqual([row["yaw_degrees"] for row in metrics], [0.0, 90.0, 180.0, 270.0])
+        self.assertGreater(
+            len({row["distance_m"] for row in metrics}),
+            1,
+            "an asymmetric subject must be fitted independently at each yaw",
+        )
+        self.assertTrue(all(row["edge_alpha_max"] == 0.0 for row in metrics))
+
+        sidecar_path = self.out_file(result["sidecar"])
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        self.assertEqual(sidecar["frames"], 4)
+        self.assertEqual(sidecar["camera_frames"], metrics)
+        self.assertEqual(sidecar["object"], "long_subject")
+
+    def test_missing_subject_names_the_listing_op(self):
+        with self.assertRaises(ForgeError) as ctx:
+            self.forge.call(
+                "render.sprite",
+                name="ghost",
+                size=32,
+                samples=1,
+            )
+        self.assertIn("object.list", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- Make `render.cinematic` auto-frame omitted camera coordinates around the full subject, including off-origin and extreme-aspect assets, while preserving explicit-position/world-origin targeting.
- Require `render.camera.position` explicitly and return an actionable schema/runtime error when it is omitted.
- Add `render.sprite`: per-view silhouette framing, scale-invariant icon lighting, contact shadows, alpha/solid/radial backdrops, linear EXR post-processing, bloom/tonemap/grade/vignette, clean straight-alpha PNG output, directional sidecars, and deterministic diagnostics.
- Add 1-4x premultiplied-linear supersampling (4096 px internal cap) plus safe exposure clamping/reporting.
- Preserve and validate required paint inputs, add live/schema regressions, regenerate the 138-op catalog/reference, and reconcile public counts to 217 tests / 174 Blender-backed.

## Why / root cause

The cinematic path treated omitted coordinates as explicit vectors, so default calls could crash or frame the world origin instead of an off-origin asset. The forge also lacked an icon-specific render path: review/cinematic renders do not provide consistent inventory framing, compositable alpha, directional sheets, or a linear-light post chain. Required paint inputs were represented as optional in generated schemas.

## Compatibility / impact

- Existing explicit `render.cinematic(position=..., target omitted)` behavior still targets world origin.
- `render.camera` now rejects omitted `position` at schema coercion instead of failing later.
- `render.sprite` is additive; effective clamps and per-frame metadata are returned and included in multi-view sidecars.
- Catalog/docs counts change from 137 to 138 ops and from 205/166 to 217/174 total/live-backed tests.

## Validation

- Full bforge discovery: **217 passed** with Blender 4.5.12 (43.163s).
- Focused live sprite: **5 passed** (alpha cleanliness + byte determinism, per-yaw silhouette refit, exposure response, supersampling/effective controls, error guidance).
- Focused live camera: **3 passed**.
- Schema + MCP: **43 passed**; final schema freshness: **19 passed**.
- Rust workspace tests: passed.
- Studio MCP 111, infra 5, engine 10, asset pipeline 5, provenance 24, verification 15, World IR 34, sim/parity 28, Nakama Python 4 + Node 6, protocol fixtures 9: all passed.
- Godot 4.7.1: **44 methods / 180 assertions**, 0 failures.
- Workflow policy, secret scan, claim check, Ruff diagnostics, changed-file formatting, and patch whitespace: passed.

## Local gate limitations

The canonical `scripts/ci/run_all.py --stage pr` launcher exits 127 because `just` is not installed on this host, so its underlying recipes were run directly. The repository-wide format/Clippy gates still report untouched baseline debt in `tools/sim/tests/test_parity.py`, `services/sim-kernel/src/lib.rs`, and `services/sim-kernel/tests/conformance.rs`; those paths are byte-identical to `origin/main` and were intentionally left out of this scoped PR.